### PR TITLE
Feature/concrete docs reqs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,4 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 
 pydata-sphinx-theme==0.7.1
-
-sphinx-plotly-directive
+sphinx-plotly-directive==0.1.3


### PR DESCRIPTION
This PR changes the docs requirements.txt to specify concrete version numbers, to keep our ReadTheDocs builds as deterministic as possible.