### PR TITLE
Feature/halfsine extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_doctest/
 
 # PyBuilder
 .pybuilder/

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -341,12 +341,13 @@ class HalfSineWavePulse(NamedTuple):
         t = np.arange(trange[0], trange[1], dt)
 
         data = np.zeros((len(t), len(self.amplitude)), dtype=float)
-        t_data = np.broadcast_to(t[..., None], data.shape)
-        t_mask = np.nonzero((t_data >= t0) & (t_data < t0 + self.duration.to_numpy()))
-        data[t_mask] = (
-            self.amplitude.to_numpy()
-            * np.sin(np.pi * t_data / self.duration.to_numpy())
-        )[t_mask]
+        t_data, ampl_data, T_data = np.broadcast_arrays(
+            t[..., None], self.amplitude.to_numpy(), self.duration.to_numpy()
+        )
+        t_mask = np.nonzero((t_data >= t0) & (t_data < t0 + T_data))
+        data[t_mask] = ampl_data[t_mask] * np.sin(
+            np.pi * t_data[t_mask] / T_data[t_mask]
+        )
 
         return pd.DataFrame(
             data,

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -232,54 +232,6 @@ def shock_spectrum(
     )
 
 
-def enveloping_half_sine(
-    pvss: pd.DataFrame,
-    damp: float = 0.0,
-) -> HalfSineWavePulse:
-    """
-    Characterize a half-sine pulse whose PVSS envelopes the input.
-
-    :param pvss: the PVSS to envelope
-    :param damp: the damping factor used to generate the input PVSS
-    :return: a tuple of amplitudes and periods, each pair of which describes a
-        half-sine pulse
-
-    .. seealso::
-
-        `Pseudo Velocity Shock Spectrum Rules For Analysis Of Mechanical Shock, Howard A. Gaberson <https://info.endaq.com/hubfs/pvsrs_rules.pdf>`_
-    """
-
-    def amp_factor(damp):
-        """
-        Calculate the PVSS amplitude attenuation on a half-sine pulse from the
-        damping coefficient.
-
-        The PVSS of a half-sine pulse differs based on the damping coefficient
-        used. While the high-frequency rolloff is relatively consistent, the
-        flat low-frequency amplitude is attenuated at higher damping values.
-        This function calculates this attenuation for a given damping
-        coefficient.
-        """
-        # This calculates the PVSS value as ω->0. However, since it necessarily
-        # computes the maximum of a function *over time*, and ω is only found
-        # therein in the multiplicative factor (ωt), it is mathematically
-        # equivalent to compute this maximum for any arbitrary ω>0. Thus we
-        # choose ω=1 for convenience, w/o loss of generality.
-        a = np.exp(1j * np.arccos(-damp))  # = -damp + 1j * np.sqrt(1 - damp**2)
-        # From WolframAlpha: https://www.wolframalpha.com/input/?i=D%5BPower%5Be%2C%5C%2840%29-d+*t%5C%2841%29%5D+sin%5C%2840%29Sqrt%5B1-Power%5Bd%2C2%5D%5D*t%5C%2841%29%2Ct%5D+%3D+0&assumption=%22ListOrTimes%22+-%3E+%22Times%22&assumption=%7B%22C%22%2C+%22e%22%7D+-%3E+%7B%22NamedConstant%22%7D&assumption=%7B%22C%22%2C+%22d%22%7D+-%3E+%7B%22Variable%22%7D&assumption=%22UnitClash%22+-%3E+%7B%22d%22%2C+%7B%22Days%22%7D%7D
-        t_max = (2 / np.imag(a)) * np.arctan2(np.imag(a), 1 - np.real(a))
-        PVSS_max = (1 / np.imag(a)) * np.imag(np.exp(a * t_max))
-        return PVSS_max
-
-    max_pvss = pvss.max()
-    max_f_pvss = pvss.mul(pvss.index, axis=0).max()
-
-    return HalfSineWavePulse(
-        amplitude=2 * np.pi * max_f_pvss,
-        duration=max_pvss / (4 * amp_factor(damp) * max_f_pvss),
-    )
-
-
 class HalfSineWavePulse(NamedTuple):
     """
     The output data type for ``enveloping_half_sine``.
@@ -359,3 +311,51 @@ class HalfSineWavePulse(NamedTuple):
 
     # def pseudo_velocity(self):
     #    pass
+
+
+def enveloping_half_sine(
+    pvss: pd.DataFrame,
+    damp: float = 0.0,
+) -> HalfSineWavePulse:
+    """
+    Characterize a half-sine pulse whose PVSS envelopes the input.
+
+    :param pvss: the PVSS to envelope
+    :param damp: the damping factor used to generate the input PVSS
+    :return: a tuple of amplitudes and periods, each pair of which describes a
+        half-sine pulse
+
+    .. seealso::
+
+        `Pseudo Velocity Shock Spectrum Rules For Analysis Of Mechanical Shock, Howard A. Gaberson <https://info.endaq.com/hubfs/pvsrs_rules.pdf>`_
+    """
+
+    def amp_factor(damp):
+        """
+        Calculate the PVSS amplitude attenuation on a half-sine pulse from the
+        damping coefficient.
+
+        The PVSS of a half-sine pulse differs based on the damping coefficient
+        used. While the high-frequency rolloff is relatively consistent, the
+        flat low-frequency amplitude is attenuated at higher damping values.
+        This function calculates this attenuation for a given damping
+        coefficient.
+        """
+        # This calculates the PVSS value as ω->0. However, since it necessarily
+        # computes the maximum of a function *over time*, and ω is only found
+        # therein in the multiplicative factor (ωt), it is mathematically
+        # equivalent to compute this maximum for any arbitrary ω>0. Thus we
+        # choose ω=1 for convenience, w/o loss of generality.
+        a = np.exp(1j * np.arccos(-damp))  # = -damp + 1j * np.sqrt(1 - damp**2)
+        # From WolframAlpha: https://www.wolframalpha.com/input/?i=D%5BPower%5Be%2C%5C%2840%29-d+*t%5C%2841%29%5D+sin%5C%2840%29Sqrt%5B1-Power%5Bd%2C2%5D%5D*t%5C%2841%29%2Ct%5D+%3D+0&assumption=%22ListOrTimes%22+-%3E+%22Times%22&assumption=%7B%22C%22%2C+%22e%22%7D+-%3E+%7B%22NamedConstant%22%7D&assumption=%7B%22C%22%2C+%22d%22%7D+-%3E+%7B%22Variable%22%7D&assumption=%22UnitClash%22+-%3E+%7B%22d%22%2C+%7B%22Days%22%7D%7D
+        t_max = (2 / np.imag(a)) * np.arctan2(np.imag(a), 1 - np.real(a))
+        PVSS_max = (1 / np.imag(a)) * np.imag(np.exp(a * t_max))
+        return PVSS_max
+
+    max_pvss = pvss.max()
+    max_f_pvss = pvss.mul(pvss.index, axis=0).max()
+
+    return HalfSineWavePulse(
+        amplitude=2 * np.pi * max_f_pvss,
+        duration=max_pvss / (4 * amp_factor(damp) * max_f_pvss),
+    )

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Tuple
+from typing import NamedTuple
 from collections import namedtuple
 import functools
 import warnings
@@ -232,10 +232,15 @@ def shock_spectrum(
     )
 
 
+class HalfSineWavePulse(NamedTuple):
+    amplitude: float
+    duration: float
+
+
 def enveloping_half_sine(
     pvss: pd.DataFrame,
     damp: float = 0.0,
-) -> Tuple[pd.Series, pd.Series]:
+) -> HalfSineWavePulse:
     """
     Characterize a half-sine pulse whose PVSS envelopes the input.
 
@@ -274,7 +279,7 @@ def enveloping_half_sine(
     max_pvss = pvss.max()
     max_f_pvss = pvss.mul(pvss.index, axis=0).max()
 
-    return namedtuple("HalfSinePulseParameters", "amplitude, period")(
+    return HalfSineWavePulse(
         amplitude=2 * np.pi * max_f_pvss,
-        period=max_pvss / (4 * amp_factor(damp) * max_f_pvss),
+        duration=max_pvss / (4 * amp_factor(damp) * max_f_pvss),
     )

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import typing
-from typing import Optional, Tuple, NamedTuple
+from typing import Optional
 from collections import namedtuple
+from dataclasses import dataclass
 import functools
 import warnings
 
@@ -232,7 +233,8 @@ def shock_spectrum(
     )
 
 
-class HalfSineWavePulse(NamedTuple):
+@dataclass
+class HalfSineWavePulse:
     """
     The output data type for ``enveloping_half_sine``.
 
@@ -251,6 +253,9 @@ class HalfSineWavePulse(NamedTuple):
 
     amplitude: pd.Series
     duration: pd.Series
+
+    def __iter__(self):
+        return iter((self.amplitude, self.duration))
 
     def to_time_series(
         self,

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -284,7 +284,7 @@ class HalfSineWavePulse(NamedTuple):
             trange[1] if trange[1] is not None else t0 + self.duration.max(),
         )
 
-        if t0 < trange[0] or trange[1] < t0 + self.duration.max():
+        if not (trange[0] <= t0 <= trange[1] - self.duration.max()):
             warnings.warn(
                 "half-sine pulse extends beyond the bounds of the time series"
             )

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -284,9 +284,8 @@ class HalfSineWavePulse(NamedTuple):
     """
     The output data type for ``enveloping_half_sine``.
 
-    The significant data members are `amplitude` and `duration`. Because this
-    class inherits from ``collections.namedtuple``, these two members can simply
-    be unpacked as if from a plain tuple:
+    The significant data members are `amplitude` and `duration`, which can
+    simply be unpacked as if from a plain tuple:
 
     .. code-block:: python
 
@@ -298,8 +297,8 @@ class HalfSineWavePulse(NamedTuple):
     .. note:: This class is not intended to be instantiated manually.
     """
 
-    amplitude: float
-    duration: float
+    amplitude: pd.Series
+    duration: pd.Series
 
     def to_time_series(
         self,

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -241,7 +241,14 @@ class HalfSineWavePulse:
     The significant data members are `amplitude` and `duration`, which can
     simply be unpacked as if from a plain tuple:
 
-    .. code-block:: python
+    .. testsetup::
+
+        import pandas as pd
+        df_pvss = pd.DataFrame([1, 1], index=[200, 400])
+
+        from endaq.calc.shock import enveloping_half_sine
+
+    .. testcode::
 
         ampl, T = enveloping_half_sine(df_pvss)
 

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -248,22 +248,14 @@ def test_pseudo_velocity_zero_padding(
 )
 @hyp.settings(deadline=None)  # this test tends to timeout
 def test_enveloping_half_sine(df_pvss, damp):
-    ampl, T = shock.enveloping_half_sine(df_pvss, damp=damp)
+    env_half_sine = shock.enveloping_half_sine(df_pvss, damp=damp)
+    ampl, T = env_half_sine
     hyp.note(f"pulse amplitude: {ampl}")
     hyp.note(f"pulse duration: {T}")
 
-    ampl = ampl[0]
-    T = T[0]
-
-    dt = min(
-        1 / (2 * df_pvss.index[-1]), T / 20
-    )  # guarantee sufficient # of samples to represent pulse
-    fs = 1 / dt
-    times = np.arange(int(fs * (T + 1 / df_pvss.index[0]))) / fs
-    pulse = np.zeros_like(times)
-    pulse[: int(T * fs)] = ampl * np.sin((np.pi / T) * times[: int(T * fs)])
+    pulse = env_half_sine.to_time_series()
     pulse_pvss = shock.shock_spectrum(
-        pd.DataFrame(pulse, index=times), freqs=df_pvss.index, damp=damp, mode="pvss"
+        pulse, freqs=df_pvss.index, damp=damp, mode="pvss"
     )
 
     # This is an approximation -> give the result a fudge-factor for correctness

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -246,7 +246,6 @@ def test_pseudo_velocity_zero_padding(
     ).map(lambda array: pd.DataFrame(array, index=np.arange(1, 41))),
     damp=hyp_st.floats(0, 0.2),
 )
-@hyp.settings(deadline=None)  # this test tends to timeout
 def test_enveloping_half_sine(df_pvss, damp):
     env_half_sine = shock.enveloping_half_sine(df_pvss, damp=damp)
     ampl, T = env_half_sine

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -264,18 +264,18 @@ def test_enveloping_half_sine(df_pvss, damp):
 
 class TestHalfSineWavePulse:
     @pytest.mark.parametrize(
-        "dt, t0, trange, warning_type",
+        "tstart, tstop, dt, tpulse, warning_type",
         [
             # dt warnings
-            (0.12, 0, (None, None), None),  # dt < duration / 8 => OK
-            (0.13, 0, (None, None), UserWarning),  # dt > duration / 8 => WARNING
+            (None, None, 0.12, 0, None),  # dt < duration / 8 => OK
+            (None, None, 0.13, 0, UserWarning),  # dt > duration / 8 => WARNING
             # trange warnings
-            (None, 0, (None, 0.5), UserWarning),  # trange[1] < t0 + duration => WARNING
-            (None, 0, (0.5, None), UserWarning),  # trange[0] > t0 => WARNING
-            (None, 1, (0.5, None), None),  # OK
+            (None, 0.5, None, 0, UserWarning),  # trange[1] < t0 + duration => WARNING
+            (0.5, None, None, 0, UserWarning),  # trange[0] > t0 => WARNING
+            (0.5, None, None, 1, None),  # OK
         ],
     )
-    def test_to_time_series_warnings(self, dt, t0, trange, warning_type):
+    def test_to_time_series_warnings(self, tstart, tstop, dt, tpulse, warning_type):
         env_half_sine = shock.HalfSineWavePulse(
             amplitude=pd.Series([1]),
             duration=pd.Series([1]),
@@ -284,7 +284,11 @@ class TestHalfSineWavePulse:
         if warning_type is None:
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
-                env_half_sine.to_time_series(dt=dt, t0=t0, trange=trange)
+                env_half_sine.to_time_series(
+                    tstart=tstart, tstop=tstop, dt=dt, tpulse=tpulse
+                )
         else:
             with pytest.warns(warning_type):
-                env_half_sine.to_time_series(dt=dt, t0=t0, trange=trange)
+                env_half_sine.to_time_series(
+                    tstart=tstart, tstop=tstop, dt=dt, tpulse=tpulse
+                )

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from unittest import mock
 import warnings
 
 import pytest
@@ -292,3 +293,13 @@ class TestHalfSineWavePulse:
                 env_half_sine.to_time_series(
                     tstart=tstart, tstop=tstop, dt=dt, tpulse=tpulse
                 )
+
+    def test_tuple_like(self):
+        env_half_sine = shock.HalfSineWavePulse(
+            amplitude=mock.sentinel.amplitude,
+            duration=mock.sentinel.duration,
+        )
+
+        ampl, T = env_half_sine
+        assert ampl == mock.sentinel.amplitude
+        assert T == mock.sentinel.duration


### PR DESCRIPTION
This PR adds a feature to `enveloping_half_sine` s.t. users can generate the pulse as a time-series.

This also sets up the infrastructure for addressing #50.

attn: @shanlyMIDE - one more step closer!