### PR TITLE
Feature/psd loglog piecewise-linear approx

### DIFF
--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -235,10 +235,11 @@ def loglog_linear_approx(
     Calculate a piecewise-linear approximation of data, in the log-log space.
 
     :param df: the input data; each column is approximated independently
-    :param knots: the inner boundary points separating the piecewise regions
+    :param knots: the interior points separating the piecewise regions
     :apram window: the length of the pre-processing smoothing window
     :param freqs_out: the frequencies at which to interpolate the output; these
-        may be explicit frequencies, or one of the following `str` options:
+        may be an array-like of explicit frequencies, or one of the following
+        `str` options:
 
         - `"knots"` (default): the knot frequencies
         - `"input"`: the frequencies on the input data (i.e., ``df.index``)

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -40,26 +40,6 @@ def test_welch_parseval(df):
     assert df_psd.to_numpy().sum() == pytest.approx(stats.rms(df.to_numpy()) ** 2)
 
 
-@pytest.mark.parametrize(
-    "agg1, agg2",
-    [
-        ("mean", lambda x, axis=-1: np.nan_to_num(np.mean(x, axis=axis))),
-        ("sum", np.sum),
-    ],
-)
-def test_to_jagged_modes(psd_df, freq_splits, agg1, agg2):
-    """Test `to_jagged(..., mode='mean')` against the equivalent `mode=np.mean`."""
-    result1 = psd.to_jagged(psd_df, freq_splits, agg=agg1)
-    result2 = psd.to_jagged(psd_df, freq_splits, agg=agg2)
-
-    assert np.all(result1.index == result2.index)
-    np.testing.assert_allclose(
-        result1.to_numpy(),
-        result2.to_numpy(),
-        atol=psd_df.min().min() * 1e-7,
-    )
-
-
 @hyp.given(
     psd_df=hyp_np.arrays(
         dtype=np.float64,

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -180,7 +180,7 @@ def test_loglog_linear_approx():
         window=20,
         freqs_out=utils.logfreqs(df, init_freq=20, bins_per_octave=4),
     )
-    calc_dB = calc_result.apply(utils.to_dB, raw=True, reference=1, squared=True)
+    calc_dB = calc_result.apply(utils.to_dB, raw=True, reference=0.04, squared=True)
 
     calc_dB_rampup = calc_dB.loc[: knots[0]]
     dlog2f = np.diff(np.log2(calc_dB_rampup.index.to_numpy()))
@@ -189,6 +189,7 @@ def test_loglog_linear_approx():
     assert np.all(dB_per_octave == pytest.approx(3, rel=0.2))
 
     calc_dB_plateau = calc_dB.loc[knots[0] : knots[1]]
+    assert np.all(calc_dB_plateau["accel"].to_numpy() == pytest.approx(0, abs=0.6))
     dlog2f = np.diff(np.log2(calc_dB_plateau.index.to_numpy()))
     ddB = np.diff(calc_dB_plateau["accel"].to_numpy())
     dB_per_octave = ddB / dlog2f

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -164,7 +164,12 @@ def test_to_octave(psd_df, agg, expt_f, expt_array):
 def test_loglog_linear_approx():
     filepath = pathlib.Path("./tests/calc/navmat-p-9492.csv")
     df = pd.read_csv(
-        filepath, delimiter="\t", header=None, index_col=0, names=["accel"]
+        filepath,
+        delimiter="\t",
+        header=None,
+        index_col=0,
+        names=["accel"],
+        dtype=dict(accel=np.float32),
     )
     df_psd = psd.welch(df, bin_width=0.5).loc[20:2000]
 
@@ -183,13 +188,13 @@ def test_loglog_linear_approx():
     dB_per_octave = ddB / dlog2f
     assert np.all(dB_per_octave == pytest.approx(3, rel=0.2))
 
-    calc_dB_plateau = calc_dB.loc[knots[0]: knots[1]]
+    calc_dB_plateau = calc_dB.loc[knots[0] : knots[1]]
     dlog2f = np.diff(np.log2(calc_dB_plateau.index.to_numpy()))
     ddB = np.diff(calc_dB_plateau["accel"].to_numpy())
     dB_per_octave = ddB / dlog2f
     assert np.all(dB_per_octave == pytest.approx(0, abs=0.6))
 
-    calc_dB_rampdown = calc_dB.loc[knots[1]:]
+    calc_dB_rampdown = calc_dB.loc[knots[1] :]
     dlog2f = np.diff(np.log2(calc_dB_rampdown.index.to_numpy()))
     ddB = np.diff(calc_dB_rampdown["accel"].to_numpy())
     dB_per_octave = ddB / dlog2f

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import timeit
+import textwrap
 
 import pytest
 import hypothesis as hyp
@@ -101,20 +102,22 @@ def test_to_jagged_mode_times():
     Check that a situation exists where the histogram method is more
     performant.
     """
-    setup = """
-from endaq.calc import psd
-import numpy as np
-import pandas as pd
+    setup = textwrap.dedent(
+        """
+        from endaq.calc import psd
+        import numpy as np
+        import pandas as pd
 
-n = 10 ** 4
+        n = 10 ** 4
 
-axis = -1
-psd_array = np.random.random((3, n))
-f = np.arange(n) / 3
-psd_df = pd.DataFrame(psd_array.T, index=f)
-#freq_splits = np.logspace(0, np.log2(n), num=100, base=2)
-freq_splits = f[1:-1]
-    """
+        axis = -1
+        psd_array = np.random.random((3, n))
+        f = np.arange(n) / 3
+        psd_df = pd.DataFrame(psd_array.T, index=f)
+        #freq_splits = np.logspace(0, np.log2(n), num=100, base=2)
+        freq_splits = f[1:-1]
+        """
+    )
 
     t_direct = timeit.timeit(
         "psd.to_jagged(psd_df, freq_splits, agg=np.sum)",

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -180,23 +180,23 @@ def test_loglog_linear_approx():
         window=20,
         freqs_out=utils.logfreqs(df, init_freq=20, bins_per_octave=4),
     )
-    calc_dB = calc_result.apply(utils.to_dB, raw=True, reference=0.04, squared=True)
+    db = calc_result.apply(utils.to_dB, raw=True, reference=0.04, squared=True)
 
-    calc_dB_rampup = calc_dB.loc[: knots[0]]
-    dlog2f = np.diff(np.log2(calc_dB_rampup.index.to_numpy()))
-    ddB = np.diff(calc_dB_rampup["accel"].to_numpy())
-    dB_per_octave = ddB / dlog2f
-    assert np.all(dB_per_octave == pytest.approx(3, rel=0.2))
+    db_rampup = db.loc[: knots[0]]
+    dlog2f = np.diff(np.log2(db_rampup.index.to_numpy()))
+    ddb = np.diff(db_rampup["accel"].to_numpy())
+    db_per_octave = ddb / dlog2f
+    assert np.all(db_per_octave == pytest.approx(3, rel=0.2))
 
-    calc_dB_plateau = calc_dB.loc[knots[0] : knots[1]]
-    assert np.all(calc_dB_plateau["accel"].to_numpy() == pytest.approx(0, abs=0.6))
-    dlog2f = np.diff(np.log2(calc_dB_plateau.index.to_numpy()))
-    ddB = np.diff(calc_dB_plateau["accel"].to_numpy())
-    dB_per_octave = ddB / dlog2f
-    assert np.all(dB_per_octave == pytest.approx(0, abs=0.6))
+    db_plateau = db.loc[knots[0] : knots[1]]
+    assert np.all(db_plateau["accel"].to_numpy() == pytest.approx(0, abs=0.6))
+    dlog2f = np.diff(np.log2(db_plateau.index.to_numpy()))
+    ddb = np.diff(db_plateau["accel"].to_numpy())
+    db_per_octave = ddb / dlog2f
+    assert np.all(db_per_octave == pytest.approx(0, abs=0.6))
 
-    calc_dB_rampdown = calc_dB.loc[knots[1] :]
-    dlog2f = np.diff(np.log2(calc_dB_rampdown.index.to_numpy()))
-    ddB = np.diff(calc_dB_rampdown["accel"].to_numpy())
-    dB_per_octave = ddB / dlog2f
-    assert np.all(dB_per_octave == pytest.approx(-3, rel=0.2))
+    db_rampdown = db.loc[knots[1] :]
+    dlog2f = np.diff(np.log2(db_rampdown.index.to_numpy()))
+    ddb = np.diff(db_rampdown["accel"].to_numpy())
+    db_per_octave = ddb / dlog2f
+    assert np.all(db_per_octave == pytest.approx(-3, rel=0.2))


### PR DESCRIPTION
requested by @shanlyMIDE

This PR adds `endaq.calc.psd.loglog_linear_approx`, which takes a PSD and generates a reduced approximation suitable for input into a shaker table. Specifically, it generates in the log-log space a piecewise-linear (a.k.a. 1st-degree spline) approximation of the PSD. Below is an example diagram of such an approximation:

![navmat-psd](https://user-images.githubusercontent.com/5862803/145074744-5bbbfc8e-4d6e-4c8f-96b2-76009fb3317e.PNG)
