### PR TITLE
Improved `get_doc()` error message if opening a nonexistent file.

### DIFF
--- a/endaq/ide/files.py
+++ b/endaq/ide/files.py
@@ -161,7 +161,9 @@ def get_doc(name=None, filename=None, url=None, parsed=True, start=0, end=None,
             filename = name
         else:
             parsed_url = urlparse(name.replace('\\', '/'))
-            if parsed_url.netloc:
+            if parsed_url.scheme == 'file':
+                filename = parsed_url.path
+            elif parsed_url.netloc:
                 url = name
             else:
                 filename = name


### PR DESCRIPTION
See issue #81.

Also added `headers` kwarg (primarily for future use w/ cloud)