### PR TITLE
Feature/more filters

### DIFF
--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -4,10 +4,74 @@ from typing import Optional, Union, Tuple
 import functools
 
 import pandas as pd
+import numpy as np
 import scipy.signal
 
 from endaq.calc import utils
 
+def _get_filter_params(low_cutoff, high_cutoff):
+    """Get the filter type and cutoff frequency array."""
+    cutoff_freqs: Union[float, Tuple[float, float]]
+    filter_type: str
+
+    if low_cutoff is not None and high_cutoff is not None:
+        cutoff_freqs = (low_cutoff, high_cutoff)
+        filter_type = "bandpass"
+    elif low_cutoff is not None:
+        cutoff_freqs = low_cutoff
+        filter_type = "highpass"
+    elif high_cutoff is not None:
+        cutoff_freqs = high_cutoff
+        filter_type = "lowpass"
+    else:
+        filter_type = ""
+        
+    return cutoff_freqs, filter_type        
+
+def bias(
+    df: pd.DataFrame,
+    mode: typing.Literal["median", "mean"] = "median"
+) -> pd.DataFrame:
+    """
+    Remove the bias of an input time series dataframe
+
+    :param df: the input data
+    :param mode: what to set to 0:
+            * `"median"` - default
+            * `"mean"`
+
+    :return: a dataframe of the filtered data
+    """
+    if (mode=="mean"):
+        df = df - df.mean()
+    else:
+        df = df - df.median()
+
+    return df    
+
+def rolling_bias(
+    df: pd.DataFrame,
+    mode: typing.Literal["median", "mean"] = "median",
+    duration: float = 5.0
+) -> pd.DataFrame:
+    """
+    Remove the bias of an input time series dataframe using a rolling window
+
+    :param df: the input data
+    :param mode: what to set to 0:
+            * `"median"` - default
+            * `"mean"`
+    :param duration: the rolling window size in seconds to use     
+
+    :return: a dataframe of the filtered data
+    """
+    n = int(duration / utils.sample_spacing(df))
+    if (mode=="mean"):
+        df = df - df.rolling(n, min_periods=1, center=True).mean()
+    else:
+        df = df - df.rolling(n, min_periods=1, center=True).median()
+
+    return df        
 
 def butterworth(
     df: pd.DataFrame,
@@ -42,20 +106,7 @@ def butterworth(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs: Union[float, Tuple[float, float]]
-    filter_type: str
-
-    if low_cutoff is not None and high_cutoff is not None:
-        cutoff_freqs = (low_cutoff, high_cutoff)
-        filter_type = "bandpass"
-    elif low_cutoff is not None:
-        cutoff_freqs = low_cutoff
-        filter_type = "highpass"
-    elif high_cutoff is not None:
-        cutoff_freqs = high_cutoff
-        filter_type = "lowpass"
-    else:
-        filter_type = ""
+    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)
@@ -74,3 +125,294 @@ def butterworth(
         df = df.mul(tukey_window, axis="rows")
 
     return df
+
+def bessel(
+    df: pd.DataFrame,
+    low_cutoff: Optional[float] = 1.0,
+    high_cutoff: Optional[float] = None,
+    half_order: int = 3,
+    tukey_percent: float = 0.0,
+    norm: typing.Literal["phase", "delay", "mag"] = "mag",
+) -> pd.DataFrame:
+    """
+    Apply a lowpass and/or a highpass Bessel filter to an array.
+
+    This function uses Bessel filter designs, and implements the filter(s)
+    as bi-directional digital biquad filters, split into second-order sections.
+
+    :param df: the input data; cutoff frequencies are relative to the
+        timestamps in `df.index`
+    :param low_cutoff: the low-frequency cutoff, if any; frequencies below this
+        value are rejected, and frequencies above this value are preserved
+    :param high_cutoff: the high-frequency cutoff, if any; frequencies above
+        this value are rejected, and frequencies below this value are preserved
+    :param half_order: half of the order of the filter; higher orders provide
+        more aggressive stopband reduction
+    :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
+        if 0 (default), no filter is applied
+    :param norm: how to normalize relative to the critical frequency:
+            * `"phase"` - "phase-matched" case which is the default in SciPy & MATLAB
+            * `"delay"` - the "natural" type obtained by solving Bessel polynomials
+            * `"mag"` - gain magnitude is -3 dB at the cutoff frequency, default for this implementation to match Butterworth
+
+    :return: the filtered data
+
+    .. seealso::
+
+        - `SciPy Bessel filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.bessel.html>`_
+          Documentation for the Bessel filter design function.
+
+        - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
+          Documentation for the Tukey window function used in preprocessing.
+    """
+    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+
+    if filter_type:
+        dt = utils.sample_spacing(df)
+
+        sos_coeffs = scipy.signal.bessel(
+            N=half_order,
+            Wn=cutoff_freqs,
+            btype=filter_type,
+            fs=1 / dt,
+            output="sos",
+            norm=norm
+        )
+        df = df.apply(functools.partial(scipy.signal.sosfiltfilt, sos_coeffs), axis=0)
+
+    if tukey_percent > 0:
+        tukey_window = scipy.signal.windows.tukey(len(df.index), alpha=tukey_percent)
+        df = df.mul(tukey_window, axis="rows")
+
+    return df  
+
+def cheby1(
+    df: pd.DataFrame,
+    low_cutoff: Optional[float] = 1.0,
+    high_cutoff: Optional[float] = None,
+    half_order: int = 3,
+    tukey_percent: float = 0.0,
+    rp: float = 3.0,
+) -> pd.DataFrame:
+    """
+    Apply a lowpass and/or a highpass Chebyshev type I filter to an array.
+
+    This function uses Chebyshev type I filter designs, and implements the filter(s)
+    as bi-directional digital biquad filters, split into second-order sections.
+
+    :param df: the input data; cutoff frequencies are relative to the
+        timestamps in `df.index`
+    :param low_cutoff: the low-frequency cutoff, if any; frequencies below this
+        value are rejected, and frequencies above this value are preserved
+    :param high_cutoff: the high-frequency cutoff, if any; frequencies above
+        this value are rejected, and frequencies below this value are preserved
+    :param half_order: half of the order of the filter; higher orders provide
+        more aggressive stopband reduction
+    :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
+        if 0 (default), no filter is applied
+    :param rp: tthe maximum ripple allowed in the passband, specified in decibels
+
+    :return: the filtered data
+
+    .. seealso::
+
+        - `SciPy Cheby1 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.cheby1.html>`_
+          Documentation for the Chebyshev type I filter design function.
+
+        - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
+          Documentation for the Tukey window function used in preprocessing.
+    """
+    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+
+    if filter_type:
+        dt = utils.sample_spacing(df)
+
+        sos_coeffs = scipy.signal.cheby1(
+            N=half_order,
+            Wn=cutoff_freqs,
+            btype=filter_type,
+            fs=1 / dt,
+            output="sos",
+            rp=rp
+        )
+        df = df.apply(functools.partial(scipy.signal.sosfiltfilt, sos_coeffs), axis=0)
+
+    if tukey_percent > 0:
+        tukey_window = scipy.signal.windows.tukey(len(df.index), alpha=tukey_percent)
+        df = df.mul(tukey_window, axis="rows")
+
+    return df
+
+def cheby2(
+    df: pd.DataFrame,
+    low_cutoff: Optional[float] = 1.0,
+    high_cutoff: Optional[float] = None,
+    half_order: int = 3,
+    tukey_percent: float = 0.0,
+    rs: float = 30.0,
+) -> pd.DataFrame:
+    """
+    Apply a lowpass and/or a highpass Chebyshev type II filter to an array.
+
+    This function uses Chebyshev type II filter designs, and implements the filter(s)
+    as bi-directional digital biquad filters, split into second-order sections.
+
+    :param df: the input data; cutoff frequencies are relative to the
+        timestamps in `df.index`
+    :param low_cutoff: the low-frequency cutoff, if any; frequencies below this
+        value are rejected, and frequencies above this value are preserved
+    :param high_cutoff: the high-frequency cutoff, if any; frequencies above
+        this value are rejected, and frequencies below this value are preserved
+    :param half_order: half of the order of the filter; higher orders provide
+        more aggressive stopband reduction
+    :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
+        if 0 (default), no filter is applied
+    :param rs: tthe minimum attenuation allowed in the stopband, specified in decibels
+
+    :return: the filtered data
+
+    .. seealso::
+
+        - `SciPy Cheby1 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.cheby2.html>`_
+          Documentation for the Chebyshev type II filter design function.
+
+        - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
+          Documentation for the Tukey window function used in preprocessing.
+    """
+    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+
+    if filter_type:
+        dt = utils.sample_spacing(df)
+
+        sos_coeffs = scipy.signal.cheby2(
+            N=half_order,
+            Wn=cutoff_freqs,
+            btype=filter_type,
+            fs=1 / dt,
+            output="sos",
+            rs=rs
+        )
+        df = df.apply(functools.partial(scipy.signal.sosfiltfilt, sos_coeffs), axis=0)
+
+    if tukey_percent > 0:
+        tukey_window = scipy.signal.windows.tukey(len(df.index), alpha=tukey_percent)
+        df = df.mul(tukey_window, axis="rows")
+
+    return df           
+
+
+def ellip(
+    df: pd.DataFrame,
+    low_cutoff: Optional[float] = 1.0,
+    high_cutoff: Optional[float] = None,
+    half_order: int = 3,
+    tukey_percent: float = 0.0,
+    rp: float = 3.0,
+    rs: float = 30.0,
+) -> pd.DataFrame:
+    """
+    Apply a lowpass and/or a highpass Elliptic filter to an array.
+
+    This function uses Elliptic filter designs, and implements the filter(s)
+    as bi-directional digital biquad filters, split into second-order sections.
+
+    :param df: the input data; cutoff frequencies are relative to the
+        timestamps in `df.index`
+    :param low_cutoff: the low-frequency cutoff, if any; frequencies below this
+        value are rejected, and frequencies above this value are preserved
+    :param high_cutoff: the high-frequency cutoff, if any; frequencies above
+        this value are rejected, and frequencies below this value are preserved
+    :param half_order: half of the order of the filter; higher orders provide
+        more aggressive stopband reduction
+    :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
+        if 0 (default), no filter is applied
+    :param rp: tthe maximum ripple allowed in the passband, specified in decibels
+    :param rs: tthe minimum attenuation allowed in the stopband, specified in decibels
+
+    :return: the filtered data
+
+    .. seealso::
+
+        - `SciPy Cheby1 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ellip.html>`_
+          Documentation for the Elliptic filter design function.
+
+        - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
+          Documentation for the Tukey window function used in preprocessing.
+    """
+    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+
+    if filter_type:
+        dt = utils.sample_spacing(df)
+
+        sos_coeffs = scipy.signal.ellip(
+            N=half_order,
+            Wn=cutoff_freqs,
+            btype=filter_type,
+            fs=1 / dt,
+            output="sos",
+            rs=rs,
+            rp=rp
+        )
+        df = df.apply(functools.partial(scipy.signal.sosfiltfilt, sos_coeffs), axis=0)
+
+    if tukey_percent > 0:
+        tukey_window = scipy.signal.windows.tukey(len(df.index), alpha=tukey_percent)
+        df = df.mul(tukey_window, axis="rows")
+
+    return df            
+
+def _fftnoise(f):
+    f = np.array(f, dtype='complex')
+    Np = (len(f) - 1) // 2
+    phases = np.random.rand(Np) * 2 * np.pi
+    phases = np.cos(phases) + 1j * np.sin(phases)
+    f[1:Np+1] *= phases
+    f[-1:-1-Np:-1] = np.conj(f[1:Np+1])
+    return np.fft.ifft(f).real
+
+def band_limited_noise(
+    min_freq: float = 0.0,
+    max_freq: float = None,
+    duration: float = 1.0,
+    sample_rate: float = 1000.0,
+    norm: typing.Literal["rms", "peak"] = "peak",
+) -> pd.DataFrame:
+    """
+    Generate a time series with noise in a defined frequency range.
+
+    :param min_freq: minimum frequency (Hz) where noise starts, default to 0
+    :param max_freq: maximum frequency (Hz) where noise ends, default to 1/2 the sample rate
+    :param duration: the duration of the time series returned, in seconds
+    :param sample_rate: sample rate (Hz) of the time series
+    :param norm: how to normalize the amplitude so that one of the following is equal to 1:
+            * `"rms"` - root mean square
+            * `"peak"` - peak value, default
+
+    :return: a dataframe of the generated time series
+
+    .. seealso::
+
+        - `stack overflow post <https://stackoverflow.com/questions/33933842/how-to-generate-noise-in-frequency-range-with-numpy>`_
+          that inspired this function and shared code we based this function on.
+    
+    """
+    samples = int(duration * sample_rate)
+    freqs = np.abs(np.fft.fftfreq(samples, 1/sample_rate))
+    f = np.zeros(samples)
+
+    if (max_freq is None):
+        max_freq = sample_rate/2
+    idx = np.where(np.logical_and(freqs>=min_freq, freqs<=max_freq))[0]
+    f[idx] = 1
+
+    df = pd.DataFrame(_fftnoise(f), 
+                        index=pd.Series(np.arange(samples)/sample_rate, name='Time (s)'),
+                        columns=['Noise from '+str(np.round(min_freq,1))+' to '+str(np.round(max_freq,1))+' Hz'])
+    
+    if (norm == 'rms'):
+        df = df / np.mean(df**2)**0.5
+    else:
+        df = df / df.abs().max()
+
+    return df
+

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -9,7 +9,7 @@ import scipy.signal
 
 from endaq.calc import utils
 
-def _get_filter_params(low_cutoff, high_cutoff):
+def _get_filter_frequencies_type(low_cutoff, high_cutoff):
     """Get the filter type and cutoff frequency array."""
     cutoff_freqs: Union[float, Tuple[float, float]]
     filter_type: str
@@ -44,7 +44,7 @@ def rolling_mean(
     if (duration is None):
         mean = df.mean()
     else:
-        n = int(duration / utils.sample_spacing(df))
+        n = int(np.ceil(duration / utils.sample_spacing(accel)) // 2 * 2 + 1)
         mean = df.rolling(n, min_periods=1, center=True).mean()    
 
     return df - mean   
@@ -82,7 +82,7 @@ def butterworth(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+    cutoff_freqs, filter_type = _get_filter_frequencies_type(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)
@@ -141,7 +141,7 @@ def bessel(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+    cutoff_freqs, filter_type = _get_filter_frequencies_type(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)
@@ -198,7 +198,7 @@ def cheby1(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+    cutoff_freqs, filter_type = _get_filter_frequencies_type(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)
@@ -255,7 +255,7 @@ def cheby2(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+    cutoff_freqs, filter_type = _get_filter_frequencies_type(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)
@@ -315,7 +315,7 @@ def ellip(
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
           Documentation for the Tukey window function used in preprocessing.
     """
-    cutoff_freqs, filter_type = _get_filter_params(low_cutoff, high_cutoff)
+    cutoff_freqs, filter_type = _get_filter_frequencies_type(low_cutoff, high_cutoff)
 
     if filter_type:
         dt = utils.sample_spacing(df)

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -14,6 +14,7 @@ def _get_filter_frequencies_type(low_cutoff, high_cutoff):
     cutoff_freqs: Union[float, Tuple[float, float]]
     filter_type: str
 
+    filter_type = ""
     if low_cutoff is not None and high_cutoff is not None:
         cutoff_freqs = (low_cutoff, high_cutoff)
         filter_type = "bandpass"
@@ -22,9 +23,7 @@ def _get_filter_frequencies_type(low_cutoff, high_cutoff):
         filter_type = "highpass"
     elif high_cutoff is not None:
         cutoff_freqs = high_cutoff
-        filter_type = "lowpass"
-    else:
-        filter_type = ""
+        filter_type = "lowpass"        
         
     return cutoff_freqs, filter_type        
 
@@ -44,7 +43,7 @@ def rolling_mean(
     if (duration is None):
         mean = df.mean()
     else:
-        n = int(np.ceil(duration / utils.sample_spacing(accel)) // 2 * 2 + 1)
+        n = int(np.ceil(duration / utils.sample_spacing(df)) // 2 * 2 + 1)
         mean = df.rolling(n, min_periods=1, center=True).mean()    
 
     return df - mean   

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -29,6 +29,7 @@ def _get_filter_frequencies_type(low_cutoff, high_cutoff):
         
     return cutoff_freqs, filter_type        
 
+
 def rolling_mean(
     df: pd.DataFrame,
     duration: float = 5.0
@@ -49,6 +50,7 @@ def rolling_mean(
         mean = df.rolling(n, min_periods=1, center=True).mean()    
 
     return df - mean   
+
 
 def butterworth(
     df: pd.DataFrame,
@@ -102,6 +104,7 @@ def butterworth(
         df = df.mul(tukey_window, axis="rows")
 
     return df
+
 
 def bessel(
     df: pd.DataFrame,
@@ -163,6 +166,7 @@ def bessel(
 
     return df  
 
+
 def cheby1(
     df: pd.DataFrame,
     low_cutoff: Optional[float] = 1.0,
@@ -219,6 +223,7 @@ def cheby1(
         df = df.mul(tukey_window, axis="rows")
 
     return df
+
 
 def cheby2(
     df: pd.DataFrame,
@@ -338,7 +343,11 @@ def ellip(
 
     return df            
 
+
 def _fftnoise(f):
+    """
+    Generate time series noise for a given range of frequencies with random phase using ifft.
+    """
     f = np.array(f, dtype='complex')
     Np = (len(f) - 1) // 2
     phases = np.random.rand(Np) * 2 * np.pi
@@ -346,6 +355,7 @@ def _fftnoise(f):
     f[1:Np+1] *= phases
     f[-1:-1-Np:-1] = np.conj(f[1:Np+1])
     return np.fft.ifft(f).real
+
 
 def band_limited_noise(
     min_freq: float = 0.0,

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -303,8 +303,8 @@ def ellip(
         more aggressive stopband reduction
     :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
         if 0 (default), no filter is applied
-    :param rp: tthe maximum ripple allowed in the passband, specified in decibels
-    :param rs: tthe minimum attenuation allowed in the stopband, specified in decibels
+    :param rp: the maximum ripple allowed in the passband, specified in decibels
+    :param rs: the minimum attenuation allowed in the stopband, specified in decibels
 
     :return: the filtered data
 

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -28,50 +28,26 @@ def _get_filter_params(low_cutoff, high_cutoff):
         
     return cutoff_freqs, filter_type        
 
-def bias(
+def rolling_mean(
     df: pd.DataFrame,
-    mode: typing.Literal["median", "mean"] = "median"
-) -> pd.DataFrame:
-    """
-    Remove the bias of an input time series dataframe
-
-    :param df: the input data
-    :param mode: what to set to 0:
-            * `"median"` - default
-            * `"mean"`
-
-    :return: a dataframe of the filtered data
-    """
-    if (mode=="mean"):
-        df = df - df.mean()
-    else:
-        df = df - df.median()
-
-    return df    
-
-def rolling_bias(
-    df: pd.DataFrame,
-    mode: typing.Literal["median", "mean"] = "median",
     duration: float = 5.0
 ) -> pd.DataFrame:
     """
-    Remove the bias of an input time series dataframe using a rolling window
+    Remove the rolling mean of an input time series dataframe
 
     :param df: the input data
-    :param mode: what to set to 0:
-            * `"median"` - default
-            * `"mean"`
-    :param duration: the rolling window size in seconds to use     
+    :param duration: the rolling window size in seconds to use
+        - if `None` is given, the entire mean is removed 
 
     :return: a dataframe of the filtered data
     """
-    n = int(duration / utils.sample_spacing(df))
-    if (mode=="mean"):
-        df = df - df.rolling(n, min_periods=1, center=True).mean()
+    if (duration is None):
+        mean = df.mean()
     else:
-        df = df - df.rolling(n, min_periods=1, center=True).median()
+        n = int(duration / utils.sample_spacing(df))
+        mean = df.rolling(n, min_periods=1, center=True).mean()    
 
-    return df        
+    return df - mean   
 
 def butterworth(
     df: pd.DataFrame,

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -14,7 +14,6 @@ def _get_filter_frequencies_type(low_cutoff, high_cutoff):
     cutoff_freqs: Union[float, Tuple[float, float]]
     filter_type: str
 
-    filter_type = ""
     if low_cutoff is not None and high_cutoff is not None:
         cutoff_freqs = (low_cutoff, high_cutoff)
         filter_type = "bandpass"
@@ -24,6 +23,8 @@ def _get_filter_frequencies_type(low_cutoff, high_cutoff):
     elif high_cutoff is not None:
         cutoff_freqs = high_cutoff
         filter_type = "lowpass"        
+    else:
+        return None, None
         
     return cutoff_freqs, filter_type        
 

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -187,7 +187,7 @@ def cheby1(
         more aggressive stopband reduction
     :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
         if 0 (default), no filter is applied
-    :param rp: tthe maximum ripple allowed in the passband, specified in decibels
+    :param rp: the maximum ripple allowed in the passband, specified in decibels
 
     :return: the filtered data
 

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -310,7 +310,7 @@ def ellip(
 
     .. seealso::
 
-        - `SciPy Cheby1 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ellip.html>`_
+        - `SciPy Ellip filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ellip.html>`_
           Documentation for the Elliptic filter design function.
 
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -250,7 +250,7 @@ def cheby2(
 
     .. seealso::
 
-        - `SciPy Cheby1 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.cheby2.html>`_
+        - `SciPy Cheby2 filter design <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.cheby2.html>`_
           Documentation for the Chebyshev type II filter design function.
 
         - `SciPy Tukey window <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -244,7 +244,7 @@ def cheby2(
         more aggressive stopband reduction
     :param tukey_percent: the alpha parameter of a preconditioning Tukey filter;
         if 0 (default), no filter is applied
-    :param rs: tthe minimum attenuation allowed in the stopband, specified in decibels
+    :param rs: the minimum attenuation allowed in the stopband, specified in decibels
 
     :return: the filtered data
 

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -9,6 +9,7 @@ import scipy.signal
 
 from endaq.calc import utils
 
+
 def _get_filter_frequencies_type(low_cutoff, high_cutoff):
     """Get the filter type and cutoff frequency array."""
     cutoff_freqs: Union[float, Tuple[float, float]]


### PR DESCRIPTION
I created a few new filtering functions:

- `endaq.calc.filters.rolling_mean` which is a simple rolling mean removal to give similar results to what the Lab does
- `bessel`, `cheby1`, `cheby2`, `ellip` for new filter types - should be identical API to `butterworth` but with added params as needed
- `band_limited_noise` to generate test time series with noise in a defined frequency range

[I tested the branch in this Colab](https://colab.research.google.com/drive/1RKp8pLG3C9A0FLWL1LVh28gC16wdrgEk#scrollTo=aPebMGLhH43F) and I think everything looks good, images below.

PSDs of noise time series
![newplot - 2022-01-10T220539 245](https://user-images.githubusercontent.com/35080650/148875208-5f0cb368-45f4-4536-b6d0-203c28c87622.png)

Filter response (question to @CrepeGoat and @CFlaniganMide why aren't the cutoff frequencies at 0.707 here which would be -3 dB?)
![newplot - 2022-01-10T220559 319](https://user-images.githubusercontent.com/35080650/148875273-4c6f0380-dbfb-4a42-921c-0b2afebc59be.png)
![newplot - 2022-01-10T221905 327](https://user-images.githubusercontent.com/35080650/148875570-763ed0cf-5f4f-4e36-9792-0bc918515b20.png)


A large IDE file before and after `rolling_mean` removal
![newplot - 2022-01-10T221034 353](https://user-images.githubusercontent.com/35080650/148875302-78991963-c073-41b4-a7ee-488769b478ab.png)
![newplot - 2022-01-10T221040 518](https://user-images.githubusercontent.com/35080650/148875309-201fa9fb-7dc6-4ee7-9469-686eaab49c1a.png)


I'll request Becker and Connor to approve, but I'm ccing @SamRagusa @pscheidler @StokesMIDE if interested