### PR TITLE
Feature/pypi links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ setuptools.setup(
         #     'idelib': ['schemata/*'],
         # },
         # test_suite='./testing',
+        project_urls={
+            "Bug Tracker": "https://github.com/MideTechnology/endaq-python/issues",
+            "Documentation": "https://docs.endaq.com/en/latest/",
+            "Source Code": "https://github.com/MideTechnology/endaq-python",
+            },
         install_requires=INSTALL_REQUIRES,
         extras_require={
             'test': INSTALL_REQUIRES + TEST_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ setuptools.setup(
         classifiers=['Development Status :: 4 - Beta',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.5',
-                     'Programming Language :: Python :: 3.6',
                      'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This PR adds project links to endaq's PYPI page, specifically for docs, bug tracking and source code. These changes are modeled after what they do for numpy. See the following reference links for more details:
- [numpy's PYPI page](https://pypi.org/project/numpy/), which has those sweet links in the page's left-side "gutter" (I don't know what to call it) under the header "Project Links"
- [numpy's setup.py](https://github.com/numpy/numpy/blob/main/setup.py#L399), specifically where it defines the `project_urls` parameter
- [Python's "Packaging Projects" documentation](https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata), describing (briefly) the function of the `project_urls` parameter

For now this is better than nothing, but we may later want to change this to reference specific docs versions for specific pip releases (which numpy does), or add/change some other link or something. Any such ideas are welcome!