### PR TITLE
added GHA docs test

### DIFF
--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -1,0 +1,61 @@
+name: Docs test on push and PR
+
+
+on: [push, pull_request, workflow_dispatch]
+
+
+jobs:
+  unit-tests:
+    name: Run Docs Tests
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9]
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON-VERSION: ${{ matrix.python-version }}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get pip cache location
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Get date
+        id: date
+        run: >
+          python -c
+          "import datetime;
+          now = datetime.datetime.now();
+          print(f'::set-output name=text::{now.year}/{now.month}-part{1 + now.day // 8}')"
+
+      - name: Load pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: $doctests-{{ runner.os }}-Python${{ matrix.python-version }}-${{ steps.date.outputs.text }}-pip-${{ hashFiles('**/setup.py', './.github/workflows/unit-tests.yml') }}
+
+      - name: Install package & (test) dependencies
+        run: python -m pip install --upgrade --upgrade-strategy=eager .[docs]
+
+      - name: Build docs
+        run: sphinx-build -W -b html docs docs/_build
+
+      - name: Run docs tests
+        run: sphinx-build -W -b doctest docs docs/_doctest

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -10,22 +10,19 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.9]
 
     env:
-      OS: ${{ matrix.os }}
-      PYTHON-VERSION: ${{ matrix.python-version }}
+      OS: ubuntu-latest
+      PYTHON-VERSION: "3.9"
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
 
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -49,7 +46,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: $doctests-{{ runner.os }}-Python${{ matrix.python-version }}-${{ steps.date.outputs.text }}-pip-${{ hashFiles('**/setup.py', './.github/workflows/unit-tests.yml') }}
+          key: $doctests-{{ runner.os }}-Python3.9-${{ steps.date.outputs.text }}-pip-${{ hashFiles('**/setup.py', './.github/workflows/unit-tests.yml') }}
 
       - name: Install package & (test) dependencies
         run: python -m pip install --upgrade --upgrade-strategy=eager .[docs]

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: $doctests-{{ runner.os }}-Python3.9-${{ steps.date.outputs.text }}-pip-${{ hashFiles('**/setup.py', './.github/workflows/unit-tests.yml') }}
+          key: doctests-${{ runner.os }}-Python3.9-${{ steps.date.outputs.text }}-pip-${{ hashFiles('**/setup.py', './.github/workflows/unit-tests.yml') }}
 
       - name: Install package & (test) dependencies
         run: python -m pip install --upgrade --upgrade-strategy=eager .[docs]


### PR DESCRIPTION
I know readthedocs has a mechanism for showing a "docs passed!" thing on PR's the same way that GHA / Travis CI say "tests passed!". Unfortunately I don't know how to trigger that (yet!), so for now I'd like to have this hand-rolled GHA docs test script that runs the docs build routine and exits on docs rendering warnings / failures. This should keep us from accidentally breaking things in the docs when making code/docstring changes.