### PR TITLE
Fix/integration

### DIFF
--- a/endaq/calc/integrate.py
+++ b/endaq/calc/integrate.py
@@ -38,7 +38,6 @@ def iter_integrals(
     df: pd.DataFrame,
     zero: Union[typing.Literal["start", "mean", "median"], Callable] = "start",
     highpass_cutoff: Optional[float] = None,
-    filter_half_order: int = 3,
     tukey_percent: float = 0.0,
 ) -> Iterable[pd.DataFrame]:
     """
@@ -51,8 +50,6 @@ def iter_integrals(
         ``-np.median(output)``
     :param highpass_cutoff: the cutoff frequency of a preconditioning highpass
         filter; if None, no filter is applied
-    :param filter_half_order: the half-order of the preconditioning highpass
-        filter, if used
     :param tukey_percent: the alpha parameter of a preconditioning tukey filter;
         if 0 (default), no filter is applied
     :return: an iterable over the data's successive integrals; the first item
@@ -74,7 +71,7 @@ def iter_integrals(
         yield df.copy()  # otherwise, edits to the yielded item would alter the results
         df = filters.butterworth(
             df,
-            half_order=filter_half_order,
+            half_order=1,  # ensures zero DC content in nth integral
             low_cutoff=highpass_cutoff,
             high_cutoff=None,
             tukey_percent=tukey_percent,
@@ -124,7 +121,6 @@ def integrals(
                 df,
                 zero=zero,
                 highpass_cutoff=highpass_cutoff,
-                filter_half_order=n // 2 + 1,  # ensures zero DC content in nth integral
                 tukey_percent=tukey_percent,
             ),
         )

--- a/endaq/calc/integrate.py
+++ b/endaq/calc/integrate.py
@@ -71,7 +71,6 @@ def iter_integrals(
         yield df.copy()  # otherwise, edits to the yielded item would alter the results
         df = filters.butterworth(
             df,
-            half_order=1,  # ensures zero DC content in nth integral
             low_cutoff=highpass_cutoff,
             high_cutoff=None,
             tukey_percent=tukey_percent,


### PR DESCRIPTION
This PR makes a fix to `endaq.calc.integrate.integrals` re: the integration's highpass filter order. Currently the order of the filter (which gets applied *on each integration*) would vary based on the number of integrations; this was an artifact of the old integration method. This PR changes that to be a constant order value of `2` per each integration.

However, more broadly I'm wondering if this is the best way to handle integrations, specifically:
- would customers *need* to adjust the order for integrations -> should we add it as a parameter? (This question is unrelated to whether or not to turn on/off the highpass filter; the filter can already be optionally disabled by setting a highpass cutoff frequency of `0`.)
- is `2` a good order value? IMO it's the minimal order value that's *even* (meaning we can use the bidirectional highpass filter) and also fully counters the increase in DC frequencies resulting from an integration.

The content herein is what I would write if 1) no, customers don't need to tweak this value, and 2) yes, 2 is a good hard-coded order value.

attn @shanlyMIDE 