### PR TITLE
Feature/batch/repeat builder options

### DIFF
--- a/endaq/batch/core.py
+++ b/endaq/batch/core.py
@@ -381,12 +381,7 @@ class GetDataBuilder:
         :param init_freq: the first frequency sample in the spectrum
         :param bins_per_octave: the number of samples per frequency octave
         """
-        if (
-            self._pvss_init_freq is not None
-            # `self._pvss_init_freq` may be set by `add_metrics`
-            # -> check metrics queue entries specifically
-            and any(name == "pvss" for (name, _) in self._metrics_queue)
-        ):
+        if any(name == "pvss" for (name, _) in self._metrics_queue):
             raise RuntimeError('cannot call "add_pvss" twice')
 
         self._metrics_queue.append(("pvss", _make_pvss))

--- a/endaq/batch/core.py
+++ b/endaq/batch/core.py
@@ -562,7 +562,7 @@ class GetDataBuilder:
             os.path.relpath(name, start=root_path) for name in local_files
         ]
 
-        series_lists = zip(*(self._get_data(file).values() for file in files))
+        series_lists = zip(*([d for (_k, d) in self._get_data(file)] for file in files))
 
         print("aggregating data...")
         meta, *dfs = (
@@ -612,8 +612,8 @@ class OutputStruct:
     This class is not intended be instantiated manually.
     """
 
-    def __init__(self, data):
-        self.dataframes: List[Tuple[str, pd.DataFrame]] = data
+    def __init__(self, data: List[Tuple[str, pd.DataFrame]]):
+        self.dataframes = data
 
     def to_csv_folder(self, folder_path):
         """
@@ -623,7 +623,7 @@ class OutputStruct:
         """
         os.makedirs(folder_path, exist_ok=True)
 
-        for k, df in self.dataframes.items():
+        for k, df in self.dataframes:
             path = os.path.join(folder_path, f"{k}.csv")
             df.to_csv(path, index=(k == "meta"))
 
@@ -659,7 +659,7 @@ class OutputStruct:
         if folder_path:
             os.makedirs(folder_path, exist_ok=True)
 
-        for k, df in self.dataframes.items():
+        for k, df in self.dataframes:
             if k == "meta":
                 continue
             if k == "psd":

--- a/endaq/batch/core.py
+++ b/endaq/batch/core.py
@@ -381,6 +381,14 @@ class GetDataBuilder:
         :param init_freq: the first frequency sample in the spectrum
         :param bins_per_octave: the number of samples per frequency octave
         """
+        if (
+            self._pvss_init_freq is not None
+            # `self._pvss_init_freq` may be set by `add_metrics`
+            # -> check metrics queue entries specifically
+            and any(name == "pvss" for (name, _) in self._metrics_queue)
+        ):
+            raise RuntimeError('cannot call "add_pvss" twice')
+
         self._metrics_queue.append(("pvss", _make_pvss))
         self._pvss_init_freq = init_freq
         self._pvss_bins_per_octave = bins_per_octave

--- a/tests/batch/test_core.py
+++ b/tests/batch/test_core.py
@@ -704,6 +704,7 @@ def test_integration(filenames):
     output_struct = (
         endaq.batch.core.GetDataBuilder(accel_highpass_cutoff=1)
         .add_psd(freq_bin_width=1)
+        .add_psd(freq_start_octave=2, bins_per_octave=12)
         .add_pvss(init_freq=1, bins_per_octave=12)
         .add_pvss_halfsine_envelope()
         .add_metrics()


### PR DESCRIPTION
waiting on #171 -> draft

This PR changes `batch.GetDataBuilder` to allow multiple calls to certain `add_*` methods. This is a building block for the cloud scripts, which require separate calls to `add_psd` to calculate linearly-spaced and log-spaced PSD's for a given file.