### PR TITLE
Feature/92 module readmes

### DIFF
--- a/docs/endaq/calc.rst
+++ b/docs/endaq/calc.rst
@@ -2,45 +2,55 @@
 ``endaq.calc``
 ##############
 
+:py:mod:`endaq.calc` is a module comprising a collection of common calculations
+for vibration analysis. It leverages the standard Python scientific
+stack (NumPy, SciPy, Pandas) in order to enable engineers to perform
+domain-specific calculations in a few lines of code, without having to
+first master Python and its scientific stack in their entireties.
+
+.. toctree::
+   :maxdepth: 2
+
+   calc_usage
 
 
-`endaq.calc.filters`
-====================
+``endaq.calc.filters``
+======================
 
 .. automodule:: endaq.calc.filters
   :members:
 
 
-`endaq.calc.integrate`
-======================
+``endaq.calc.integrate``
+========================
 
 .. automodule:: endaq.calc.integrate
   :members:
 
 
-`endaq.calc.psd`
-================
+``endaq.calc.psd``
+==================
 
 .. automodule:: endaq.calc.psd
   :members:
 
 
-`endaq.calc.shock`
-==================
+``endaq.calc.shock``
+====================
 
 .. automodule:: endaq.calc.shock
   :members:
 
 
-`endaq.calc.stats`
-==================
+``endaq.calc.stats``
+====================
 
 .. automodule:: endaq.calc.stats
   :members:
 
 
-`endaq.calc.utils`
-==================
+``endaq.calc.utils``
+====================
 
 .. automodule:: endaq.calc.utils
   :members:

--- a/docs/endaq/calc_usage.rst
+++ b/docs/endaq/calc_usage.rst
@@ -1,0 +1,66 @@
+=============================
+``endaq.calc`` Usage Examples
+=============================
+
+
+Filters
+~~~~~~~
+
+.. code:: python
+
+   df_accel_highpass = endaq.calc.filters.butterworth(df_accel, low_cutoff=1, high_cutoff=None)
+   df_accel_lowpass = endaq.calc.filters.butterworth(df_accel, low_cutoff=None, high_cutoff=100)
+
+Integration
+~~~~~~~~~~~
+
+.. code:: python
+
+   dfs_integrate = endaq.calc.integrate.integrals(df_accel, n=2, highpass_cutoff=1.0, tukey_percent=0.05)
+
+PSD
+~~~
+
+Linearly-spaced
+^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   df_accel_psd = endaq.calc.psd.welch(df_accel, bin_width=1/11)
+
+Octave-spaced
+^^^^^^^^^^^^^
+
+.. code:: python
+
+   df_accel_psd_oct = endaq.calc.psd.to_octave(df_accel_psd, fstart=1, octave_bins=3)
+
+Derivatives & Integrals
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   df_vel_psd = endaq.calc.psd.differentiate(df_accel_psd, n=-1)
+   df_jerk_psd = endaq.calc.psd.differentiate(df_accel_psd, n=1)
+
+Vibration Criterion (VC) Curves
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   df_accel_vc = endaq.calc.psd.vc_curves(df_accel_psd, fstart=1, octave_bins=3)
+
+Shock Analysis
+~~~~~~~~~~~~~~
+
+.. code:: python
+
+   df_accel_pvss = endaq.calc.shock.shock_spectrum(df_accel, freqs=2 ** np.arange(-10, 13, 0.25), damp=0.05, mode="pvss")
+   df_accel_srs = endaq.calc.shock.shock_spectrum(df_accel, freqs=[1, 10, 100, 1000], damp=0.05, mode="srs")
+
+Shock Characterization: Half-Sine-Wave Pulse
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   half_sine_params = endaq.calc.shock.enveloping_half_sine(df_accel_pvss, damp=0.05)

--- a/docs/endaq/cloud.rst
+++ b/docs/endaq/cloud.rst
@@ -2,6 +2,13 @@
 ``endaq.cloud``
 ###############
 
+This module houses tools and functions to make both interacting with the enDAQ Cloud API and the [enDAQ Cloud](https://cloud.endaq.com) itself easier.
+
+.. toctree::
+   :maxdepth: 2
+
+   cloud_API_wrapper
+
 
 `endaq.cloud.core`
 ==================

--- a/docs/endaq/plot.rst
+++ b/docs/endaq/plot.rst
@@ -2,6 +2,11 @@
 ``endaq.plot``
 ##############
 
+.. toctree::
+   :maxdepth: 2
+
+   plot_usage
+
 
 `endaq.plot`
 ==============

--- a/docs/endaq/plot_usage.rst
+++ b/docs/endaq/plot_usage.rst
@@ -1,0 +1,67 @@
+``endaq.plot`` Usage Examples
+=============================
+
+For these examples we assume there is a Pandas DataFrame named ``df``
+which has it’s index as time stamps and it’s one column being sensor
+values (e.g. x-axis accleration, or pressure). It also assumes there is
+a Pandas DataFrame ``attribute_df`` which contains all the attribute
+data about various data files. More information can be found about how
+to get this data from enDAQ IDE files in the `endaq-cloud
+readme <https://github.com/MideTechnology/endaq-python/tree/main/endaq/cloud>`__.
+
+.. code:: python
+
+   from endaq.plot import octave_spectrogram, multi_file_plot_attributes, octave_psd_bar_plot
+   from endaq.plot.utilities import set_theme
+
+Setting The Aesthetic Theme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   set_theme(theme='endaq')
+
+Creating Spectrograms With Octave Spaced Frequencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   data_df, fig = octave_spectrogram(df, window=.15)
+   fig.show()
+
+.. figure:: https://i.imgur.com/929aszu.png
+   :alt: Spectrogram With Octave Spaced Frequencies
+
+   Spectrogram With Octave Spaced Frequencies
+
+Creating PSD Bar Plots With Octave Spaced Frequencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   fig = octave_psd_bar_plot(df, yaxis_title="Magnitude")
+   fig.show()
+
+.. figure:: https://i.imgur.com/ueqcVTQ.png
+   :alt: PSD Bar Plot With Octave Spaced Frequencies
+
+   PSD Bar Plot With Octave Spaced Frequencies
+
+Plot Attributes In Figure With Subplots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   fig = multi_file_plot_attributes(attribute_df)
+   fig.show()
+
+.. figure:: https://i.imgur.com/5Yy4DN7.png
+   :alt: Attributes Plotted As Subplots
+
+   Attributes Plotted As Subplots
+
+Other Links
+-----------
+
+-  the endaq package - https://github.com/MideTechnology/endaq-python
+-  the enDAQ homepage - https://endaq.com/


### PR DESCRIPTION
This moves the README contents from submodules to the documentation. This is similar to #107 (which should be merged first), but with less editing of the content.

See issue #92