### PR TITLE
removed redundant link to API Cloud Wrapper reference

### DIFF
--- a/docs/api_ref.rst
+++ b/docs/api_ref.rst
@@ -10,5 +10,3 @@ enDAQ API Reference
    endaq/cloud
    endaq/plot
    endaq/batch
-
-   endaq/cloud_API_wrapper


### PR DESCRIPTION
This PR removes the extra link to the Cloud API Wrapper reference, as discussed in our meeting today.

New docs will eventually be rendered here: https://docs.endaq.com/en/fix-docs/; making this a draft PR until the docs are built.