### PR TITLE
Feature/118 pandas localtime

### DIFF
--- a/endaq/ide/info.py
+++ b/endaq/ide/info.py
@@ -343,6 +343,8 @@ def get_primary_sensor_data(
     measurement_type: typing.Union[str, MeasurementType] = ANY,
     criteria: typing.Literal["samples", "rate", "duration"] = "samples",
     time_mode: typing.Literal["seconds", "timedelta", "datetime"] = "datetime",
+    tz: typing.Union[pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo,
+                     typing.Literal["device", "local", "utc"]] = "utc",
     least: bool = False,
     force_data_return: bool = False
 ) -> pd.DataFrame:
@@ -369,6 +371,15 @@ def get_primary_sensor_data(
             * `"seconds"` - a `pandas.Float64Index` of relative timestamps, in seconds
             * `"timedelta"` - a `pandas.TimeDeltaIndex` of relative timestamps
             * `"datetime"` - a `pandas.DateTimeIndex` of absolute timestamps
+        :param tz: Optional time zone information for displaying the `"datetime"` time
+            mode. It can be a standard time zone object (`pytz.timezone`,
+            `dateutil.tz.tzfile`, `datetime.tzinfo`) or one of three special strings:
+
+            * `"utc"` - standard UTC time (default).
+            * `"local"` - the  current computer's local time zone (note: may not be the
+                user's actual time zone when used on enDAQ Cloud).
+            * `"device"` - the time zone specified by the original recording device's
+                configured UTC offset.
         :param least: If set to `True` it will return the channels ranked lowest by
             the given criteria.
         :param force_data_return: If set to `True` and the specified `measurement_type`
@@ -418,7 +429,7 @@ def get_primary_sensor_data(
     parent = channels.iloc[0].channel.parent
     
     #Get parent channel data
-    data = to_pandas(parent, time_mode=time_mode)
+    data = to_pandas(parent, time_mode=time_mode, tz=tz)
     
     #Return only the subchannels with right units
     return data[channels.name]    

--- a/tests/ide/test_info.py
+++ b/tests/ide/test_info.py
@@ -190,7 +190,16 @@ def test_to_pandas(test_IDE, time_mode, subchannel):
     assert np.all(result.to_numpy() == eventarray.arrayValues().T)
 
 
+def test_to_pandas_tz(test_IDE):
+    """ Minimal test of time zones in `to_pandas()`. Mostly a sanity check. """
+    channel = test_IDE.channels[32]
+    
+    result_utc = info.to_pandas(channel, tz="utc")
+    result_local = info.to_pandas(channel, tz="local")
+    result_device = info.to_pandas(channel, tz="device")
 
+    assert "UTC" in str(result_utc.index.dtype)
+    assert "device" in str(result_device.index.dtype)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a solution to issue #118. It adds a `tz` parameter, which can be the strings `"utc"` (default), `"local"` (user's local time), `"device"` (TZ based on recorder's UTC offset), or a standard type of time zone info object. 

One significant change is that the index for all `"datetime"` indices, the type was explicitly changed to a `pandas.DatetimeIndex` in order to add the timezone information (`numpy.datetime64` does not support timezones). We will have to be on the lookout for any issues this might introduce (small discrepancies due to rounding errors or whatnot).

Note: current tests are minimal. Mostly just a sanity check.