### PR TITLE
refactored markdown text to fix formatting issues in webinar notebooks

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,10 +15,6 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx_plotly_directive',
     'nbsphinx',
+    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx_plotly_directive',
     'nbsphinx',
-    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-serializinghtml==1.1.5
 
 pydata-sphinx-theme==0.7.1
 sphinx-plotly-directive==0.1.3
+nbsphinx==0.8.8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ sphinxcontrib-serializinghtml==1.1.5
 pydata-sphinx-theme==0.7.1
 sphinx-plotly-directive==0.1.3
 nbsphinx==0.8.8
+ipython==8.1.0

--- a/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
+++ b/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
@@ -1,20 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "Webinar-Intro-Python-Acceleration-CSV-Analysis.ipynb",
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -35,7 +19,7 @@
     "This is part of our webinar series on Python for Mechanical Engineers:\n",
     "\n",
     "1. **Get Started with Python**\n",
-    "  * [Watch Recording of This](https://info.endaq.com/why-mechanical-engineers-should-use-python-webinar)\n",
+    "   * [Watch Recording of This](https://info.endaq.com/why-mechanical-engineers-should-use-python-webinar)\n",
     "2. [Introduction to Numpy & Pandas for Data Analysis](https://colab.research.google.com/drive/1O-VwAdRoSlcrineAk0Jkd_fcw7mFGHa4#scrollTo=ce97q1ZcBiwj)\n",
     "3. [Introduction to Plotly for Plotting Data](https://colab.research.google.com/drive/1pag2pKQQW5amWgRykAH8uMAPqHA2yUfU)\n",
     "4. [Introduction of the enDAQ Library](https://colab.research.google.com/drive/1WAtQ8JJC_ny0fki7eUABACMA-isZzKB6)"
@@ -63,9 +47,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "Ut2acKSEKN1C"
    },
+   "outputs": [],
    "source": [
     "filenames = ['https://info.endaq.com/hubfs/data/surgical-instrument.csv',\n",
     "             'https://info.endaq.com/hubfs/data/blushift.csv',\n",
@@ -74,12 +60,11 @@
     "             'https://info.endaq.com/hubfs/data/Calibration-Shake.csv',\n",
     "             'https://info.endaq.com/hubfs/data/Mining-Hammer.csv'] #largest dataset\n",
     "filename = filenames[4]"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -88,13 +73,8 @@
     "id": "MaNRqOKcbNsl",
     "outputId": "1b96883c-ba3d-49c3-d3e8-745a1700de73"
    },
-   "source": [
-    "filenames[4]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "application/vnd.google.colaboratory.intrinsic+json": {
        "type": "string"
@@ -103,9 +83,13 @@
        "'https://info.endaq.com/hubfs/data/Calibration-Shake.csv'"
       ]
      },
+     "execution_count": 87,
      "metadata": {},
-     "execution_count": 87
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "filenames[4]"
    ]
   },
   {
@@ -126,23 +110,27 @@
    },
    "source": [
     "Note that if running this locally you'll only need to install one time, then subsequent runs can just do the import. But colab and anaconda will contain all the libraries we'll need anyways so the install isn't necessary. Here is how the install would be done though:\n",
-    "~~~\n",
+    "\n",
+    "```\n",
     "!pip install pandas\n",
     "!pip install numpy\n",
     "!pip install matplotlib\n",
     "!pip install plotly\n",
     "!pip install scipy\n",
-    "~~~\n",
+    "```\n",
     "\n",
     "You can always check which libraries you have installed by doing:\n",
-    "~~~\n",
+    "\n",
+    "```\n",
     "!pip freeze\n",
-    "~~~\n",
+    "```\n",
+    "\n",
     "We do need to upgrade plotly though to work in Colab"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -150,20 +138,19 @@
     "id": "rKONh6lJYtF6",
     "outputId": "e0c78623-92a5-43e8-d0b7-22fddf826f09"
    },
-   "source": [
-    "!pip install --upgrade plotly"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Requirement already satisfied: plotly in /usr/local/lib/python3.7/dist-packages (5.3.1)\n",
       "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from plotly) (1.15.0)\n",
       "Requirement already satisfied: tenacity>=6.2.0 in /usr/local/lib/python3.7/dist-packages (from plotly) (8.0.1)\n"
      ]
     }
+   ],
+   "source": [
+    "!pip install --upgrade plotly"
    ]
   },
   {
@@ -177,9 +164,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "4s3mCpAZNAZq"
    },
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -187,9 +176,7 @@
     "import plotly.express as xp\n",
     "import plotly.io as pio; pio.renderers.default = \"iframe\"\n",
     "from scipy import signal"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -215,6 +202,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -223,15 +211,8 @@
     "id": "sXOwidDEOrS0",
     "outputId": "21e88975-7eac-4088-8c7f-24599ba1012a"
    },
-   "source": [
-    "df = pd.read_csv(filename) #load the data\n",
-    "df = df.set_index(df.columns[0]) #set the first column as the index\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -353,9 +334,15 @@
        "[138440 rows x 3 columns]"
       ]
      },
+     "execution_count": 91,
      "metadata": {},
-     "execution_count": 91
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = pd.read_csv(filename) #load the data\n",
+    "df = df.set_index(df.columns[0]) #set the first column as the index\n",
+    "df"
    ]
   },
   {
@@ -369,11 +356,11 @@
     "\n",
     "The peak will be applied after first finding the absolute value to ensure we don't ignore large negative values. \n",
     "\n",
-    "$$peak=max(\\left | a \\right |)$$\n",
+    "$$peak=\\max(\\left | a \\right |)$$\n",
     "\n",
     "Then the RMS is a simple square root of the mean of all the values squared. \n",
     "\n",
-    "$$rms = \\sqrt{(\\frac{1}{n})\\sum_{i=1}^{n}(a_{i})^{2}}$$\n",
+    "$$rms = \\sqrt{\\left(\\frac{1}{n}\\right)\\sum_{i=1}^{n}(a_{i})^{2}}$$\n",
     "\n",
     "The crest factor is equal to the peak divided by the RMS.\n",
     "$$crest = \\frac{peak}{rms}$$"
@@ -381,6 +368,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -389,22 +377,8 @@
     "id": "oxFZ6Oj0O2Pr",
     "outputId": "98837822-36b4-4ef3-c319-fe32e31956bc"
    },
-   "source": [
-    "abs_max = df.abs().max() #maximum of the absolute values, the peak\n",
-    "std = df.std() #standard deviation (equivalent to the AC coupled RMS value)\n",
-    "crest_factor = abs_max/std #crest factor (peak / RMS)\n",
-    "\n",
-    "stats = pd.concat([abs_max, #combine the stats into one table\n",
-    "                   std,\n",
-    "                   crest_factor],\n",
-    "                  axis=1)\n",
-    "stats.columns = ['Peak Acceleration (g)','RMS (g)','Crest Factor'] #set the headers of the table\n",
-    "stats"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -460,9 +434,22 @@
        " \"Z (2000g)\"               8.850233  2.687501      3.293109"
       ]
      },
+     "execution_count": 94,
      "metadata": {},
-     "execution_count": 94
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "abs_max = df.abs().max() #maximum of the absolute values, the peak\n",
+    "std = df.std() #standard deviation (equivalent to the AC coupled RMS value)\n",
+    "crest_factor = abs_max/std #crest factor (peak / RMS)\n",
+    "\n",
+    "stats = pd.concat([abs_max, #combine the stats into one table\n",
+    "                   std,\n",
+    "                   crest_factor],\n",
+    "                  axis=1)\n",
+    "stats.columns = ['Peak Acceleration (g)','RMS (g)','Crest Factor'] #set the headers of the table\n",
+    "stats"
    ]
   },
   {
@@ -481,6 +468,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -489,6 +477,20 @@
     "id": "K1ZUY6PNP7ab",
     "outputId": "d6aaccfa-76ad-4f05-9346-50ff67638ee3"
    },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydd1xW1f/A3x+GggiIogwxB7jD3FpqOUttmOubmqOlqZW/5lfLhg3NbNk3NcsWti0rsxxpSq7MlXskKg4EVJClDIHz++Ne8AEe4GE+gOf9ej2v594zP+fec+/nnvU5opRCo9FoNJrCcLC3ABqNRqOpHGiFodFoNBqb0ApDo9FoNDahFYZGo9FobEIrDI1Go9HYhFYYGo1Go7GJKqUwRCRcRPraW47CEJGVIjLOxrA+IrJBRBJF5O2ylq0AOWaIyJf2yr+0EZFQEXmomHELvBYi0lxEdpv3bErxpQQRUSISVJI0ygtLWUVkoYi8YB73FJEzZZz3vSLye1nmkU++xS6biDQyr5lTactVVlQphZEf1m5qWb8ARaSaiFwQkZq5z5VSA5RSITYmNQG4AHgopZ4qK3mvBXLfkzLkv8B6pZS7Uup/Nsj1rIjMKkmGxX35iIi/5bMhIqNEZIeIJIlIpPlx072o8iilJiqlXi1qPFuwVlal1FdKqVvLKL/WIvK7iMSKSJyI7BSRgWWRV0XnmlAYduJmYLdSKimfc1tpCBxUeoVlaVDce1BUGgIHihD+dmBFGclSGAOBVQAi8iQwF5gF+ADXAQuAQeUpkIg4lmd+NrAcWAP4AvWAKUCCXSWyF0qpKvMDwoGngb1APPAd4AYkA5lAkvkbBaQBV8zzPWb8UOB1YBtGhVgG1Db9XIAvgRggDtgO+BQgyzvAk9bOzXweMo/vAzYBbwEXgRPAANPvc1PGNFPOvkB1jIf6rPmbC1TPRwZP4BMgEogAXgMcC8vX9G8M/AkkYjws84AvLfy/B6LM67wBaG3hVwf4xbyG24BXgU0FXKtBwG4z/DGgv+nub6YTC4QB4y3izDBl+NKUcR/QDHgWOAecBm7N756Y9+BVYLMZ/3fA2/TrCZyxUrf6WuT9A0b9SgR2ATeYfuuADCDFvGfNMF7KB82wEcDTFul6mfJm3ZdnzPt1FngAUECQ6Xc78I95nU4DMyzSOWWGzarjNwKBpjwxGK3Ur4Baucr1IzDErCtJwPAC7lNn4C+M+h9p1olqFv6Wsn4OvGZ5PYHnTDnCgXst4n0OfIChNC9h1POilvU+LOoYcBPGMxpv/t9k4ZfvvbdSZm8zr1r5+GeV7SnzPkYC91v4F1SORmbaTub5UPPaXI/xMT8N43mIAZZgvovykWM8cMgsz0Ggvek+FaPOJQJHgD4Yz1WyZXpAO/PeOBf4ji2vl3l5/MyLvc28ILXNCzgR6y+AGVi8AC0qUoR5w9yApVlhgIcxvjRqAI5AB4xuIswb+2uutA4Dza2dk1dhXDFvuCMwCeNlIbkfPPP8FWArxpdOXWAL8Go+1+Mn4EOzLPXMa/Owjfn+hfGCrY7xZZ5IToXxAODOVQW228LvW7OCu5nXMoJ8FAbGSyge6Gc+JPWBFqbfBowvXBegLXAe6G1x/1KA2wAnYDGG0psOOJvlOpHfPTHvwTGMF7qreT7b8iVgpW5ZKowrwDAzr6fNvJ1z31/zPBLoYR57YT7M5vkI4BvzuD8QzdX69zU5X8I9gWDzOrUxw95t7eVjugWZ17U6Rl3ZAMy18HfGeEm4m3mnW8a3cq86AF3N690I4/l63MK/IIWRztX6dAuGYmhuETYe6GaWzaUYZb0Ps45hPPsXgTGmrCPN8zqF3XsrZRbgKPArcDe5PhItyvaKeT0HApcBr6LcM+B+jI+irOv3fxjPeYB5zT7ErCdWZByO8Yx1MuUNwmjlNsdQUv4W+QWax+vI+QH2JrCw0HdsebzIy+uH8VCPtjifAyykaApjtsV5K4yve0eMF+QWoI0NcgQCYQWch5JTYVj61TArkW/uB888PwYMtDi/DQi3IoMPkAq4WriNxOhbLzBfjK6IdMDNwv/r3NfLwq+WGdfTvFZXMF/6pv8s8lcYHwLvWnFvgPGl7m7h9jrwucX9W2PhdyfG12bWl7o7Fl+G+dyD5y3OJwOrzGNr9SWcnApjq4WfAzmVQvb9Nc9PYXxweFgp5xfAGPP401z1rxkWL2ErcedmXTusvESthL8b+MfivA/wh3l8LxBVxOftceAni/PCFIZlfVoCvGARdnEheRVYVnIqjDHAtlzx/wLuK+ze55N3AEZr6hhGT8UGoKlF2ZJzyXIO6FqEcjyN0SoIsAh3COhjce6H8Vzlub/AauD/rLgHmbL0JVfLAXgIWGceC4Ziubmwe14VxzCiLI4vA0Ud4DxtcXwS46vBG+PBXg18KyJnRWSOiDjnk8ZAYGUB5/nKrJS6bB7mJ7e/KZeljP5WwjU0ZY80B+riMF7O9WzI1x+4qJS6lCsfwOhjFpHZInJMRBIwXqZgXKe6GF9Mua9jfjTAeBBz4w/EKqUSc6VT3+I82uI4GbiglMqwOM8qD1i/ByWpK9nlU0plYnRLWLsPYHQ1DAROisifInIjgIg4YLQAVpnh/CnguolIFxFZLyLnRSQeo/XsnZ+A5gy7b0UkwrxPX+YKP5CrYycxgHdBg+Yi0kxEfhWRKDO9WQXlnwtr9cnyelmWu8hlzUXuZyQrP8u6Y/Xem7O7kszfcwBKqTNKqUeVUoEYz9UljBZtFjFKqfR80rOlHM8A85VSlhNzGgI/WTy7hzA+oHyslNfqM6SUCsNQ6jOAc2ZdyLrmS4EbRcQPowchE9hoJe0cVEWFYQ1loxsYFz+L6zC0+gWl1BWl1MtKqVYY/aN3AGPzScPyQbR2XhLOYlQmSxnPWgl3GqOF4a2UqmX+PJRSrW3IIxLwEhG3XPlkMQpj3KEvRquikekuGN1G6eS9jvlxGuPrPzdngdoi4p4rnQgb5LdGUe7BJYwWF5A9CFs3V5gGFv4OGF+h1u4DSqntSqlBGMr6Z4yvazC6EE4qpc6b55EUfN2+xhjTaaCU8sRoPUtWNlaynmW6ByulPIDRFuEh5zX5C6O+3G2tDCYfYHTrNTXTey5XegVhrT5ZXq/c8he1rJbkfkay8iu07ihjdldN85dn5ppS6jQwH6Pb0BYKKkcWtwLPi8hQC7fTGGOKtSx+Lkopa2XI7xlCKfW1Uqo7xvVQwBum+0WMsZt7MJ7nb5XZ3CiIa0VhRAN1RMQzl1sj82G3ZLSItBKRGhj9kj8opTJEpJeIBJsvjwQMRZKZOyMzXmdgvbXzUuAbjMpVV0S8gRcxvhxzoJSKxKgQb4uIh4g4iEigiNxSWAZKqZPADuBlcypqd4wunyzcMV4uMRgv1lkWcTMwBlJniEgNEWkFjCsgu0+A+0WkjyljfRFpYT6YW4DXRcRFRNoAD1ora2EU4x78C7iIyO1mK/J5jH5kSzqIyBDzi/xxjOux1Ure1cw1Ap5KqSsYdSer3gwEfrMIvgS4z6L+vZQrOXeMVleKiHTGeNCzOG+m2yRX+CQgXkTqY3zJZsnVGGOyxCEApVQ8Rl2aLyJ3m/fOWUQGiMgci/QSgCQRaYEx7lUUsupTD4wPru8LCFvUslqyAmhmThF2EpF7MLqXfy2ivIiIl4i8LCJBZv30xuieznOvi1GOLA5gjCHNF5G7TLeFwEwRaWjKUVdE8put9jHwtIh0EIMgEWkoxnqg3iJSHWO8L2vyTxZfY3z0DjOPC+WaUBhKqcMYL9rjZhPPn6uVNUZEdlkE/wKjTzUKY/Ata+GVL8bMmASM5uGfZlhE5DkRyeru6A38pZRKyee8pLyG8TLfizEzaJfplrV4yXI651igGkb/6EVTfj8b8xkFdMGYofQSOZvgizGa+BFm2rkfnkcxmuRRGNfyM0tPETkgIvcCKKW2YQz4vYsx8PknV78OR2K0Xs5iDOC/pJRaa6P8lhTpHpgvz8kYD2IERosj9+KsZRhfZ1mDq0NMhWCNMUC42Y0zEWO8AHJNp1VKrcTo416HMQC6Llc6k4FXRCQR4+W+xCLuZWAmsNms412Bl4H2GNf1NwxFnkWeqbxKqbeBJzEU5HmML9dHMVpFYPS1j8KYALEIY5aYrURhXKuzGLO1JprPZX4UtayW5YjBUEhPYXzU/Be4Qyl1oQjyZpGGUQfXYjz7+zE+Du6zMX6+5cgl8x5T5kUiMgB4D6Nl8rsZdyvG8wiA2WXWw4z7Pcb1+Brj3vyMMfBfHZiNMbEhCqOF+6xFtr8ATTHGrvbYUhixoRVyzSAioRgDux+XII0FwH6l1AJr59ciInIfxiBwkReAlVL+Fe4eiIgPxnTL+rZ0BZRB/iuAeUope63/0FRCKs2S9ErEbozpt/mda8qfingPPIGn7KEsTEIpvW5SzTWCVhiljFLqo4LONeVPRbwHSql/McZK7JX/nMJDaTQ50V1SGo1Go7GJa2LQW6PRaDQlp0p2SXl7e6tGjRoVK+6lS5dwc3MrPGAlRJetcqLLVjmpbGXbuXPnBaVU7vVGOaiSCqNRo0bs2LGjWHFDQ0Pp2bNn6QpUQdBlq5zoslVOKlvZRKQgiwyA7pLSaDQajY1ohaHRaDQam9AKQ6PRaDQ2USXHMDQaTcXlypUrnDlzhpSUFDw9PTl06JC9RSoTKmrZXFxcCAgIwNk5P2Pb+aMVhkajKVfOnDmDu7s7jRo1IikpCXd398IjVUISExMrXNmUUsTExHDmzBkaN25c5Pi6S0qj0ZQrKSkp1KlTBxFbLaNrSgsRoU6dOqSkFM8WqlYYGo2m3NHKwn6U5NprhaG5JlFKsSxsGSnppWV1XqOp+miFoakSJGQkMP738VxMuWhT+M1nN/P85ueZu2tuGUumqchkWYTI+t+xYwetW7cmLS0NgGPHjtGkSRMSEhLyxI2MjOSOO+4AYM2aNXTo0IHg4GA6dOjAunVXtzLZuXMnwcHBBAUFMWXKlKw9tYmNjaVfv340bdqUfv36cfGiUXeVUkyZMoWgoCDatGnDrl278uSdmxEjRnD06NF8y1VaaIWhqRKEJoSyNXIrS48uLTDcheQLHI49TFJaUvY5QHBIMBN+n1DmcmoqNh07duSWW27hrbfeAuCRRx5h5syZeHh45An7zjvvMH78eAC8vb1Zvnw5+/btIyQkhDFjxmSHmzRpEosWLeLo0aMcPXqUVauMLdxnz55Nnz59OHr0KH369GH27NkArFy5MjvsRx99xKRJhW9sOGnSJObMKXsDxFphaErMxjMb+eXYL/YWwypLjizhvV3v8XOYsWlcryW9GL58eLb/6vDV2cd/Rf7FvvP7yl1Gjf2oW7dujn+AWbNmsWjRIubMmUN6ejojR460Gnfp0qX0798fgHbt2uHv7w9A69atSU5OJjU1lcjISBISEujatSsiwtixY/n5Z6MuLlu2jHHjjN2Lx40bl8N97NixiAhdu3YlLi6OyMhIMjMzmTx5Mi1atKBfv34MHDiQH374AYAePXqwdu1a0tPT8y1XaaCn1WpKzOQ/JgMwfdN0/hnzD04OeauVUopF+xYxpOkQvF29i5T+lHVT2Byxmd+G/Iavmy8AC3YvIORACH/f+3eOsMfjjpOcnkxsSiz1a9bn1a2vZvvdHXR39nFyenL28ZaILdnHo1aM4osBX9C2XtsiyagpHm/8foyjF5ILD1gEWvl78NKdrW0Ku3379hz/ALVq1WLatGlMnjyZgwcPWo134sQJvLy8qF4991bvhiJp37491atXJzw8nICAgGy/gIAAIiIiAIiOjsbPz9gx2dfXl+joaAAiIiJo0KBBnjibN28mPDycgwcPcu7cOVq2bMkDDzwAgIODA0FBQezZs4cOHTpYLVdpoFsYmhJxPP54jvOsQeTYlFi+Pfxttvu+C/t4/5/3uefXewgOCSY8PpwNZzbk+aKfs30O438fn8Nt/en1pGWm0e+HfgBEX4rmgz0fcDn9MsEhwXx3+DvWJKwBYPnx5XT+qjP9l/bnvlX35UjHUjEoru4D8/Dah3OEG7NyDLEpsUW5DJoqxsqVK/Hx8clXYURGRlr9ej9w4ABTp07lww8/LFJ+IlLo7KVNmzYxfPhwHBwc8PX1pVevXjn869Wrx9mzZ4uUb1HRLQxNsbiQfIFeS3rlcb/xmxt54PoH+HT/pwB08OlAU6+m3LviXgDOXT4HQMjBEH7412hO7xq9i+mbp1PDqUb2GMSmiE341/Rn2oZpOdL/O/JvHvr9oRxur/39mlUZd0bvzHFuqRhe2vJSgeXbFrWNJUeWsD3K+EL74c4faF67eYFxNEVn6q2BFW5x26+//kp8fDyrV69m8ODB3HbbbdSoUSNHGFdX1zxrGc6cOcPgwYNZvHgxgYGBJCYmUr9+fc6cOZMjTP369QHw8fEhMjISPz8/IiMjqVevHgD169fn9OnTVuMUREpKCq6ursUuty3YrYUhIs1FZLfFL0FEHs8VpqeIxFuEedFe8mquciXzCuNWjsvXP0tZAAz5ZQi/Hv81T5gsZQHQ/sv2rDyxMseA9aS1kxj08yAOxeY0rZBbWZQVz/z5TLayAHhtq3WlpKlaJCcn8+STTzJ//nyCg4MZNGgQM2fOzBOuWbNmhIeHZ5/HxcVx++23M3v2bLp165bt7ufnh4eHB1u3bkUpxeLFixk0aBAAd911FyEhIQCEhITkcF+8eDFKKbZu3Yqnpyd+fn5069aNpUuXkpmZSXR0NKGhoTlk+vfff7n++utL+YrkxG4KQyl1RCnVVinVFugAXAZ+shJ0Y1Y4pdQr5Sulxhof7vmQU4mnbA7/7MZny1Ca8uFY3DF7i6ApB1599VUGDx5Mq1atAJgxYwbffPNNjimrAG5ubgQGBhIWFgbAvHnzCAsL45VXXqFt27a0bduW8+fPA7BgwQIeeughgoKCCAwMZMCAAQBMmzaNNWvW0LRpU9auXcu0aUZreuDAgTRp0oSgoCDGjx/PggULABg6dCgBAQG0atWK0aNH0759ezw9PQFjPMTV1RVfX98yvT4VpUuqD3BMKVXoBh4a+5PVrXQtkXglkfjUeDyre9pbFE0ZMmvWrBzn7u7uHD9+3GrYRx99lM8//5zXXnuN559/nueffz6Hf2JiImBM1d2/f3+e+HXq1OGPP/7I4y4izJ8/P4+7g4MDb731FjVr1iQmJobOnTsTHBwMwNdff83DDz+cJ05pU1EUxgjgm3z8bhSRPcBZ4Gml1AFrgURkAjABjL7B3M01W0lKSip23IpOaZVt/Zn1JRemEjJs6TCm+08v93yrWp309PTMfplmZGRkH1c2+vbtS0RERL7yl0XZBg4cSHx8PGlpaTzzzDO4ubmRmJiIi4sLQ4YMsTm/lJSUYtUpyVp1aC9EpBqGMmitlIrO5ecBZCqlkkRkIPCeUqppYWl27NhR6S1a81JaZQsOCS65MJWUfePKf51GVauThw4domXLlkDFtOhaWlTkslnegyxEZKdSqmNB8SrCtNoBwK7cygJAKZWglEoyj1cAziJStEn8Go1GoykVKoLCGEk+3VEi4ivm5GQR6Ywhb0w5yqbRaDQaE7uOYYiIG9APeNjCbSKAUmohMAyYJCLpQDIwQtm7D02j0WiuUeyqMJRSl4A6udwWWhzPA+aVt1wajUajyUtF6JLSaDQau2BpBjwlJYUWLVqwb9/ViQ1vvvmm1emqycnJ3HLLLWRkZLB7925uvPFGWrduTZs2bfjuu++yw504cYIuXboQFBTEPffck202PTU1lXvuuYegoCC6dOmSYxHg66+/TlBQEM2bN2f16tW5s87D008/ncOces+ePQkPDy910+agFYZGo9EA4OLiwty5c5k8eTJKKSIiIli4cGG22XFLPv30U4YMGYKjoyM1atRg8eLFHDhwgFWrVvH4448TFxcHwNSpU3niiScICwvDy8uLTz75BIBPPvkELy8vwsLCeOKJJ5g6dSoABw8e5Ntvv81Oa/LkyWRkZBQo92OPPWZVxrJAKwyNRnPNktsMeP/+/fHz82Px4sU88cQTzJgxAy8vrzzxvvrqq2xTHs2aNaNpU2O2v7+/P/Xq1eP8+fMopVi3bh3Dhg0D8powzzJtPmzYMP744w9jF8hlyxgxYgTVq1encePGBAUFsW3bNsBYhd68eXO6d+/OyJEjs/fsaNiwITExMURFRQFQu3ZtHB0dS920OVSchXsajeYapPr6lyDmSOkm6hsMA2z74rZmBnzu3Ll07tyZpk2b5tgIKYu0tDSOHz9utctn27ZtpKWlERgYyKlTp6hVqxZOTsZr1tK0uaUJcycnJzw9PYmJiSEiIoKuXbtmp5cVZ/v27SxdupQ9e/Zw5coV2rdvT4cOHbLDtW/fns2bNzN06FB+/PHHPGUqLbTC0BSJvef32lsEjaZM8ff3p3fv3tnbr+bmwoUL1KpVK497ZGQkY8aMISQkBAeH0u282bx5M4MGDcLFxQUXFxfuvPPOHP7lYdoctMLQFJEsM+XXKtqeVOmS2utlqlXA1dAODg75vvStmTZPSEjg9ttvZ+bMmdkthNq1axMXF0d6ejpOTk45zJRnmTAPCAggPT2d+Ph46tSpk69pc0sT6dYoD9PmoMcwNJoiEX05j0ECzTWGl5cXGRkZ2UojLS2NwYMHM3bs2OzxCjCMCPbq1St7G9XcJsyzTJv/8MMP9O7dGxHhrrvu4ttvvyU1NZUTJ05w9OhROnfuTLdu3Vi+fDkpKSkkJSXx6685twwoD9PmoFsYGo1GU2RuvfVWNm3aRN++fVmyZAkbNmwgJiaGzz//HIDPP/+cwMBA3njjDUaMGMHzzz9Pu3btePDBBwF48MEHGTNmDEFBQdSuXZtvvzV2p2zdujX/+c9/aNWqFU5OTsyfPx9HR0c6derEXXfdRZs2bfDx8SE4ODjbtPmVK1cICwujY8cCzUCVClphaDQaTS6yXvz58cgjj/Duu+/St29fRo8ezejRo/OESUxMpEmTJtmznCxxcXHh+++/t5r29OnTmT49r1Xkp59+mhkzZnD58mVuvvnm7EHvX3/9lWHDhmUPrpclWmFoNBpNEWnfvj29evUiIyMDR0fHcslzwoQJHDx4kJSUFMaNG0f79u0BSE9P56mnnioXGbTC0GiKwKmEUzTzamZvMTQVgAceeKBc8/v666+tug8fPrzcZNCD3hpNEXgi9Al7i6DR2A2tMDQajUZjE1phaDQajcYmtMLQaDQajU1ohaHRaK5ZLM2bA8yfP5+2bdtm/66//npEhEOHDuWJGxkZmW0+ZM2aNXTo0IHg4GA6dOiQw9z4zp07CQ4OJigoiClTppC1B1xsbCz9+vWjadOm9OvXj4sXLwKglGLKlCkEBQXRpk0bdu3aVWg5RowYwdGjR/MtV2mhFYZGo9GYPPLII+zevTv7d9ddd3HvvffSsmXLPGHfeecdxo8fD4C3tzfLly9n3759hISE5DBaOGnSJBYtWsTRo0c5evQoq1atAmD27Nn06dOHo0eP0qdPn2wT5StXrswO+9FHHzFp0qRC5Z40aRJz5swpjUtQIFphaDSaa5bc5s0t2bBhA0uWLGHBggVW4y5dupT+/fsD0K5dO/z9/QFjtXZycjKpqalERkaSkJBA165dERHGjh1r1cR5btPnY8eORUTo2rUrcXFxREZGkpmZyeTJk2nRogX9+vVj4MCB2WZHevTowdq1a0lPTy+0XCVBr8PQaDR2Y+6euRxPOl6qabao3YKpnafaFNaaeXOAuLg47rvvPr744gs8PDzyxDtx4gReXl5Ur149j9/SpUtp37491atXJzw8nICAgGw/SxPn0dHR+Pn5AeDr60t0tGGnzNL0uWWczZs3Ex4ezsGDBzl37hwtW7bMXgvi4OBAUFAQe/bsoUOHDvmWq6ToFobGZq5kXrG3CBpNuTBx4kTGjBlDt27drPpHRkZa/Xo/cOAAU6dO5cMPPyxSfiKCiBQYZtOmTQwfPhwHBwd8fX3p1atXDv/yMHFu9xaGiIQDiUAGkK6U6pjLX4D3gIHAZeA+pVTho0CaUuez/Z/ZW4QKQXpmOk4Odn90qgSP3/A47hXMvHlISAgnT57kyy+/zDeMNRPnZ86cYfDgwSxevJjAwEASExPzmCa3NHHu4+NDZGQkfn5+REZGUq9ePYB8TZwXRnmYOK8oLYxeSqm2uZWFyQCgqfmbAHxQrpJpsrmQfMHeIlQIfg//3d4iaMqI48eP89xzz/HVV18VaMyvWbNmhIeHZ5/HxcVx++23M3v27BytEj8/Pzw8PNi6dStKKRYvXmzVxHlu0+eLFy9GKcXWrVvx9PTEz8+Pbt26sXTpUjIzM4mOjiY0NDSHTOVh4ryiKIyCGAQsVgZbgVoi4mdvoa5Fvjn8jb1FqBDorrmqyxtvvMHly5cZMmRIjum1GzduzBHOzc2NwMBAwsLCAJg3bx5hYWG88sor2XHOnz8PwIIFC3jooYcICgoiMDCQAQMGADBt2jTWrFlD06ZNWbt2LdOmTQNg4MCBNGnShKCgIMaPH5896D506FACAgJo1aoVo0ePpn379tkmzqOjo3F1dcXX17dMr49kzQm2FyJyArgIKOBDpdRHufx/BWYrpTaZ538AU5VSO3KFm4DRAsHHx6dDln35opKUlETNmjWLFbeiU9KyPXbysVKUpnLzfsP3yy2vqlYnPT09CQoKAihXa6+lzfLly/nnn3948cUXrfqXRdmy6kJMTAy9evVizZo1+Pj4MG/ePDw8PBg7dqxN6YSFhREfH5/DrVevXjvz6eXJpiJ0xHZXSkWISD1gjYgcVkptKGoipqL5CKBjx46qZ8+exRImNDSU4sat6JS4bCGlJkqlpzzrSFWrk4cOHcoet0hMTKxwYxi2MmrUKC5fvpyv/GVRtjvvvJO4uDjS0tJ46aWXshWvr68vY8aMsXlPDBcXF9q1a1fk/O2uMJRSEeb/ORH5CegMWCqMCKCBxXmA6abRaDR25aGHHirX/HKPW2Rx//33l0v+dh3DEBE3EXHPOgZuBfbnCvYLMFYMugLxSqnIchZVo9GUIvbuCr+WKcm1t3cLwwf4yZx/7LaLkJEAACAASURBVAR8rZRaJSITAZRSC4EVGFNqwzCm1ZaPKtXk4Pzl8/YWQVNFcHFxISYmhjp16thblGsOpRQxMTG4uLgUK75dFYZS6jhwgxX3hRbHCnikPOXS5KX3973tLYKmihAQEMCZM2c4f/48KSkpxX55VXQqatlcXFxyrD4vCvZuYWg0lZKEtAQ8quU1GaEpHGdnZxo3bgwYffLFGXytDFTFslWGdRgaTYVjy9kt9hZBoyl3tMLQaIrBM38+Y28RNJpyRysMjUaj0diEVhgajUajsQmtMDSaYpKQlmBvETSackUrDE2h6EVW1rl85bK9RajSZKpMktOTyz3PcSvH8efpP8s138qCVhiaQtkeVbq7dlUVIi9pgwOlxeUrl/O8pGdvm03nrzqTnpleYNzDsYcJjw8vUf77zu8jIimClPQUdp3bxTMbCp7UsCt6F9GXokuUZ2VEKwxNoeh9MKwzdqVtlkE1MHHNRO76+S5mbJlh1Tz8a1tf49F1j3L04tFst6X/LgUgLC6M1/9+nZjkGF7Y/AIp6Tk3Lhq+fDh3/nwnC/cspCAyMjMIDglmxpYZBIcEE3YxLNtv1IpR9F/an9DTofnGPxx7mOXHlgMwbtU4Bi8bbDXclYwrdP6qM7/HV719U/TCPU2hHIs/Zm8RNJWczWc3A3Ai/gRLjy7NdnfEkWcPP8veC3sBQzkE1Qri+3+/Jy0zDYDH1j1G1KUovj78NQA/h/3MKze9AkB1x6t7as/fPZ/5u+cD8ObNb3JzwM08u/FZ1p1eB8D7vQ2T9Fn5D/4l7wt/6kZjL/Dk9GSWHFlCeEI4Q4KG5Ah7Z+CdACReSeRUwin2XtjLsxufZeINE1m4ZyGTb5hMcnoyy+OWM4tZJbpuFQ2774dRFnTs2FHt2LGj8IBWqGqmpC0pbtmCQ4JLX5gqwr5x+8o8j6pQJ6tSHdo3bp/N5SmP+lFaiEih+2HoLimNRlOmVLWP0qqk/IqKVhiaAqlqD3tps+bkGnuLUOHJ6krSVH60wtAUyIYzRd788Jpi34XK0+VgL2Zvm21vETSlhFYYmgL5/MDn9hZBo9FUELTC0BTIjujiTR64VohPjbe3CBpNuaEVhkZTAlIzUu0tQoXm430f21sEu7L73G57i1CqaIWh0WjKjPd2vWdvEezKq1tftbcIpUqBC/dExAW4A+gB+APJwH7gN6XUgbIXT6PRaCov/178194ilCr5tjBE5GVgM3Aj8DfwIbAESAdmi8gaEWlTLlJqNBUUbaROUxhHYo/YW4RSo6AWxjal1Ev5+L0jIvWA64qbsYg0ABYDPoACPlJKvZcrTE9gGXDCdPpRKfVKcfPUFI3TCaftLUKFJ+lKkr1F0FRwjlw8QvPaze0tRqmQr8JQSv1WUESl1DngXAnyTgeeUkrtEhF3YKeIrFFKHcwVbqNS6o4S5KMpJs9vft7eIlQKTiacpKFHQ3uLoamgVKXFr4UaHxSR5RgtAEvigR3Ah0qplLyxCkcpFQlEmseJInIIqA/kVhgaO5CpMtl1bpe9xagU3PHTHZXKZpBGU1xssVZ7HKgLfGOe3wMkAs2ARcCYkgohIo2AdhhjJbm5UUT2AGeBp/MbbBeRCcAEAB8fH0JDQ4slS1JSUrHjVnSKUrY9l/eUrTBVjLKsM5W1Th5L0VaOAV7c/CKeZzztLUapUKi1WhHZrpTqZM1NRA4opVqXSACRmsCfwEyl1I+5/DyATKVUkogMBN5TSjUtLE1trdY6RSnbtWxgrTiUZQujstbJ/kv7E5EUYW8xKgSVoQVaWtZqa4pI9uC2eVzTPE0rgXyIiDOwFPgqt7IAUEolKKWSzOMVgLOIeJckT42mLPhwz4f2FqHCoZXFVYJDgjmZcNLeYpQYWxTGU8AmEVkvIqHARuBpEXEDQoqbsYgI8AlwSCn1Tj5hfM1wiEhnU96Y4uap0ZQV83bPs7cImgrOFwe/sLcIJabQMQyl1AoRaQq0MJ2OWAx0zy1B3t0wxj/2iUjW+vnnMKfqKqUWAsOASSKSjrFocISqSlMONJoqyrW433VhfHfkO6Z3mY75DVwpyVdhiEh3pdQmAKVUKrAnl78HcJ1San9xMjbTLvDKKaXmAfrTTaOpZExcO9HeIlRIktOTqeFcw95iFJuCuqSGisgWEXlRRG4Xkc4icrOIPCAiXwC/Aq7lJKdGU+EZ+stQEtIS7C2G3UlOTyYsLszeYlRIKnPrAgpQGEqpJzDsSEUCw4FXgSeBphjrL25WSm0vFyk15crRi0ftLUKl5N+L//Lm9jftLYbdeWL9E/YWocJyIfmCvUUoEQWOYSilYjHWWiwqH3E09uZI7BGGLR9mbzEqLWeTztpbBLuz+exme4tQYdkUsYmRLUbaW4xio82ba3KglUXJ2Ba1zd4iaCows/6eZW8RSoQtK701VZy95/dSv2Z9DsRoi/UajSZ/tMKobCRGwYa3oP9scCyd23fvintLJR3NtY1SStsfs4GQAyGMaTUGB6l8HTw2SSwiN4nIKBEZm/Ura8E01jn/zUTYvoi4fatKnNa6U+u0CZAyIDgkmG2R117X1I9Hf+S+VffZW4wKz1s73qq0i/gKVRjmFNq3gO5AJ/NXoL2RaxWlFB+EHiPucoksphRIZKyx/8LJ2MslTuu7I9+VOA2Ndd7ZadV4QZVlw5kNzPhrhr3FqDTsu1DxbUtZw5YWRkegm1JqslLqMfM3pawFszcZieeITUoF4FJqOslpGdl+yWkZXE5LzxNnx4EjjFh/Mx9881O+6cYkpaKU4lTkOVIuJxqOv0zhgyV3MXntZBskMxa6l2Q+d0xyDKQm4nB8Y7HT0BTMtTYe9Mgfj9hbhErF6vDV9hahWNiiMPYDvmUtSIUiah8Obzdl1uxpxF5Ko/VLq2n5otkFlJ7KC69Mp9WLebuE6u96By9J4pZY61/uJy5cYvbrz7Pis5lc92FTkt8wra3sCmFB8gk2Rlh5gV9JgUxDWWVkZpCmMgFITbduIWXfmXg2/xvF6j3WDZ1tjdxKzyU9Wf/PIrZVq3x9qJqKR1pG2bWoqzIp6cXaSsiu2PLG8AYOishqEfkl61fWgtmVc4f5xNOD1U3X8sXWf+jhsJfXnD7hp3/O8Pdnz/CW0wfc6rCDK5lXGLp0Ak1e+oSUKxn4H89SFDm//sPOJfL8xz/h/3Eb3nT+iNtPGYu7vCSJ5f+E5wj725fvsWx3BD/uOsOPSz6DmT6w9CEAntv0HPf7Gwt/Fm3KGS+LO+dtIva721m8tR93fNyTL/8JJTgkmNBPjW1L9oevB+CffxaR5lC5V51WdLZGbi1WvJT0FB774zFOJZyyLcK612CPlY+U9a/D7m/yulthQWgYX/9tY365mPePtt5THDp91YnQ06FW/fZHxBN+4VL5CmQDtkyzmVHWQlQUoi5F8djJxxhwtBsra9cCYPnG1ayt9jYAvZasYqHzH+AA9zuu5lDMEP5N+ov6/gfYcuwOarpUp0NKKplKsfGNIfRI/gNmxNP3nQ184fwW1R2vrvL8wsOdAZcu8dzeOzlo5gXQ99iLdI/ZwqC0cJo7nOaDWh54nfqdqO/vZsXlqxvSuF2JRSnF6gNR+Hm68vyOMSSmJQLPsLRuAntdXIAY3tj7GACPOe7mfeDXf06CG3xWQ0+QK2vG/z4+7z4I5w6DyoSMNPBvazXe1sithJ4J5VJcFJ8OWVJgHsEhwXRJTuHjqHPw0wTUC7EsOfgnvRvdRN0/ZxuB2ha+UGzOqiMAjOpyXSEh8/LZgc+KHEdj8Ni6x9g1Zhe7TyUSXN8TF2dHAO5/fzleksTvr+e0yRV2MYyfwn7i6Y5PIyJkpCaxY/nDdBnwP3CrU+by2mKt9k8R8cEY7AbYZu7nXeU4HnccgJXVrq5UvVEO0fW6AC45ONDz339p6BjBG161ePTiIaabX/neDhd4ZeeDxPj5ALDp5Ho8M42uo92n4wBQZqtDAU/V82aNWw3m1PEC4EtPj+z8Rvj7klLtIMb3okUFuJxz97Jx7p/QZrGx7brTsQmkBxqy1ONivuVTSnHa4V+br4em5ASHBDOyxUimdprK4b/exmP9G7hnZlIrMxNmxFuN4xB3GgCXc//A/9qS2Pxp3vt+MI8N+hKHam55wv/t6pJ9/P2/S3ht1yym/zKSLGtOX2w9yZiu5p7jG9+B5gOgXktIiYekc0Q6OeFb93uizuddtJmekcmc1Ud4+OYm1KlZHYCYY7u46dNDUGczmx5+pQRXRwPw0YZjLDw5nCuJrXA8dz/+tVzZXH0K1SQDsFAYe79n4vYXiXZyYmyDfvj4tuXz9f9l7qW9fLDqMbrf+F/wDQYHxzKT1ZY9vf8DvAmEYvS1vC8izyilfigzqezEm6sPQ65r7VLzEJccjJ67nddtoZNLA8B4yV858y3OHhBWrRqkXx0z6N4wgM8io+mYksqFA38y2fE3PGocIdj/Oj6IOscat/ytVYZVq1aonMGNr6PfpauzpNIDP8o+nlJvGm+4elmN9++esaR51bLqpyk7vjn8Dcm7V/KzSxw08KdWRgYbT0UQEvoXb52cwEsXYhiWeImw0ZupvmosF1OioG4dNtZwZc6VOL6IngNA+3eb0M01AIfYMH6qeTtud7ycnccYPx++iIzmVOxhAJydY/gXZ4YG+MGRO1j1y71cavwZHVJSGfPnTDLHLqPJL0+iLhxhWOPGXPLO4I6UVCLWhFO/36MApFzJoOWrX6DSvDkRe46tGY8ywfc2+uz8nIYNGxBZPZ3eP/Qq/wtaxVh4cjgAzu4Hwf0ZooDJNeowMS4e9/DjNKzfkP0R8QSGziPa03hl9109hm/6buJkqrE90N6z2+n+0S1w83+h9/Qyk9WWLVr3AP2yWhUiUhdYq5S6ocykKiHF3aI18NV3qXHdpzncfNPTiXIqfvfNB1Hn8MzI5HuPmvzkXrPwCJprgoVR53imrjeJjsbHSIfkFHZatBTyY9mZs4zx8yHBMe9XZKfkFE47O9lcXz8/G819/j453ByUoq3jEF7ociszN+1lh+MHNE1LwzvVlb/cM/JJSVOW1M1oTK2MIzwbc5EH/K7eL7eEQBpVP8iB6kbLb98Jcwwqn5ZrYdiyRastCmOfUirY4twB2GPpVtEorsJ4fVYfvq5fJXvbNBpNFWdRZDSdUlJxLEOFYcunyCoRWQ1kTbe4B1hRLIkqOFpZaDSaysp4Px/cMzLZUoZ52DLo/YyIDMXYUhXgI6VU/ivTNBqNRmMXsro4ywqbOjuVUkuBpWUqiUaj0WgqNAXt6b1JKdVdRBLJskdhegFKKeWRT1SNRqPRVEEK2qK1u/nvrpTysPi5l5ayEJH+InJERMJEZJoV/+oi8p3p/7eINCqNfDUajUZTdGy1VluoW1EREUdgPjAAaAWMFJFWuYI9CFxUSgUB7wJvlDRfjUaj0RQPW0ZIWlueiIgT0KEU8u4MhCmljiul0oBvgUG5wgwCQszjH4A+UhIzrRqNRqMpNgWNYTwLPAe4ikhCljOQBnyUX7wiUB84bXF+BuiSXxilVLqIxGPYy7iQKxwiMgGYAODj40NoaGgpiKjRaDSVi7J89+WrMJRSrwOvi8jrSqlny0yCUkIp9RGmIuvYsaPq2bNn0RMJKTyIRqPRVGSK9e6zEVvWYTwrIl5AU8DFwn1DCfOOABpYnAeYbtbCnDG7wjyBmBLmq9FoNJpiYIvxwYeA/8N4oe8GugJ/Ab1LmPd2oKmINMZQDCOAUbnC/AKMM/MbBqxThdky0Wg0Gk2ZYMug9/9hmDY/qZTqBbQD4kqasVIqHXgUWA0cApYopQ6IyCsicpcZ7BOgjoiEAU8CeabeajQajaZ8sGWld4pSKkVEEJHqSqnDItK8NDJXSq0gl10qpdSLFscpwPDSyEuj0Wg0JcOWFsYZEakF/AysEZFlgPUNozUaTYXiliS937am9ChUYSilBiul4pRSM4AXMLqJ7i5rwTSaqsRXZ6PKPc89J06x84r1bWA1FY8uySn2FqFQClQYIuIoIoezzpVSfyqlfjEX2lU5toWf5rPI6ALDzI0+X07SFMzI+ER7i6ApAm1S02iVmmrV77awnvzPrFeZabVz+PW8dJmOuV4k7hmZ/F+sMYzonGsOyCeR0YyLT7BwsX2da7fLyVbdv40of2V3LZIJZKT4UC1Tse/EKR65WOKh4lKnQIWhlMoAjohI0XeGr4QsqDaZjik5H+oH4nJuRlI7w/quY5ZbppY2K09H5HoJwH9jr+7d/fnZq0pu14lT3JBi/cWkKX+6JKfwcWQ0+9y6EpzkajXMpQwvel1O5uGjN3Dp2DPsPXGKm82X9y2JznRKvpInzoPxCew5cYrhR2/K4d45JZUJMak8eLQDL1x5gJ41+9r05eqamckH0edZdiyVvVk7twEvXIildVqV/D6scPyV2ZLLJx5nx0ljPfPDcQk57kUW7kcn8sepCDonp/DnyTNMvBjPCxdiy0VGW8YwvIADIvKHiPyS9StrwezBU1Nf43CtW3K43R+fyE3mw/vq+Rh8cimM96POMz4unnfO5Vl8Xir8fiKWgPQMno69+rXxd/hpnDC25Hw7+jxemVdlcgbez9UKap6qH3h78VHUObqkpNLSz5NeLf+bx18pYWVmZ9Y2fYH/pQ8DBAFuNF/ytYd9z9tJjwPQPsVwc0Aht73Onnavce+Tc7PTmhd1jgwleLxwksdf+5yZM9/l9RF38XHUOXo6Xt3LvXFaXgX065lIBJh65WEE2HTyDG+eu8CtDx3MEc4r0Y+0CD0PpSxo5utG1v0Ho20owA8RkQxIusTf4acZFXUHZ9MbUS8jg0+izlE7M5NH4uL5T2IS805lwMl7y1RGWxTGC8AdwCvA2xa/qoeDA1Ftn2TjPRvpY7YYamVmZt9A74wM/NMzWH/qTHaUnsnJTLlotEKyvuQet/j6Ly57T5xi34lT1H5kI9RqaMiSWgOAaamTAfg06hxr4sfgkZmZHe+C8mBlWk+6O3plu02LvYh7RiZtdMujXJkbfT77AXNycafbgHtpXauZ4XBoOolHXibpyAxAaNp/EuJk7M18LNOPe29+lXXD19E7MJi3O7VhpVdfhkXVB8xOphsn027QY1xXp0Z2fusT/kOz1MVgpgNAzXrw9FHeuWcNK+5axt/hp1liZTylnvkhtF214IG0p/HMzKT/pcvU8vTMEa5fm8F8OepR1g1fx7o+n9BMf4yUiM7JKdS+5A2Ah4sT6566hYiA27P9l2XcRPO0K8w5H0MNpcjAzWo64Zk+jLv0Ju/f80CZymvLSu8/RaQh0FQptVZEagB5d6CvQtRyqcVcixZDVj/xX6odjdRRAjKstCYGvsXsVf/lF3c37o9PZG5tr7xhcnElIRhnj3053C6deASf6mEIiwCoXrcJTNoMaZc4PWsL4pjCb5k1+V9PT2h2G2/63UDXZ4NZcfpx/NIzeDZ9As8+N5PTfz3Npoj1AHRMSaXbsYH06dSILWfe4if3msW9NJoi0ODGJ6DlEDj4M3R6CIDPbv+S+NR4PJ3r8uGGY7Tw9cDD1YmGddw48toAGk37jXtd5rO1Yx/qmunUcnEgoP+71Lg1Fr67Jd/8Rj42i1anrfR716yHM9DAqwnc/SHUbQ5rxgBw+fRYejYNoHmKC14kMveetvx1rAHsf8tqHo28a9KpkTnO4upNdY8ASNVbGxeHx2Mv8mB8Ij8O/4yXdkwik0ya1K0JD30NGem88+LDfJwxkEEv/wpfDoXj6+na83Y+/ulsnrRSqMaU3kH0bF6vTGW2ZaX3eAyjfrWBQAyDgAuBPmUqWQXipZhYmly5QvfbQoiv04DxH3wPfJAzUDU36ng04IE4Y8ZxjROjudz4y3zT/PFMJP2SXsWh2gUcXSJ5qdV0Gvt1poGnP6FHzsOvi64Gru4O1d3ZMnUAN81eRwZAz6nZ3uepRYP0DDKU8H1GT6YpRY8W9/BlxHo6XTa+AL/P6MkAzxq8sjuWvpcu84jv1Yo1MOkSK2pa/3LRFI+pnabSrNVo4+TmZ7LdXZ1ccXUyxjIe79ssT7w/n+lJLddqVtPMMnKQexjb3dmdujXq0tzXnea+7gULdsM9OU5/e+hhGnu70fyfVURRh7vb1Sc4wBP2Q1KdYHJ/Wrg5W9QTEcTdVyuMYuKsgC6TCKpnZXshRyf+lzGEB7o1BgdHGPszAH2B8C7t4NIxeDPQCHvLVMT3Tv6ved76VNrYsnDvEQxT5H8DKKWOikjZqrEKhndGJu9FfkAX9+tofZ03Qwf2p97fr4FUgxtGQexxuH4osv1jMBVGekqDAtP86PL9oJzJTPPG0SWSzs26cZ2nEec/HRvAr3nj+NeyPmj63IAWsB6Uxauks38X0mK7siOmE6H9Agm/pU+2Fcubk1MYnzCWRR6LjfiJGazQjY5SZXSWsigiDevkr7idHZ0BaKpyPrZbRm0pcj4L+izgVOIpWvjmfVkF1q0JE0Kp6dXYcHjyEBP2LeKjsB/wqeGTI2wjz0bsvbCXDnV6sTNmfZHluJaR/q9DqzG0zsxgZIuRjG01Nod/+Ozb84kJuHlfPe71HKWyktoGbFEYqUqptKxtKEwjgFXfnpNrbUiOhfHree7nA3AaMs1SP9SjCTRaBp4B4OF3Nc71wyBiJwAxeNLkUh3Ou121ldjEswlz/G/D9fcXGJ/ZBICdDy9iz/k92coim9vfgXTbxhwevLkpxI1m5FYjTbfqTjg5OLLu/v/x9d8nueXmq9XpibRJvFvtA1q3u4mBZ9ezIvk0nu1GQ1SVnMdQpfCo5sHHbR6nZaOSN+57BPTIcf7Xs72JTrCob/7tLDL2Z+KNzxF83S10q98tR7znuz5P/0b9iUuNY+cmrTBsobFnYxq6N+TuIGM5m6ODI891ea7oCT15CBLydk+VJbYojD9FJGtfjH7AZGB52YpVARj2KWx8G/xuYPTgIA78uJf2Da/ONKFBp7xxuk6C1YYl+Ffvvp79Z+by2uDWsPRB0pvdRvUbRuIgDkQFjuTIm1tof10t3Kq5cVP9m/Km1elB22UVgUHz+WKgMXDp4mwMMdWv5cozt7XIEfSnzB6sSOnC2x6Neb36MF777QloXIvWdVpzIOaA7Xlq7EKXdkWoF0XAz9MVP0/rLVgAZwdnejbomcfd1cmVHgE9WH6s6r8SSovZPWbTqk7uzUWLgYe/8StHbFEY0zC2St0HPIxh++njshSqQhDYy/gBrfw9WPZo98LjmK2wSKcGjOnaEDBmN/GfxThbBPOt48Xbw2/gluZ18yRRGGueuJnTF62v+chSFAUx4HpfVu6PQhAcOozDITMdOtzHvCsJ9FrSq8jyaDSW9GzQk9DTofYWo0JTKsrCTtgySyoTWGT+NIVwfuJ+vNw9Cw03tENAsdJv6uNOU59CBjYL4IHujVm5P4pOjb2MwbQuEwDwdvIuJKZGUzg1nGoUHuga5t6WZbtOoqwpaIvWfRQwVqGUalMmElVy6voWPNhtbzo1ql3wYJqmxDze/nF7i1DuZI1xavInqFYQ0zpX7h0aCmph3FFuUmgqDHcF3sUvx/QAeEmoV+OamkSYB58aPkRfLtgm27VIsQa2KxgF7emdbcI818I914LiaSov+8YZiwhndp9JcEiwnaWpfHTz74ZndU/6Nexnb1HKnb7X9WVD4w082eFJnByc+HT/pyw+uNjeYlUo2tVrV3igCk6hpkHMhXs/AB+aTgEYe2NoNBoLAtwDeOPmN3BxcrG3KOWOi5MLc26eg4+bD3Vc6/BMp2cKj3SN4eRQ+b+zbbEl9QjQDUgAY+EecG23uTUaK9R01qsfNVUbWxRGquX+F9fMwj2NpohMvGGivUXQaMoUWxRG7oV733MtLNzTaIpAQM2Aa7IrSmMbvRv0trcIpYItCmMacJ6cC/eeL0mmIvKmiBwWkb0i8pO5Z7i1cOEisk9EdovIjpLkqdGUJW3q6lnmuflvp7z7f1yrVJX6YYvCcAU+VUoNV0oNAz413UrCGuB6cy3Hv8CzBYTtpZRqq5TqWMI8NUXg50F6XkNRmHHTDHuLUOEY02qMvUWoMNzX+j57i1Aq2KIw/iCngnAF1pYkU6XU70qpdPN0K8bMK00FIrBWIMsGLbO3GJWGLJPlGk1uqjlUw9GhamwhZMs8LxelVFLWiVIqydxEqbR4APguHz8F/C4iCvhQKfVRfomIyASMfTvw8fHJNuVdVJKSkoodt6JT1LJFXcm7M5smL67iWqZ1pirXyWuBwbUGV5n7Z4vCuCQi7ZVSuwBEpAOQXFgkEVkL+Frxmq6UWmaGmQ6kA1/lk0x3pVSEuf/GGhE5rJTaYC2gqUw+AujYsaPq2bNnYSJaJTQ0lOLGregUtWypGanM/HJm2QlURfBx9ynTOlOp62SIvQWwP8Etg+kZ1NPeYpQKtiiMx4HvReQsxmZfvsA9BUcBpVTfgvxF5D4M8yN9VNZWYnnTiDD/z4nITxgbOVlVGJrSp7pj9cIDaTQFcH2d69kfs9/eYmhKCVus1W4XkRaQvanTEaXUlZJkKiL9gf8CtyilrNrqFhE3wEEplWge3wq8UpJ8NZqyQBveyx99baoWtpgGeQRwU0rtV0rtB2qKyOQS5jsPcMfoZtotIgvNvPxFZIUZxgfYJCJ7gG3Ab0qpVSXMV6PRaMoVVYXWOdvSJTVeKTU/60QpddG0L7WguJkqpYLycT8LDDSPjwM3FDcPjUajqQg09GhobxFKDVum1TqKRbtSRByBamUnkkajqSpM7zLd3iLYnWDvqmP52RaFsQr4TkT6iEgf4BvTTXMN4FPDx94iVHi6+XeztwgVltbere0tgt2pClZqs7ClJFMx1jdMMs/XoLdrvWb45e5f6PJ1F3uLUWFZM2wN3q56e1uNdVrWbmlvEUqVQlsYSqlMpdRCpdQw0zTIQeD9shdNUxGo4az3aC4IeScozQAAD/NJREFUXzffKvUFWRbUdqltbxHsxrw+8+wtQqliS5cUItJOROaISDjG1NbDZSqVRqOpMvw2+Dd7i2AX5jSYU+W2681XYYhIMxF5SUQOY7QoTgOilOqllNItDI1GYxM1q9VkWLNhxY7fuo5t4yD5bYH6eo/Xi533uFbjso8X9l1YpLiuDlXPvlhBLYzDQG/gDqVUd1NJZJSPWBqNpirxSNtHih3X29Wb+jXrFxhm/X/Ws3jA1T3EezXoBcC0ztO4o8kd/HjXjzblNbrl6OzjF7q+wMiWIwHwqu5Ft/p5JzcMaTrEpnSrCgUpjCFAJLBeRBaZM6T0sk2NxqSqbIpTHjhIwb3fo1qMYteYXVb9FIp8rAcB8H/t/y/PxAOPah4ANPJoBEBTr6b8NfKvbP+VQ1bi5+aXI041h2pM7TyVm/xvAqBtvbbUr1mfd3q+w4+D8iqcBu4NeLz949nnXXyr/uSQfEfrlFI/Az+bZjkGYdiUqiciHwA/KaV+LycZNZoKiTZ7YTu1XWoz48YZhCeE06tBL8atutrVs2/cvuzjz277DIWik28n/jz9J4+uezRPWu/3fp/zyefpUb8Hq8NXM7LFyDxhpnWeRvPazbNf/mB0jWUR4B7A78N+Z3vUdgCiLkVld2nN7jGb1eGraebVDIB+DftZLdOKIStyyHw26Sx/R/1t8zWpjNhiS+oS8DXwtYh4AcMxptpqhXGNMKDxAFaeWGlvMSocWd0eGtsY2mxo9vHktpNZsDuvsYiOvlf3Sctaw3Fvi3t5+a+XAfig7wd0r989O8y41uOwRs1qNW3awKmTb6c8bl4uXoxoMcJqePdq7iSmJVqVeVnY1f1j2tdrX2jelZEizQdUSl3EMCGe774UmqqHs4OzvUWokNwZeKe9Rai0OErhGwp5u3pntz5a1mnJ2UtnbVrX4O7snq/fN7d/w+5zu20XNBdbRm7h57CfrS5ozWpx3tnkTmb1mFVl9sCwRE8g1xRK7r5ejUFh/fKa/Onq15X3/7F9suWs7rP49+K/1HGtU2C4H+78ocAw13tfz/Xe19ucrzXuDrq7QP+qZGwwN7rGawrl4RsetrcImipGm7ptmN5lOoNqDbIpfA3nGrSt17bQcM1rN7fbynsx5wRphaG5pnF2cNY2pTSlzogWI+jrWeA+a5oKhlYYGpt4tdur9hZBo6nQZO1QWcOp6prT0WMYGpu40f9Ge4ug0VRo+lzXhyntpjCq5Sh7i1JmaIWh0Wg0pYCjgyPj24y3txhliu6S0mg0Go1NaIWh0Wg0Gpuwi8IQkRkiEiEiu83fwHzC9ReRIyISJiLTyltOjSY/XrnpFXuLoNGUO/Ycw3hXKfVWfp7m3uHzgf9v7+5jrKrvPI6/P8wMnWGQp8JMhwflebpBBGQKUgQHqYpQrVBkYc0u7aYdSSS7/aPZVkm7dk0TtbrZaLPdtSsJ9kHadBdrWpVqy6xs//ChrHV8qCshNGVqZRsjdrJN68N3/7hnppfhznBmuHPPvXc+r4TMOb9z7r3fX87lfnJ+99zfuQI4ATwj6eGIeKlUBZoNZPOCzVmXYFZy5TwktQI4GhHHIuKPwH5ykyCamVkGsgyM3ZKel7Q3mdSwvxnkbtrU60TSZmZmGRixISlJTwAfKLBpD/A14DYgkr93A399jq/XAXQANDc3D3vir56enqqcNAzOvW8z6mbQ/XZ38QqqYKV8j/g9WZmqsW8jFhgRkeo3/5K+DvygwKZuYFbe+sykbaDX65tFt62tLdrb21PXmq+zs5PhPrbcnWvf9j+xn+5uBwZQ0veI35OVqRr7ltVVUvnTn24GXiiw2zPAAklzJI0FtgMPl6I+K2zZtML3TB5ttrcWvleCWbXL6iqpOyUtJTckdRy4EUDSdODfImJjRLwjaTdwEKgB9kbEixnVa8CSpiVZl1AWVrZU/604zQrJJDAiouCtsCLi18DGvPVHgEdKVZcN7pKWS7IuoSx45l4brcr5slqzsjR30tysSzDLhAPDzMxScWCYmVkqDgyzIeq9FafZaOPAMBuicXXVe0c1s8E4MMzMLBUHhpmZpeLAMDOzVBwYZmaWigPDbAiWNy/PugSzzDgwzIZgy4ItWZdglhkHhpmZpeLAsCGZO3F0z6NUo5qsSzDLjAPDhmT3st1Zl5Cp1dNXZ12CWWYcGDYk62aty7qETEmeFsRGLweGDUntmKzuuWVmWXNgmJlZKg4MsyEYXzc+6xLMMuPAMBuCmjG+SspGLweGmZmlksk3mJK+A7Qmq5OANyNiaYH9jgO/A94F3omItpIVaWZmp8kkMCLiz3uXJd0NnBpk93UR8duRr8rMzAaT6TWSyl3Uvg24PMs6zMzs7LK+qH4N8HpEvDrA9gB+JCmAf42I+wZ6IkkdQAdAc3MznZ2dwyqop6dn2I8td8Xq24SaCbz17lvnXlAFyuK94fdkZarGvo1YYEh6AvhAgU17IuL7yfIO4MFBnubSiOiW1AQ8LukXEfFkoR2TMLkPoK2tLdrb24dVd2dnJ8N9bLkrVt+mPjSVt06NzsDI4r3h92Rlqsa+jVhgRMRHBtsuqRbYAgx4g4GI6E7+npR0AFgBFAwMK52VLSs5dupY1mWYWYlleVntR4BfRMSJQhslNUo6r3cZuBJ4oYT12QCuuOCKrEswswxkGRjb6TccJWm6pEeS1WbgvyT9HHga+GFEPFbiGq2AhZMXZl1CUWycszHrEswqSmaBERGfiIh/6df264jYmCwfi4glyb9FEfHlbCq1/hpqG85oW3/++pLW0Dq59ew7ncUda+8oQiVmo4d/6W1DNrZmLEf+8giXzbwMgKZxTdy2+jamNUwb8DG3r7m9qDXsu3ofWxduHXD7sqZlp63PmziPey+/t2/9mrnXDPk1185cO+THmFWTrC+rtQpVN6aOr67/6mltP9n2ExbvW1xw/01zN3HoV4c4ePwgAFfNvqpv+Wy+cfU3qBtTx41P3MipP5ziC5d8gca6xoJ3v1t//npuXnEzzY3NHDx+kOXNyzl84jAb5mygobaBgx8/yCtvvMK689ed8Ro3H76ZBzc9yJrvrClYx4JJC1LVa1atfIZhRdXS2ALAriW7AJhSP4Wn/uIpAO667K6+/fKXBzNv4jyWNi1l0dRFfW1XXnAlANtat52x/56Ve2hubAZyoTS1YSqbF2zuG0abPn76GWEBsLRpKY9+/FEm1U+ivqYegAeufoCf7vhp3z7Xzr82Vc1m1cpnGDYirpt/HXVj6ti6cCvj6sb1tTfUNvCpxZ8qymssnLyQQ9sOse6761jRuIL7t95flOeded5Mjr55lMa6RiaMncAtK29hVcsqZk+cXZTnN6tUPsOwovrkhZ8EcmcWHRd1MKV+ymnbn77haTou6uhb37VkFweuPXDaPl9c9cWCz/3pxZ8GoLGusa9tasNUvnfN99j+/u1Fqb+QHR/c4bAww4FhRbbjgzvo2tlV8Eqq/rp2dnHT0puYP3l+X9vFTRdz/cLrC+6/c9FOunZ2UVdTd1p765RW6lRX8DFn86UPf+mM4bHeL9ObxzUP6znNqpUDw8rKPZffA/zpbGKkbVmwhatmX3Va2w1/dgNdO7uY+L6JJanBrFI4MKys9H5I+0d1ZuXHgWFlaeZ5M2ka18RnP/TZrEsxs4SvkrKyVF9bz4+v/3HWZZhZHgeGlYWvrP0KE8ZOyLoMMxuEA8PKwoY5G7IuwczOwt9hmJlZKg4MMzNLxYFhZmapODDMzCwVB4aZmaXiwDAzs1QcGGZmlooDw8zMUlFEZF1D0Un6X+CXw3z4VOC3RSynnLhvlcl9q0yV1rcLImLaYDtUZWCcC0nPRkRb1nWMBPetMrlvlaka++YhKTMzS8WBYWZmqTgwznRf1gWMIPetMrlvlanq+ubvMMzMLBWfYZiZWSoODDMzS8WBkZC0QdIrko5K+nzW9RSTpOOSuiQ9J+nZrOs5F5L2Sjop6YW8timSHpf0avJ3cpY1DtcAfbtVUndy7J6TtDHLGodL0ixJhyS9JOlFSX+btFf8sRukb1Vx7PL5OwxAUg3wP8AVwAngGWBHRLyUaWFFIuk40BYRlfQjooIkrQV6gAci4sKk7U7gjYi4PQn7yRHxuSzrHI4B+nYr0BMRd2VZ27mS1AK0RMQRSecBPwOuAz5BhR+7Qfq2jSo4dvl8hpGzAjgaEcci4o/AfuBjGddkBUTEk8Ab/Zo/BuxLlveR+89acQboW1WIiNci4kiy/DvgZWAGVXDsBulb1XFg5MwAfpW3foLqOuAB/EjSzyR1ZF3MCGiOiNeS5d8AzVkWMwJ2S3o+GbKquCGb/iTNBpYBT1Flx65f36DKjp0DY3S4NCIuBq4GbkqGPqpS5MZYq2mc9WvAPGAp8Bpwd7blnBtJ44F/Bz4TEW/lb6v0Y1egb1V17MCB0asbmJW3PjNpqwoR0Z38PQkcIDcEV01eT8aRe8eTT2ZcT9FExOsR8W5EvAd8nQo+dpLqyH2gfisi/iNpropjV6hv1XTsejkwcp4BFkiaI2kssB14OOOaikJSY/JFHJIagSuBFwZ/VMV5GNiZLO8Evp9hLUXV+2Ga2EyFHjtJAu4HXo6If8zbVPHHbqC+Vcuxy+erpBLJJW//BNQAeyPiyxmXVBSS5pI7qwCoBb5dyX2T9CDQTm7q6NeBvwceAr4LnE9uWvttEVFxXx4P0Ld2ckMaARwHbswb868Yki4FDgNdwHtJ8y3kxvor+tgN0rcdVMGxy+fAMDOzVDwkZWZmqTgwzMwsFQeGmZml4sAwM7NUHBhmZpaKA8NsEJLenzfb6G/yZh/tkfTPI/San5H0V4Ns/6ikfxiJ1zYbjC+rNUupFDPHSqoFjgAXR8Q7A+yjZJ/VEfF/I1WLWX8+wzAbBkntkn6QLN8qaZ+kw5J+KWmLpDuTe5A8lkwbgaTlkv4zmQTyYL9fAve6HDjSGxaS/ia5z8LzkvZD35xLncBHS9JZs4QDw6w45pH7sL8W+CZwKCIWA78HNiWhcS+wNSKWA3uBQr+4X03ufgq9Pg8si4iLgF157c8Ca4reC7NB1GZdgFmVeDQi3pbURW56mceS9i5gNtAKXAg8nhtRoobcDKb9tZC7n0Kv54FvSXqI3BQovU4C04vZAbOzcWCYFccfACLiPUlvx5++HHyP3P8zAS9GxKqzPM/vgfq89U3AWuAaYI+kxclwVX2yr1nJeEjKrDReAaZJWgW56bAlLSqw38vA/GSfMcCsiDgEfA6YCIxP9ltIFcx+apXFgWFWAsmtf7cCd0j6OfAc8OECuz5K7owCcsNW30yGuf4buCci3ky2rQN+OLJVm53Ol9WalRlJB4C/i4hXB9jeTG6a+vWlrcxGOweGWZmR1EruXtdPDrD9Q8DbEfFcaSuz0c6BYWZmqfg7DDMzS8WBYWZmqTgwzMwsFQeGmZml4sAwM7NU/h8v9glw8CWfOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots() #create an empty plot\n",
     "\n",
@@ -501,21 +503,6 @@
     "\n",
     "fig.savefig('full-time-history.png')\n",
     "plt.show()"
-   ],
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEWCAYAAAB1xKBvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydd1xW1f/A3x+GggiIogwxB7jD3FpqOUttmOubmqOlqZW/5lfLhg3NbNk3NcsWti0rsxxpSq7MlXskKg4EVJClDIHz++Ne8AEe4GE+gOf9ej2v594zP+fec+/nnvU5opRCo9FoNJrCcLC3ABqNRqOpHGiFodFoNBqb0ApDo9FoNDahFYZGo9FobEIrDI1Go9HYhFYYGo1Go7GJKqUwRCRcRPraW47CEJGVIjLOxrA+IrJBRBJF5O2ylq0AOWaIyJf2yr+0EZFQEXmomHELvBYi0lxEdpv3bErxpQQRUSISVJI0ygtLWUVkoYi8YB73FJEzZZz3vSLye1nmkU++xS6biDQyr5lTactVVlQphZEf1m5qWb8ARaSaiFwQkZq5z5VSA5RSITYmNQG4AHgopZ4qK3mvBXLfkzLkv8B6pZS7Uup/Nsj1rIjMKkmGxX35iIi/5bMhIqNEZIeIJIlIpPlx072o8iilJiqlXi1qPFuwVlal1FdKqVvLKL/WIvK7iMSKSJyI7BSRgWWRV0XnmlAYduJmYLdSKimfc1tpCBxUeoVlaVDce1BUGgIHihD+dmBFGclSGAOBVQAi8iQwF5gF+ADXAQuAQeUpkIg4lmd+NrAcWAP4AvWAKUCCXSWyF0qpKvMDwoGngb1APPAd4AYkA5lAkvkbBaQBV8zzPWb8UOB1YBtGhVgG1Db9XIAvgRggDtgO+BQgyzvAk9bOzXweMo/vAzYBbwEXgRPAANPvc1PGNFPOvkB1jIf6rPmbC1TPRwZP4BMgEogAXgMcC8vX9G8M/AkkYjws84AvLfy/B6LM67wBaG3hVwf4xbyG24BXgU0FXKtBwG4z/DGgv+nub6YTC4QB4y3izDBl+NKUcR/QDHgWOAecBm7N756Y9+BVYLMZ/3fA2/TrCZyxUrf6WuT9A0b9SgR2ATeYfuuADCDFvGfNMF7KB82wEcDTFul6mfJm3ZdnzPt1FngAUECQ6Xc78I95nU4DMyzSOWWGzarjNwKBpjwxGK3Ur4Baucr1IzDErCtJwPAC7lNn4C+M+h9p1olqFv6Wsn4OvGZ5PYHnTDnCgXst4n0OfIChNC9h1POilvU+LOoYcBPGMxpv/t9k4ZfvvbdSZm8zr1r5+GeV7SnzPkYC91v4F1SORmbaTub5UPPaXI/xMT8N43mIAZZgvovykWM8cMgsz0Ggvek+FaPOJQJHgD4Yz1WyZXpAO/PeOBf4ji2vl3l5/MyLvc28ILXNCzgR6y+AGVi8AC0qUoR5w9yApVlhgIcxvjRqAI5AB4xuIswb+2uutA4Dza2dk1dhXDFvuCMwCeNlIbkfPPP8FWArxpdOXWAL8Go+1+Mn4EOzLPXMa/Owjfn+hfGCrY7xZZ5IToXxAODOVQW228LvW7OCu5nXMoJ8FAbGSyge6Gc+JPWBFqbfBowvXBegLXAe6G1x/1KA2wAnYDGG0psOOJvlOpHfPTHvwTGMF7qreT7b8iVgpW5ZKowrwDAzr6fNvJ1z31/zPBLoYR57YT7M5vkI4BvzuD8QzdX69zU5X8I9gWDzOrUxw95t7eVjugWZ17U6Rl3ZAMy18HfGeEm4m3mnW8a3cq86AF3N690I4/l63MK/IIWRztX6dAuGYmhuETYe6GaWzaUYZb0Ps45hPPsXgTGmrCPN8zqF3XsrZRbgKPArcDe5PhItyvaKeT0HApcBr6LcM+B+jI+irOv3fxjPeYB5zT7ErCdWZByO8Yx1MuUNwmjlNsdQUv4W+QWax+vI+QH2JrCw0HdsebzIy+uH8VCPtjifAyykaApjtsV5K4yve0eMF+QWoI0NcgQCYQWch5JTYVj61TArkW/uB888PwYMtDi/DQi3IoMPkAq4WriNxOhbLzBfjK6IdMDNwv/r3NfLwq+WGdfTvFZXMF/6pv8s8lcYHwLvWnFvgPGl7m7h9jrwucX9W2PhdyfG12bWl7o7Fl+G+dyD5y3OJwOrzGNr9SWcnApjq4WfAzmVQvb9Nc9PYXxweFgp5xfAGPP401z1rxkWL2ErcedmXTusvESthL8b+MfivA/wh3l8LxBVxOftceAni/PCFIZlfVoCvGARdnEheRVYVnIqjDHAtlzx/wLuK+ze55N3AEZr6hhGT8UGoKlF2ZJzyXIO6FqEcjyN0SoIsAh3COhjce6H8Vzlub/AauD/rLgHmbL0JVfLAXgIWGceC4Ziubmwe14VxzCiLI4vA0Ud4DxtcXwS46vBG+PBXg18KyJnRWSOiDjnk8ZAYGUB5/nKrJS6bB7mJ7e/KZeljP5WwjU0ZY80B+riMF7O9WzI1x+4qJS6lCsfwOhjFpHZInJMRBIwXqZgXKe6GF9Mua9jfjTAeBBz4w/EKqUSc6VT3+I82uI4GbiglMqwOM8qD1i/ByWpK9nlU0plYnRLWLsPYHQ1DAROisifInIjgIg4YLQAVpnh/CnguolIFxFZLyLnRSQeo/XsnZ+A5gy7b0UkwrxPX+YKP5CrYycxgHdBg+Yi0kxEfhWRKDO9WQXlnwtr9cnyelmWu8hlzUXuZyQrP8u6Y/Xem7O7kszfcwBKqTNKqUeVUoEYz9UljBZtFjFKqfR80rOlHM8A85VSlhNzGgI/WTy7hzA+oHyslNfqM6SUCsNQ6jOAc2ZdyLrmS4EbRcQPowchE9hoJe0cVEWFYQ1loxsYFz+L6zC0+gWl1BWl1MtKqVYY/aN3AGPzScPyQbR2XhLOYlQmSxnPWgl3GqOF4a2UqmX+PJRSrW3IIxLwEhG3XPlkMQpj3KEvRquikekuGN1G6eS9jvlxGuPrPzdngdoi4p4rnQgb5LdGUe7BJYwWF5A9CFs3V5gGFv4OGF+h1u4DSqntSqlBGMr6Z4yvazC6EE4qpc6b55EUfN2+xhjTaaCU8sRoPUtWNlaynmW6ByulPIDRFuEh5zX5C6O+3G2tDCYfYHTrNTXTey5XegVhrT5ZXq/c8he1rJbkfkay8iu07ihjdldN85dn5ppS6jQwH6Pb0BYKKkcWtwLPi8hQC7fTGGOKtSx+Lkopa2XI7xlCKfW1Uqo7xvVQwBum+0WMsZt7MJ7nb5XZ3CiIa0VhRAN1RMQzl1sj82G3ZLSItBKRGhj9kj8opTJEpJeIBJsvjwQMRZKZOyMzXmdgvbXzUuAbjMpVV0S8gRcxvhxzoJSKxKgQb4uIh4g4iEigiNxSWAZKqZPADuBlcypqd4wunyzcMV4uMRgv1lkWcTMwBlJniEgNEWkFjCsgu0+A+0WkjyljfRFpYT6YW4DXRcRFRNoAD1ora2EU4x78C7iIyO1mK/J5jH5kSzqIyBDzi/xxjOux1Ure1cw1Ap5KqSsYdSer3gwEfrMIvgS4z6L+vZQrOXeMVleKiHTGeNCzOG+m2yRX+CQgXkTqY3zJZsnVGGOyxCEApVQ8Rl2aLyJ3m/fOWUQGiMgci/QSgCQRaYEx7lUUsupTD4wPru8LCFvUslqyAmhmThF2EpF7MLqXfy2ivIiIl4i8LCJBZv30xuieznOvi1GOLA5gjCHNF5G7TLeFwEwRaWjKUVdE8put9jHwtIh0EIMgEWkoxnqg3iJSHWO8L2vyTxZfY3z0DjOPC+WaUBhKqcMYL9rjZhPPn6uVNUZEdlkE/wKjTzUKY/Ata+GVL8bMmASM5uGfZlhE5DkRyeru6A38pZRKyee8pLyG8TLfizEzaJfplrV4yXI651igGkb/6EVTfj8b8xkFdMGYofQSOZvgizGa+BFm2rkfnkcxmuRRGNfyM0tPETkgIvcCKKW2YQz4vYsx8PknV78OR2K0Xs5iDOC/pJRaa6P8lhTpHpgvz8kYD2IERosj9+KsZRhfZ1mDq0NMhWCNMUC42Y0zEWO8AHJNp1VKrcTo416HMQC6Llc6k4FXRCQR4+W+xCLuZWAmsNms412Bl4H2GNf1NwxFnkWeqbxKqbeBJzEU5HmML9dHMVpFYPS1j8KYALEIY5aYrURhXKuzGLO1JprPZX4UtayW5YjBUEhPYXzU/Be4Qyl1oQjyZpGGUQfXYjz7+zE+Du6zMX6+5cgl8x5T5kUiMgB4D6Nl8rsZdyvG8wiA2WXWw4z7Pcb1+Brj3vyMMfBfHZiNMbEhCqOF+6xFtr8ATTHGrvbYUhixoRVyzSAioRgDux+XII0FwH6l1AJr59ciInIfxiBwkReAlVL+Fe4eiIgPxnTL+rZ0BZRB/iuAeUope63/0FRCKs2S9ErEbozpt/mda8qfingPPIGn7KEsTEIpvW5SzTWCVhiljFLqo4LONeVPRbwHSql/McZK7JX/nMJDaTQ50V1SGo1Go7GJa2LQW6PRaDQlp0p2SXl7e6tGjRoVK+6lS5dwc3MrPGAlRJetcqLLVjmpbGXbuXPnBaVU7vVGOaiSCqNRo0bs2LGjWHFDQ0Pp2bNn6QpUQdBlq5zoslVOKlvZRKQgiwyA7pLSaDQajY1ohaHRaDQam9AKQ6PRaDQ2USXHMDQaTcXlypUrnDlzhpSUFDw9PTl06JC9RSoTKmrZXFxcCAgIwNk5P2Pb+aMVhkajKVfOnDmDu7s7jRo1IikpCXd398IjVUISExMrXNmUUsTExHDmzBkaN25c5Pi6S0qj0ZQrKSkp1KlTBxFbLaNrSgsRoU6dOqSkFM8WqlYYGo2m3NHKwn6U5NprhaG5JlFKsSxsGSnppWV1XqOp+miFoakSJGQkMP738VxMuWhT+M1nN/P85ueZu2tuGUumqchkWYTI+t+xYwetW7cmLS0NgGPHjtGkSRMSEhLyxI2MjOSOO+4AYM2aNXTo0IHg4GA6dOjAunVXtzLZuXMnwcHBBAUFMWXKlKw9tYmNjaVfv340bdqUfv36cfGiUXeVUkyZMoWgoCDatGnDrl278uSdmxEjRnD06NF8y1VaaIWhqRKEJoSyNXIrS48uLTDcheQLHI49TFJaUvY5QHBIMBN+n1DmcmoqNh07duSWW27hrbfeAuCRRx5h5syZeHh45An7zjvvMH78eAC8vb1Zvnw5+/btIyQkhDFjxmSHmzRpEosWLeLo0aMcPXqUVauMLdxnz55Nnz59OHr0KH369GH27NkArFy5MjvsRx99xKRJhW9sOGnSJObMKXsDxFphaErMxjMb+eXYL/YWwypLjizhvV3v8XOYsWlcryW9GL58eLb/6vDV2cd/Rf7FvvP7yl1Gjf2oW7dujn+AWbNmsWjRIubMmUN6ejojR460Gnfp0qX0798fgHbt2uHv7w9A69atSU5OJjU1lcjISBISEujatSsiwtixY/n5Z6MuLlu2jHHjjN2Lx40bl8N97NixiAhdu3YlLi6OyMhIMjMzmTx5Mi1atKBfv34MHDiQH374AYAePXqwdu1a0tPT8y1XaaCn1WpKzOQ/JgMwfdN0/hnzD04OeauVUopF+xYxpOkQvF29i5T+lHVT2Byxmd+G/Iavmy8AC3YvIORACH/f+3eOsMfjjpOcnkxsSiz1a9bn1a2vZvvdHXR39nFyenL28ZaILdnHo1aM4osBX9C2XtsiyagpHm/8foyjF5ILD1gEWvl78NKdrW0Ku3379hz/ALVq1WLatGlMnjyZgwcPWo134sQJvLy8qF4991bvhiJp37491atXJzw8nICAgGy/gIAAIiIiAIiOjsbPz9gx2dfXl+joaAAiIiJo0KBBnjibN28mPDycgwcPcu7cOVq2bMkDDzwAgIODA0FBQezZs4cOHTpYLVdpoFsYmhJxPP54jvOsQeTYlFi+Pfxttvu+C/t4/5/3uefXewgOCSY8PpwNZzbk+aKfs30O438fn8Nt/en1pGWm0e+HfgBEX4rmgz0fcDn9MsEhwXx3+DvWJKwBYPnx5XT+qjP9l/bnvlX35UjHUjEoru4D8/Dah3OEG7NyDLEpsUW5DJoqxsqVK/Hx8clXYURGRlr9ej9w4ABTp07lww8/LFJ+IlLo7KVNmzYxfPhwHBwc8PX1pVevXjn869Wrx9mzZ4uUb1HRLQxNsbiQfIFeS3rlcb/xmxt54PoH+HT/pwB08OlAU6+m3LviXgDOXT4HQMjBEH7412hO7xq9i+mbp1PDqUb2GMSmiE341/Rn2oZpOdL/O/JvHvr9oRxur/39mlUZd0bvzHFuqRhe2vJSgeXbFrWNJUeWsD3K+EL74c4faF67eYFxNEVn6q2BFW5x26+//kp8fDyrV69m8ODB3HbbbdSoUSNHGFdX1zxrGc6cOcPgwYNZvHgxgYGBJCYmUr9+fc6cOZMjTP369QHw8fEhMjISPz8/IiMjqVevHgD169fn9OnTVuMUREpKCq6ursUuty3YrYUhIs1FZLfFL0FEHs8VpqeIxFuEedFe8mquciXzCuNWjsvXP0tZAAz5ZQi/Hv81T5gsZQHQ/sv2rDyxMseA9aS1kxj08yAOxeY0rZBbWZQVz/z5TLayAHhtq3WlpKlaJCcn8+STTzJ//nyCg4MZNGgQM2fOzBOuWbNmhIeHZ5/HxcVx++23M3v2bLp165bt7ufnh4eHB1u3bkUpxeLFixk0aBAAd911FyEhIQCEhITkcF+8eDFKKbZu3Yqnpyd+fn5069aNpUuXkpmZSXR0NKGhoTlk+vfff7n++utL+YrkxG4KQyl1RCnVVinVFugAXAZ+shJ0Y1Y4pdQr5Sulxhof7vmQU4mnbA7/7MZny1Ca8uFY3DF7i6ApB1599VUGDx5Mq1atAJgxYwbffPNNjimrAG5ubgQGBhIWFgbAvHnzCAsL45VXXqFt27a0bduW8+fPA7BgwQIeeughgoKCCAwMZMCAAQBMmzaNNWvW0LRpU9auXcu0aUZreuDAgTRp0oSgoCDGjx/PggULABg6dCgBAQG0atWK0aNH0759ezw9PQFjPMTV1RVfX98yvT4VpUuqD3BMKVXoBh4a+5PVrXQtkXglkfjUeDyre9pbFE0ZMmvWrBzn7u7uHD9+3GrYRx99lM8//5zXXnuN559/nueffz6Hf2JiImBM1d2/f3+e+HXq1OGPP/7I4y4izJ8/P4+7g4MDb731FjVr1iQmJobOnTsTHBwMwNdff83DDz+cJ05pU1EUxgjgm3z8bhSRPcBZ4Gml1AFrgURkAjABjL7B3M01W0lKSip23IpOaZVt/Zn1JRemEjJs6TCm+08v93yrWp309PTMfplmZGRkH1c2+vbtS0RERL7yl0XZBg4cSHx8PGlpaTzzzDO4ubmRmJiIi4sLQ4YMsTm/lJSUYtUpyVp1aC9EpBqGMmitlIrO5ecBZCqlkkRkIPCeUqppYWl27NhR6S1a81JaZQsOCS65MJWUfePKf51GVauThw4domXLlkDFtOhaWlTkslnegyxEZKdSqmNB8SrCtNoBwK7cygJAKZWglEoyj1cAziJStEn8Go1GoykVKoLCGEk+3VEi4ivm5GQR6Ywhb0w5yqbRaDQaE7uOYYiIG9APeNjCbSKAUmohMAyYJCLpQDIwQtm7D02j0WiuUeyqMJRSl4A6udwWWhzPA+aVt1wajUajyUtF6JLSaDQau2BpBjwlJYUWLVqwb9/ViQ1vvvmm1emqycnJ3HLLLWRkZLB7925uvPFGWrduTZs2bfjuu++yw504cYIuXboQFBTEPffck202PTU1lXvuuYegoCC6dOmSYxHg66+/TlBQEM2bN2f16tW5s87D008/ncOces+ePQkPDy910+agFYZGo9EA4OLiwty5c5k8eTJKKSIiIli4cGG22XFLPv30U4YMGYKjoyM1atRg8eLFHDhwgFWrVvH4448TFxcHwNSpU3niiScICwvDy8uLTz75BIBPPvkELy8vwsLCeOKJJ5g6dSoABw8e5Ntvv81Oa/LkyWRkZBQo92OPPWZVxrJAKwyNRnPNktsMeP/+/fHz82Px4sU88cQTzJgxAy8vrzzxvvrqq2xTHs2aNaNpU2O2v7+/P/Xq1eP8+fMopVi3bh3Dhg0D8powzzJtPmzYMP744w9jF8hlyxgxYgTVq1encePGBAUFsW3bNsBYhd68eXO6d+/OyJEjs/fsaNiwITExMURFRQFQu3ZtHB0dS920OVSchXsajeYapPr6lyDmSOkm6hsMA2z74rZmBnzu3Ll07tyZpk2b5tgIKYu0tDSOHz9utctn27ZtpKWlERgYyKlTp6hVqxZOTsZr1tK0uaUJcycnJzw9PYmJiSEiIoKuXbtmp5cVZ/v27SxdupQ9e/Zw5coV2rdvT4cOHbLDtW/fns2bNzN06FB+/PHHPGUqLbTC0BSJvef32lsEjaZM8ff3p3fv3tnbr+bmwoUL1KpVK497ZGQkY8aMISQkBAeH0u282bx5M4MGDcLFxQUXFxfuvPPOHP7lYdoctMLQFJEsM+XXKtqeVOmS2utlqlXA1dAODg75vvStmTZPSEjg9ttvZ+bMmdkthNq1axMXF0d6ejpOTk45zJRnmTAPCAggPT2d+Ph46tSpk69pc0sT6dYoD9PmoMcwNJoiEX05j0ECzTWGl5cXGRkZ2UojLS2NwYMHM3bs2OzxCjCMCPbq1St7G9XcJsyzTJv/8MMP9O7dGxHhrrvu4ttvvyU1NZUTJ05w9OhROnfuTLdu3Vi+fDkpKSkkJSXx6685twwoD9PmoFsYGo1GU2RuvfVWNm3aRN++fVmyZAkbNmwgJiaGzz//HIDPP/+cwMBA3njjDUaMGMHzzz9Pu3btePDBBwF48MEHGTNmDEFBQdSuXZtvvzV2p2zdujX/+c9/aNWqFU5OTsyfPx9HR0c6derEXXfdRZs2bfDx8SE4ODjbtPmVK1cICwujY8cCzUCVClphaDQaTS6yXvz58cgjj/Duu+/St29fRo8ezejRo/OESUxMpEmTJtmznCxxcXHh+++/t5r29OnTmT49r1Xkp59+mhkzZnD58mVuvvnm7EHvX3/9lWHDhmUPrpclWmFoNBpNEWnfvj29evUiIyMDR0fHcslzwoQJHDx4kJSUFMaNG0f79u0BSE9P56mnnioXGbTC0GiKwKmEUzTzamZvMTQVgAceeKBc8/v666+tug8fPrzcZNCD3hpNEXgi9Al7i6DR2A2tMDQajUZjE1phaDQajcYmtMLQaDQajU1ohaHRaK5ZLM2bA8yfP5+2bdtm/66//npEhEOHDuWJGxkZmW0+ZM2aNXTo0IHg4GA6dOiQw9z4zp07CQ4OJigoiClTppC1B1xsbCz9+vWjadOm9OvXj4sXLwKglGLKlCkEBQXRpk0bdu3aVWg5RowYwdGjR/MtV2mhFYZGo9GYPPLII+zevTv7d9ddd3HvvffSsmXLPGHfeecdxo8fD4C3tzfLly9n3759hISE5DBaOGnSJBYtWsTRo0c5evQoq1atAmD27Nn06dOHo0eP0qdPn2wT5StXrswO+9FHHzFp0qRC5Z40aRJz5swpjUtQIFphaDSaa5bc5s0t2bBhA0uWLGHBggVW4y5dupT+/fsD0K5dO/z9/QFjtXZycjKpqalERkaSkJBA165dERHGjh1r1cR5btPnY8eORUTo2rUrcXFxREZGkpmZyeTJk2nRogX9+vVj4MCB2WZHevTowdq1a0lPTy+0XCVBr8PQaDR2Y+6euRxPOl6qabao3YKpnafaFNaaeXOAuLg47rvvPr744gs8PDzyxDtx4gReXl5Ur149j9/SpUtp37491atXJzw8nICAgGw/SxPn0dHR+Pn5AeDr60t0tGGnzNL0uWWczZs3Ex4ezsGDBzl37hwtW7bMXgvi4OBAUFAQe/bsoUOHDvmWq6ToFobGZq5kXrG3CBpNuTBx4kTGjBlDt27drPpHRkZa/Xo/cOAAU6dO5cMPPyxSfiKCiBQYZtOmTQwfPhwHBwd8fX3p1atXDv/yMHFu9xaGiIQDiUAGkK6U6pjLX4D3gIHAZeA+pVTho0CaUuez/Z/ZW4QKQXpmOk4Odn90qgSP3/A47hXMvHlISAgnT57kyy+/zDeMNRPnZ86cYfDgwSxevJjAwEASExPzmCa3NHHu4+NDZGQkfn5+REZGUq9ePYB8TZwXRnmYOK8oLYxeSqm2uZWFyQCgqfmbAHxQrpJpsrmQfMHeIlQIfg//3d4iaMqI48eP89xzz/HVV18VaMyvWbNmhIeHZ5/HxcVx++23M3v27BytEj8/Pzw8PNi6dStKKRYvXmzVxHlu0+eLFy9GKcXWrVvx9PTEz8+Pbt26sXTpUjIzM4mOjiY0NDSHTOVh4ryiKIyCGAQsVgZbgVoi4mdvoa5Fvjn8jb1FqBDorrmqyxtvvMHly5cZMmRIjum1GzduzBHOzc2NwMBAwsLCAJg3bx5hYWG88sor2XHOnz8PwIIFC3jooYcICgoiMDCQAQMGADBt2jTWrFlD06ZNWbt2LdOmTQNg4MCBNGnShKCgIMaPH5896D506FACAgJo1aoVo0ePpn379tkmzqOjo3F1dcXX17dMr49kzQm2FyJyArgIKOBDpdRHufx/BWYrpTaZ538AU5VSO3KFm4DRAsHHx6dDln35opKUlETNmjWLFbeiU9KyPXbysVKUpnLzfsP3yy2vqlYnPT09CQoKAihXa6+lzfLly/nnn3948cUXrfqXRdmy6kJMTAy9evVizZo1+Pj4MG/ePDw8PBg7dqxN6YSFhREfH5/DrVevXjvz6eXJpiJ0xHZXSkWISD1gjYgcVkptKGoipqL5CKBjx46qZ8+exRImNDSU4sat6JS4bCGlJkqlpzzrSFWrk4cOHcoet0hMTKxwYxi2MmrUKC5fvpyv/GVRtjvvvJO4uDjS0tJ46aWXshWvr68vY8aMsXlPDBcXF9q1a1fk/O2uMJRSEeb/ORH5CegMWCqMCKCBxXmA6abRaDR25aGHHirX/HKPW2Rx//33l0v+dh3DEBE3EXHPOgZuBfbnCvYLMFYMugLxSqnIchZVo9GUIvbuCr+WKcm1t3cLwwf4yZx/7LaLkJEAACAASURBVAR8rZRaJSITAZRSC4EVGFNqwzCm1ZaPKtXk4Pzl8/YWQVNFcHFxISYmhjp16thblGsOpRQxMTG4uLgUK75dFYZS6jhwgxX3hRbHCnikPOXS5KX3973tLYKmihAQEMCZM2c4f/48KSkpxX55VXQqatlcXFxyrD4vCvZuYWg0lZKEtAQ8quU1GaEpHGdnZxo3bgwYffLFGXytDFTFslWGdRgaTYVjy9kt9hZBoyl3tMLQaIrBM38+Y28RNJpyRysMjUaj0diEVhgajUajsQmtMDSaYpKQlmBvETSackUrDE2h6EVW1rl85bK9RajSZKpMktOTyz3PcSvH8efpP8s138qCVhiaQtkeVbq7dlUVIi9pgwOlxeUrl/O8pGdvm03nrzqTnpleYNzDsYcJjw8vUf77zu8jIimClPQUdp3bxTMbCp7UsCt6F9GXokuUZ2VEKwxNoeh9MKwzdqVtlkE1MHHNRO76+S5mbJlh1Tz8a1tf49F1j3L04tFst6X/LgUgLC6M1/9+nZjkGF7Y/AIp6Tk3Lhq+fDh3/nwnC/cspCAyMjMIDglmxpYZBIcEE3YxLNtv1IpR9F/an9DTofnGPxx7mOXHlgMwbtU4Bi8bbDXclYwrdP6qM7/HV719U/TCPU2hHIs/Zm8RNJWczWc3A3Ai/gRLjy7NdnfEkWcPP8veC3sBQzkE1Qri+3+/Jy0zDYDH1j1G1KUovj78NQA/h/3MKze9AkB1x6t7as/fPZ/5u+cD8ObNb3JzwM08u/FZ1p1eB8D7vQ2T9Fn5D/4l7wt/6kZjL/Dk9GSWHFlCeEI4Q4KG5Ah7Z+CdACReSeRUwin2XtjLsxufZeINE1m4ZyGTb5hMcnoyy+OWM4tZJbpuFQ2774dRFnTs2FHt2LGj8IBWqGqmpC0pbtmCQ4JLX5gqwr5x+8o8j6pQJ6tSHdo3bp/N5SmP+lFaiEih+2HoLimNRlOmVLWP0qqk/IqKVhiaAqlqD3tps+bkGnuLUOHJ6krSVH60wtAUyIYzRd788Jpi34XK0+VgL2Zvm21vETSlhFYYmgL5/MDn9hZBo9FUELTC0BTIjujiTR64VohPjbe3CBpNuaEVhkZTAlIzUu0tQoXm430f21sEu7L73G57i1CqaIWh0WjKjPd2vWdvEezKq1tftbcIpUqBC/dExAW4A+gB+APJwH7gN6XUgbIXT6PRaCov/178194ilCr5tjBE5GVgM3Aj8DfwIbAESAdmi8gaEWlTLlJqNBUUbaROUxhHYo/YW4RSo6AWxjal1Ev5+L0jIvWA64qbsYg0ABYDPoACPlJKvZcrTE9gGXDCdPpRKfVKcfPUFI3TCaftLUKFJ+lKkr1F0FRwjlw8QvPaze0tRqmQr8JQSv1WUESl1DngXAnyTgeeUkrtEhF3YKeIrFFKHcwVbqNS6o4S5KMpJs9vft7eIlQKTiacpKFHQ3uLoamgVKXFr4UaHxSR5RgtAEvigR3Ah0qplLyxCkcpFQlEmseJInIIqA/kVhgaO5CpMtl1bpe9xagU3PHTHZXKZpBGU1xssVZ7HKgLfGOe3wMkAs2ARcCYkgohIo2AdhhjJbm5UUT2AGeBp/MbbBeRCcAEAB8fH0JDQ4slS1JSUrHjVnSKUrY9l/eUrTBVjLKsM5W1Th5L0VaOAV7c/CKeZzztLUapUKi1WhHZrpTqZM1NRA4opVqXSACRmsCfwEyl1I+5/DyATKVUkogMBN5TSjUtLE1trdY6RSnbtWxgrTiUZQujstbJ/kv7E5EUYW8xKgSVoQVaWtZqa4pI9uC2eVzTPE0rgXyIiDOwFPgqt7IAUEolKKWSzOMVgLOIeJckT42mLPhwz4f2FqHCoZXFVYJDgjmZcNLeYpQYWxTGU8AmEVkvIqHARuBpEXEDQoqbsYgI8AlwSCn1Tj5hfM1wiEhnU96Y4uap0ZQV83bPs7cImgrOFwe/sLcIJabQMQyl1AoRaQq0MJ2OWAx0zy1B3t0wxj/2iUjW+vnnMKfqKqUWAsOASSKSjrFocISqSlMONJoqyrW433VhfHfkO6Z3mY75DVwpyVdhiEh3pdQmAKVUKrAnl78HcJ1San9xMjbTLvDKKaXmAfrTTaOpZExcO9HeIlRIktOTqeFcw95iFJuCuqSGisgWEXlRRG4Xkc4icrOIPCAiXwC/Aq7lJKdGU+EZ+stQEtIS7C2G3UlOTyYsLszeYlRIKnPrAgpQGEqpJzDsSEUCw4FXgSeBphjrL25WSm0vFyk15crRi0ftLUKl5N+L//Lm9jftLYbdeWL9E/YWocJyIfmCvUUoEQWOYSilYjHWWiwqH3E09uZI7BGGLR9mbzEqLWeTztpbBLuz+exme4tQYdkUsYmRLUbaW4xio82ba3KglUXJ2Ba1zd4iaCows/6eZW8RSoQtK701VZy95/dSv2Z9DsRoi/UajSZ/tMKobCRGwYa3oP9scCyd23fvintLJR3NtY1SStsfs4GQAyGMaTUGB6l8HTw2SSwiN4nIKBEZm/Ura8E01jn/zUTYvoi4fatKnNa6U+u0CZAyIDgkmG2R117X1I9Hf+S+VffZW4wKz1s73qq0i/gKVRjmFNq3gO5AJ/NXoL2RaxWlFB+EHiPucoksphRIZKyx/8LJ2MslTuu7I9+VOA2Ndd7ZadV4QZVlw5kNzPhrhr3FqDTsu1DxbUtZw5YWRkegm1JqslLqMfM3pawFszcZieeITUoF4FJqOslpGdl+yWkZXE5LzxNnx4EjjFh/Mx9881O+6cYkpaKU4lTkOVIuJxqOv0zhgyV3MXntZBskMxa6l2Q+d0xyDKQm4nB8Y7HT0BTMtTYe9Mgfj9hbhErF6vDV9hahWNiiMPYDvmUtSIUiah8Obzdl1uxpxF5Ko/VLq2n5otkFlJ7KC69Mp9WLebuE6u96By9J4pZY61/uJy5cYvbrz7Pis5lc92FTkt8wra3sCmFB8gk2Rlh5gV9JgUxDWWVkZpCmMgFITbduIWXfmXg2/xvF6j3WDZ1tjdxKzyU9Wf/PIrZVq3x9qJqKR1pG2bWoqzIp6cXaSsiu2PLG8AYOishqEfkl61fWgtmVc4f5xNOD1U3X8sXWf+jhsJfXnD7hp3/O8Pdnz/CW0wfc6rCDK5lXGLp0Ak1e+oSUKxn4H89SFDm//sPOJfL8xz/h/3Eb3nT+iNtPGYu7vCSJ5f+E5wj725fvsWx3BD/uOsOPSz6DmT6w9CEAntv0HPf7Gwt/Fm3KGS+LO+dtIva721m8tR93fNyTL/8JJTgkmNBPjW1L9oevB+CffxaR5lC5V51WdLZGbi1WvJT0FB774zFOJZyyLcK612CPlY+U9a/D7m/yulthQWgYX/9tY365mPePtt5THDp91YnQ06FW/fZHxBN+4VL5CmQDtkyzmVHWQlQUoi5F8djJxxhwtBsra9cCYPnG1ayt9jYAvZasYqHzH+AA9zuu5lDMEP5N+ov6/gfYcuwOarpUp0NKKplKsfGNIfRI/gNmxNP3nQ184fwW1R2vrvL8wsOdAZcu8dzeOzlo5gXQ99iLdI/ZwqC0cJo7nOaDWh54nfqdqO/vZsXlqxvSuF2JRSnF6gNR+Hm68vyOMSSmJQLPsLRuAntdXIAY3tj7GACPOe7mfeDXf06CG3xWQ0+QK2vG/z4+7z4I5w6DyoSMNPBvazXe1sithJ4J5VJcFJ8OWVJgHsEhwXRJTuHjqHPw0wTUC7EsOfgnvRvdRN0/ZxuB2ha+UGzOqiMAjOpyXSEh8/LZgc+KHEdj8Ni6x9g1Zhe7TyUSXN8TF2dHAO5/fzleksTvr+e0yRV2MYyfwn7i6Y5PIyJkpCaxY/nDdBnwP3CrU+by2mKt9k8R8cEY7AbYZu7nXeU4HnccgJXVrq5UvVEO0fW6AC45ONDz339p6BjBG161ePTiIaabX/neDhd4ZeeDxPj5ALDp5Ho8M42uo92n4wBQZqtDAU/V82aNWw3m1PEC4EtPj+z8Rvj7klLtIMb3okUFuJxz97Jx7p/QZrGx7brTsQmkBxqy1ONivuVTSnHa4V+br4em5ASHBDOyxUimdprK4b/exmP9G7hnZlIrMxNmxFuN4xB3GgCXc//A/9qS2Pxp3vt+MI8N+hKHam55wv/t6pJ9/P2/S3ht1yym/zKSLGtOX2w9yZiu5p7jG9+B5gOgXktIiYekc0Q6OeFb93uizuddtJmekcmc1Ud4+OYm1KlZHYCYY7u46dNDUGczmx5+pQRXRwPw0YZjLDw5nCuJrXA8dz/+tVzZXH0K1SQDsFAYe79n4vYXiXZyYmyDfvj4tuXz9f9l7qW9fLDqMbrf+F/wDQYHxzKT1ZY9vf8DvAmEYvS1vC8izyilfigzqezEm6sPQ65r7VLzEJccjJ67nddtoZNLA8B4yV858y3OHhBWrRqkXx0z6N4wgM8io+mYksqFA38y2fE3PGocIdj/Oj6IOscat/ytVYZVq1aonMGNr6PfpauzpNIDP8o+nlJvGm+4elmN9++esaR51bLqpyk7vjn8Dcm7V/KzSxw08KdWRgYbT0UQEvoXb52cwEsXYhiWeImw0ZupvmosF1OioG4dNtZwZc6VOL6IngNA+3eb0M01AIfYMH6qeTtud7ycnccYPx++iIzmVOxhAJydY/gXZ4YG+MGRO1j1y71cavwZHVJSGfPnTDLHLqPJL0+iLhxhWOPGXPLO4I6UVCLWhFO/36MApFzJoOWrX6DSvDkRe46tGY8ywfc2+uz8nIYNGxBZPZ3eP/Qq/wtaxVh4cjgAzu4Hwf0ZooDJNeowMS4e9/DjNKzfkP0R8QSGziPa03hl9109hm/6buJkqrE90N6z2+n+0S1w83+h9/Qyk9WWLVr3AP2yWhUiUhdYq5S6ocykKiHF3aI18NV3qXHdpzncfNPTiXIqfvfNB1Hn8MzI5HuPmvzkXrPwCJprgoVR53imrjeJjsbHSIfkFHZatBTyY9mZs4zx8yHBMe9XZKfkFE47O9lcXz8/G819/j453ByUoq3jEF7ociszN+1lh+MHNE1LwzvVlb/cM/JJSVOW1M1oTK2MIzwbc5EH/K7eL7eEQBpVP8iB6kbLb98Jcwwqn5ZrYdiyRastCmOfUirY4twB2GPpVtEorsJ4fVYfvq5fJXvbNBpNFWdRZDSdUlJxLEOFYcunyCoRWQ1kTbe4B1hRLIkqOFpZaDSaysp4Px/cMzLZUoZ52DLo/YyIDMXYUhXgI6VU/ivTNBqNRmMXsro4ywqbOjuVUkuBpWUqiUaj0WgqNAXt6b1JKdVdRBLJskdhegFKKeWRT1SNRqPRVEEK2qK1u/nvrpTysPi5l5ayEJH+InJERMJEZJoV/+oi8p3p/7eINCqNfDUajUZTdGy1VluoW1EREUdgPjAAaAWMFJFWuYI9CFxUSgUB7wJvlDRfjUaj0RQPW0ZIWlueiIgT0KEU8u4MhCmljiul0oBvgUG5wgwCQszjH4A+UhIzrRqNRqMpNgWNYTwLPAe4ikhCljOQBnyUX7wiUB84bXF+BuiSXxilVLqIxGPYy7iQKxwiMgGYAODj40NoaGgpiKjRaDSVi7J89+WrMJRSrwOvi8jrSqlny0yCUkIp9RGmIuvYsaPq2bNn0RMJKTyIRqPRVGSK9e6zEVvWYTwrIl5AU8DFwn1DCfOOABpYnAeYbtbCnDG7wjyBmBLmq9FoNJpiYIvxwYeA/8N4oe8GugJ/Ab1LmPd2oKmINMZQDCOAUbnC/AKMM/MbBqxThdky0Wg0Gk2ZYMug9/9hmDY/qZTqBbQD4kqasVIqHXgUWA0cApYopQ6IyCsicpcZ7BOgjoiEAU8CeabeajQajaZ8sGWld4pSKkVEEJHqSqnDItK8NDJXSq0gl10qpdSLFscpwPDSyEuj0Wg0JcOWFsYZEakF/AysEZFlgPUNozUaTYXiliS937am9ChUYSilBiul4pRSM4AXMLqJ7i5rwTSaqsRXZ6PKPc89J06x84r1bWA1FY8uySn2FqFQClQYIuIoIoezzpVSfyqlfjEX2lU5toWf5rPI6ALDzI0+X07SFMzI+ER7i6ApAm1S02iVmmrV77awnvzPrFeZabVz+PW8dJmOuV4k7hmZ/F+sMYzonGsOyCeR0YyLT7BwsX2da7fLyVbdv40of2V3LZIJZKT4UC1Tse/EKR65WOKh4lKnQIWhlMoAjohI0XeGr4QsqDaZjik5H+oH4nJuRlI7w/quY5ZbppY2K09H5HoJwH9jr+7d/fnZq0pu14lT3JBi/cWkKX+6JKfwcWQ0+9y6EpzkajXMpQwvel1O5uGjN3Dp2DPsPXGKm82X9y2JznRKvpInzoPxCew5cYrhR2/K4d45JZUJMak8eLQDL1x5gJ41+9r05eqamckH0edZdiyVvVk7twEvXIildVqV/D6scPyV2ZLLJx5nx0ljPfPDcQk57kUW7kcn8sepCDonp/DnyTNMvBjPCxdiy0VGW8YwvIADIvKHiPyS9StrwezBU1Nf43CtW3K43R+fyE3mw/vq+Rh8cimM96POMz4unnfO5Vl8Xir8fiKWgPQMno69+rXxd/hpnDC25Hw7+jxemVdlcgbez9UKap6qH3h78VHUObqkpNLSz5NeLf+bx18pYWVmZ9Y2fYH/pQ8DBAFuNF/ytYd9z9tJjwPQPsVwc0Aht73Onnavce+Tc7PTmhd1jgwleLxwksdf+5yZM9/l9RF38XHUOXo6Xt3LvXFaXgX065lIBJh65WEE2HTyDG+eu8CtDx3MEc4r0Y+0CD0PpSxo5utG1v0Ho20owA8RkQxIusTf4acZFXUHZ9MbUS8jg0+izlE7M5NH4uL5T2IS805lwMl7y1RGWxTGC8AdwCvA2xa/qoeDA1Ftn2TjPRvpY7YYamVmZt9A74wM/NMzWH/qTHaUnsnJTLlotEKyvuQet/j6Ly57T5xi34lT1H5kI9RqaMiSWgOAaamTAfg06hxr4sfgkZmZHe+C8mBlWk+6O3plu02LvYh7RiZtdMujXJkbfT77AXNycafbgHtpXauZ4XBoOolHXibpyAxAaNp/EuJk7M18LNOPe29+lXXD19E7MJi3O7VhpVdfhkXVB8xOphsn027QY1xXp0Z2fusT/kOz1MVgpgNAzXrw9FHeuWcNK+5axt/hp1liZTylnvkhtF214IG0p/HMzKT/pcvU8vTMEa5fm8F8OepR1g1fx7o+n9BMf4yUiM7JKdS+5A2Ah4sT6566hYiA27P9l2XcRPO0K8w5H0MNpcjAzWo64Zk+jLv0Ju/f80CZymvLSu8/RaQh0FQptVZEagB5d6CvQtRyqcVcixZDVj/xX6odjdRRAjKstCYGvsXsVf/lF3c37o9PZG5tr7xhcnElIRhnj3053C6deASf6mEIiwCoXrcJTNoMaZc4PWsL4pjCb5k1+V9PT2h2G2/63UDXZ4NZcfpx/NIzeDZ9As8+N5PTfz3Npoj1AHRMSaXbsYH06dSILWfe4if3msW9NJoi0ODGJ6DlEDj4M3R6CIDPbv+S+NR4PJ3r8uGGY7Tw9cDD1YmGddw48toAGk37jXtd5rO1Yx/qmunUcnEgoP+71Lg1Fr67Jd/8Rj42i1anrfR716yHM9DAqwnc/SHUbQ5rxgBw+fRYejYNoHmKC14kMveetvx1rAHsf8tqHo28a9KpkTnO4upNdY8ASNVbGxeHx2Mv8mB8Ij8O/4yXdkwik0ya1K0JD30NGem88+LDfJwxkEEv/wpfDoXj6+na83Y+/ulsnrRSqMaU3kH0bF6vTGW2ZaX3eAyjfrWBQAyDgAuBPmUqWQXipZhYmly5QvfbQoiv04DxH3wPfJAzUDU36ng04IE4Y8ZxjROjudz4y3zT/PFMJP2SXsWh2gUcXSJ5qdV0Gvt1poGnP6FHzsOvi64Gru4O1d3ZMnUAN81eRwZAz6nZ3uepRYP0DDKU8H1GT6YpRY8W9/BlxHo6XTa+AL/P6MkAzxq8sjuWvpcu84jv1Yo1MOkSK2pa/3LRFI+pnabSrNVo4+TmZ7LdXZ1ccXUyxjIe79ssT7w/n+lJLddqVtPMMnKQexjb3dmdujXq0tzXnea+7gULdsM9OU5/e+hhGnu70fyfVURRh7vb1Sc4wBP2Q1KdYHJ/Wrg5W9QTEcTdVyuMYuKsgC6TCKpnZXshRyf+lzGEB7o1BgdHGPszAH2B8C7t4NIxeDPQCHvLVMT3Tv6ved76VNrYsnDvEQxT5H8DKKWOikjZqrEKhndGJu9FfkAX9+tofZ03Qwf2p97fr4FUgxtGQexxuH4osv1jMBVGekqDAtP86PL9oJzJTPPG0SWSzs26cZ2nEec/HRvAr3nj+NeyPmj63IAWsB6Uxauks38X0mK7siOmE6H9Agm/pU+2Fcubk1MYnzCWRR6LjfiJGazQjY5SZXSWsigiDevkr7idHZ0BaKpyPrZbRm0pcj4L+izgVOIpWvjmfVkF1q0JE0Kp6dXYcHjyEBP2LeKjsB/wqeGTI2wjz0bsvbCXDnV6sTNmfZHluJaR/q9DqzG0zsxgZIuRjG01Nod/+Ozb84kJuHlfPe71HKWyktoGbFEYqUqptKxtKEwjgFXfnpNrbUiOhfHree7nA3AaMs1SP9SjCTRaBp4B4OF3Nc71wyBiJwAxeNLkUh3Ou121ldjEswlz/G/D9fcXGJ/ZBICdDy9iz/k92coim9vfgXTbxhwevLkpxI1m5FYjTbfqTjg5OLLu/v/x9d8nueXmq9XpibRJvFvtA1q3u4mBZ9ezIvk0nu1GQ1SVnMdQpfCo5sHHbR6nZaOSN+57BPTIcf7Xs72JTrCob/7tLDL2Z+KNzxF83S10q98tR7znuz5P/0b9iUuNY+cmrTBsobFnYxq6N+TuIGM5m6ODI891ea7oCT15CBLydk+VJbYojD9FJGtfjH7AZGB52YpVARj2KWx8G/xuYPTgIA78uJf2Da/ONKFBp7xxuk6C1YYl+Ffvvp79Z+by2uDWsPRB0pvdRvUbRuIgDkQFjuTIm1tof10t3Kq5cVP9m/Km1elB22UVgUHz+WKgMXDp4mwMMdWv5cozt7XIEfSnzB6sSOnC2x6Neb36MF777QloXIvWdVpzIOaA7Xlq7EKXdkWoF0XAz9MVP0/rLVgAZwdnejbomcfd1cmVHgE9WH6s6r8SSovZPWbTqk7uzUWLgYe/8StHbFEY0zC2St0HPIxh++njshSqQhDYy/gBrfw9WPZo98LjmK2wSKcGjOnaEDBmN/GfxThbBPOt48Xbw2/gluZ18yRRGGueuJnTF62v+chSFAUx4HpfVu6PQhAcOozDITMdOtzHvCsJ9FrSq8jyaDSW9GzQk9DTofYWo0JTKsrCTtgySyoTWGT+NIVwfuJ+vNw9Cw03tENAsdJv6uNOU59CBjYL4IHujVm5P4pOjb2MwbQuEwDwdvIuJKZGUzg1nGoUHuga5t6WZbtOoqwpaIvWfRQwVqGUalMmElVy6voWPNhtbzo1ql3wYJqmxDze/nF7i1DuZI1xavInqFYQ0zpX7h0aCmph3FFuUmgqDHcF3sUvx/QAeEmoV+OamkSYB58aPkRfLtgm27VIsQa2KxgF7emdbcI818I914LiaSov+8YZiwhndp9JcEiwnaWpfHTz74ZndU/6Nexnb1HKnb7X9WVD4w082eFJnByc+HT/pyw+uNjeYlUo2tVrV3igCk6hpkHMhXs/AB+aTgEYe2NoNBoLAtwDeOPmN3BxcrG3KOWOi5MLc26eg4+bD3Vc6/BMp2cKj3SN4eRQ+b+zbbEl9QjQDUgAY+EecG23uTUaK9R01qsfNVUbWxRGquX+F9fMwj2NpohMvGGivUXQaMoUWxRG7oV733MtLNzTaIpAQM2Aa7IrSmMbvRv0trcIpYItCmMacJ6cC/eeL0mmIvKmiBwWkb0i8pO5Z7i1cOEisk9EdovIjpLkqdGUJW3q6lnmuflvp7z7f1yrVJX6YYvCcAU+VUoNV0oNAz413UrCGuB6cy3Hv8CzBYTtpZRqq5TqWMI8NUXg50F6XkNRmHHTDHuLUOEY02qMvUWoMNzX+j57i1Aq2KIw/iCngnAF1pYkU6XU70qpdPN0K8bMK00FIrBWIMsGLbO3GJWGLJPlGk1uqjlUw9GhamwhZMs8LxelVFLWiVIqydxEqbR4APguHz8F/C4iCvhQKfVRfomIyASMfTvw8fHJNuVdVJKSkoodt6JT1LJFXcm7M5smL67iWqZ1pirXyWuBwbUGV5n7Z4vCuCQi7ZVSuwBEpAOQXFgkEVkL+Frxmq6UWmaGmQ6kA1/lk0x3pVSEuf/GGhE5rJTaYC2gqUw+AujYsaPq2bNnYSJaJTQ0lOLGregUtWypGanM/HJm2QlURfBx9ynTOlOp62SIvQWwP8Etg+kZ1NPeYpQKtiiMx4HvReQsxmZfvsA9BUcBpVTfgvxF5D4M8yN9VNZWYnnTiDD/z4nITxgbOVlVGJrSp7pj9cIDaTQFcH2d69kfs9/eYmhKCVus1W4XkRaQvanTEaXUlZJkKiL9gf8CtyilrNrqFhE3wEEplWge3wq8UpJ8NZqyQBveyx99baoWtpgGeQRwU0rtV0rtB2qKyOQS5jsPcMfoZtotIgvNvPxFZIUZxgfYJCJ7gG3Ab0qpVSXMV6PRaMoVVYXWOdvSJTVeKTU/60QpddG0L7WguJkqpYLycT8LDDSPjwM3FDcPjUajqQg09GhobxFKDVum1TqKRbtSRByBamUnkkajqSpM7zLd3iLYnWDvqmP52RaFsQr4TkT6iEgf4BvTTXMN4FPDx94iVHi6+XeztwgVltbere0tgt2pClZqs7ClJFMx1jdMMs/XoLdrvWb45e5f6PJ1F3uLUWFZM2wN3q56e1uNdVrWbmlvEUqVQlsYSqlMpdRCpdQw0zTIQeD9shdNUxGo4az3aC4IeScozQAAD/NJREFUXzffKvUFWRbUdqltbxHsxrw+8+wtQqliS5cUItJOROaISDjG1NbDZSqVRqOpMvw2+Dd7i2AX5jSYU+W2681XYYhIMxF5SUQOY7QoTgOilOqllNItDI1GYxM1q9VkWLNhxY7fuo5t4yD5bYH6eo/Xi533uFbjso8X9l1YpLiuDlXPvlhBLYzDQG/gDqVUd1NJZJSPWBqNpirxSNtHih3X29Wb+jXrFxhm/X/Ws3jA1T3EezXoBcC0ztO4o8kd/HjXjzblNbrl6OzjF7q+wMiWIwHwqu5Ft/p5JzcMaTrEpnSrCgUpjCFAJLBeRBaZM6T0sk2NxqSqbIpTHjhIwb3fo1qMYteYXVb9FIp8rAcB8H/t/y/PxAOPah4ANPJoBEBTr6b8NfKvbP+VQ1bi5+aXI041h2pM7TyVm/xvAqBtvbbUr1mfd3q+w4+D8iqcBu4NeLz949nnXXyr/uSQfEfrlFI/Az+bZjkGYdiUqiciHwA/KaV+LycZNZoKiTZ7YTu1XWoz48YZhCeE06tBL8atutrVs2/cvuzjz277DIWik28n/jz9J4+uezRPWu/3fp/zyefpUb8Hq8NXM7LFyDxhpnWeRvPazbNf/mB0jWUR4B7A78N+Z3vUdgCiLkVld2nN7jGb1eGraebVDIB+DftZLdOKIStyyHw26Sx/R/1t8zWpjNhiS+oS8DXwtYh4AcMxptpqhXGNMKDxAFaeWGlvMSocWd0eGtsY2mxo9vHktpNZsDuvsYiOvlf3Sctaw3Fvi3t5+a+XAfig7wd0r989O8y41uOwRs1qNW3awKmTb6c8bl4uXoxoMcJqePdq7iSmJVqVeVnY1f1j2tdrX2jelZEizQdUSl3EMCGe774UmqqHs4OzvUWokNwZeKe9Rai0OErhGwp5u3pntz5a1mnJ2UtnbVrX4O7snq/fN7d/w+5zu20XNBdbRm7h57CfrS5ozWpx3tnkTmb1mFVl9sCwRE8g1xRK7r5ejUFh/fKa/Onq15X3/7F9suWs7rP49+K/1HGtU2C4H+78ocAw13tfz/Xe19ucrzXuDrq7QP+qZGwwN7rGawrl4RsetrcImipGm7ptmN5lOoNqDbIpfA3nGrSt17bQcM1rN7fbynsx5wRphaG5pnF2cNY2pTSlzogWI+jrWeA+a5oKhlYYGpt4tdur9hZBo6nQZO1QWcOp6prT0WMYGpu40f9Ge4ug0VRo+lzXhyntpjCq5Sh7i1JmaIWh0Wg0pYCjgyPj24y3txhliu6S0mg0Go1NaIWh0Wg0Gpuwi8IQkRkiEiEiu83fwHzC9ReRIyISJiLTyltOjSY/XrnpFXuLoNGUO/Ycw3hXKfVWfp7m3uHzgf9v7+5jrKrvPI6/P8wMnWGQp8JMhwflebpBBGQKUgQHqYpQrVBkYc0u7aYdSSS7/aPZVkm7dk0TtbrZaLPdtSsJ9kHadBdrWpVqy6xs//ChrHV8qCshNGVqZRsjdrJN68N3/7hnppfhznBmuHPPvXc+r4TMOb9z7r3fX87lfnJ+99zfuQI4ATwj6eGIeKlUBZoNZPOCzVmXYFZy5TwktQI4GhHHIuKPwH5ykyCamVkGsgyM3ZKel7Q3mdSwvxnkbtrU60TSZmZmGRixISlJTwAfKLBpD/A14DYgkr93A399jq/XAXQANDc3D3vir56enqqcNAzOvW8z6mbQ/XZ38QqqYKV8j/g9WZmqsW8jFhgRkeo3/5K+DvygwKZuYFbe+sykbaDX65tFt62tLdrb21PXmq+zs5PhPrbcnWvf9j+xn+5uBwZQ0veI35OVqRr7ltVVUvnTn24GXiiw2zPAAklzJI0FtgMPl6I+K2zZtML3TB5ttrcWvleCWbXL6iqpOyUtJTckdRy4EUDSdODfImJjRLwjaTdwEKgB9kbEixnVa8CSpiVZl1AWVrZU/604zQrJJDAiouCtsCLi18DGvPVHgEdKVZcN7pKWS7IuoSx45l4brcr5slqzsjR30tysSzDLhAPDzMxScWCYmVkqDgyzIeq9FafZaOPAMBuicXXVe0c1s8E4MMzMLBUHhpmZpeLAMDOzVBwYZmaWigPDbAiWNy/PugSzzDgwzIZgy4ItWZdglhkHhpmZpeLAsCGZO3F0z6NUo5qsSzDLjAPDhmT3st1Zl5Cp1dNXZ12CWWYcGDYk62aty7qETEmeFsRGLweGDUntmKzuuWVmWXNgmJlZKg4MsyEYXzc+6xLMMuPAMBuCmjG+SspGLweGmZmlksk3mJK+A7Qmq5OANyNiaYH9jgO/A94F3omItpIVaWZmp8kkMCLiz3uXJd0NnBpk93UR8duRr8rMzAaT6TWSyl3Uvg24PMs6zMzs7LK+qH4N8HpEvDrA9gB+JCmAf42I+wZ6IkkdQAdAc3MznZ2dwyqop6dn2I8td8Xq24SaCbz17lvnXlAFyuK94fdkZarGvo1YYEh6AvhAgU17IuL7yfIO4MFBnubSiOiW1AQ8LukXEfFkoR2TMLkPoK2tLdrb24dVd2dnJ8N9bLkrVt+mPjSVt06NzsDI4r3h92Rlqsa+jVhgRMRHBtsuqRbYAgx4g4GI6E7+npR0AFgBFAwMK52VLSs5dupY1mWYWYlleVntR4BfRMSJQhslNUo6r3cZuBJ4oYT12QCuuOCKrEswswxkGRjb6TccJWm6pEeS1WbgvyT9HHga+GFEPFbiGq2AhZMXZl1CUWycszHrEswqSmaBERGfiIh/6df264jYmCwfi4glyb9FEfHlbCq1/hpqG85oW3/++pLW0Dq59ew7ncUda+8oQiVmo4d/6W1DNrZmLEf+8giXzbwMgKZxTdy2+jamNUwb8DG3r7m9qDXsu3ofWxduHXD7sqZlp63PmziPey+/t2/9mrnXDPk1185cO+THmFWTrC+rtQpVN6aOr67/6mltP9n2ExbvW1xw/01zN3HoV4c4ePwgAFfNvqpv+Wy+cfU3qBtTx41P3MipP5ziC5d8gca6xoJ3v1t//npuXnEzzY3NHDx+kOXNyzl84jAb5mygobaBgx8/yCtvvMK689ed8Ro3H76ZBzc9yJrvrClYx4JJC1LVa1atfIZhRdXS2ALAriW7AJhSP4Wn/uIpAO667K6+/fKXBzNv4jyWNi1l0dRFfW1XXnAlANtat52x/56Ve2hubAZyoTS1YSqbF2zuG0abPn76GWEBsLRpKY9+/FEm1U+ivqYegAeufoCf7vhp3z7Xzr82Vc1m1cpnGDYirpt/HXVj6ti6cCvj6sb1tTfUNvCpxZ8qymssnLyQQ9sOse6761jRuIL7t95flOeded5Mjr55lMa6RiaMncAtK29hVcsqZk+cXZTnN6tUPsOwovrkhZ8EcmcWHRd1MKV+ymnbn77haTou6uhb37VkFweuPXDaPl9c9cWCz/3pxZ8GoLGusa9tasNUvnfN99j+/u1Fqb+QHR/c4bAww4FhRbbjgzvo2tlV8Eqq/rp2dnHT0puYP3l+X9vFTRdz/cLrC+6/c9FOunZ2UVdTd1p765RW6lRX8DFn86UPf+mM4bHeL9ObxzUP6znNqpUDw8rKPZffA/zpbGKkbVmwhatmX3Va2w1/dgNdO7uY+L6JJanBrFI4MKys9H5I+0d1ZuXHgWFlaeZ5M2ka18RnP/TZrEsxs4SvkrKyVF9bz4+v/3HWZZhZHgeGlYWvrP0KE8ZOyLoMMxuEA8PKwoY5G7IuwczOwt9hmJlZKg4MMzNLxYFhZmapODDMzCwVB4aZmaXiwDAzs1QcGGZmlooDw8zMUlFEZF1D0Un6X+CXw3z4VOC3RSynnLhvlcl9q0yV1rcLImLaYDtUZWCcC0nPRkRb1nWMBPetMrlvlaka++YhKTMzS8WBYWZmqTgwznRf1gWMIPetMrlvlanq+ubvMMzMLBWfYZiZWSoODDMzS8WBkZC0QdIrko5K+nzW9RSTpOOSuiQ9J+nZrOs5F5L2Sjop6YW8timSHpf0avJ3cpY1DtcAfbtVUndy7J6TtDHLGodL0ixJhyS9JOlFSX+btFf8sRukb1Vx7PL5OwxAUg3wP8AVwAngGWBHRLyUaWFFIuk40BYRlfQjooIkrQV6gAci4sKk7U7gjYi4PQn7yRHxuSzrHI4B+nYr0BMRd2VZ27mS1AK0RMQRSecBPwOuAz5BhR+7Qfq2jSo4dvl8hpGzAjgaEcci4o/AfuBjGddkBUTEk8Ab/Zo/BuxLlveR+89acQboW1WIiNci4kiy/DvgZWAGVXDsBulb1XFg5MwAfpW3foLqOuAB/EjSzyR1ZF3MCGiOiNeS5d8AzVkWMwJ2S3o+GbKquCGb/iTNBpYBT1Flx65f36DKjp0DY3S4NCIuBq4GbkqGPqpS5MZYq2mc9WvAPGAp8Bpwd7blnBtJ44F/Bz4TEW/lb6v0Y1egb1V17MCB0asbmJW3PjNpqwoR0Z38PQkcIDcEV01eT8aRe8eTT2ZcT9FExOsR8W5EvAd8nQo+dpLqyH2gfisi/iNpropjV6hv1XTsejkwcp4BFkiaI2kssB14OOOaikJSY/JFHJIagSuBFwZ/VMV5GNiZLO8Evp9hLUXV+2Ga2EyFHjtJAu4HXo6If8zbVPHHbqC+Vcuxy+erpBLJJW//BNQAeyPiyxmXVBSS5pI7qwCoBb5dyX2T9CDQTm7q6NeBvwceAr4LnE9uWvttEVFxXx4P0Ld2ckMaARwHbswb868Yki4FDgNdwHtJ8y3kxvor+tgN0rcdVMGxy+fAMDOzVDwkZWZmqTgwzMwsFQeGmZml4sAwM7NUHBhmZpaKA8NsEJLenzfb6G/yZh/tkfTPI/San5H0V4Ns/6ikfxiJ1zYbjC+rNUupFDPHSqoFjgAXR8Q7A+yjZJ/VEfF/I1WLWX8+wzAbBkntkn6QLN8qaZ+kw5J+KWmLpDuTe5A8lkwbgaTlkv4zmQTyYL9fAve6HDjSGxaS/ia5z8LzkvZD35xLncBHS9JZs4QDw6w45pH7sL8W+CZwKCIWA78HNiWhcS+wNSKWA3uBQr+4X03ufgq9Pg8si4iLgF157c8Ca4reC7NB1GZdgFmVeDQi3pbURW56mceS9i5gNtAKXAg8nhtRoobcDKb9tZC7n0Kv54FvSXqI3BQovU4C04vZAbOzcWCYFccfACLiPUlvx5++HHyP3P8zAS9GxKqzPM/vgfq89U3AWuAaYI+kxclwVX2yr1nJeEjKrDReAaZJWgW56bAlLSqw38vA/GSfMcCsiDgEfA6YCIxP9ltIFcx+apXFgWFWAsmtf7cCd0j6OfAc8OECuz5K7owCcsNW30yGuf4buCci3ky2rQN+OLJVm53Ol9WalRlJB4C/i4hXB9jeTG6a+vWlrcxGOweGWZmR1EruXtdPDrD9Q8DbEfFcaSuz0c6BYWZmqfg7DDMzS8WBYWZmqTgwzMwsFQeGmZml4sAwM7NU/h8v9glw8CWfOQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     }
-    }
    ]
   },
   {
@@ -547,6 +534,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -555,17 +543,8 @@
     "id": "03td9T_yeIFn",
     "outputId": "9d282cb6-2681-4b6a-a12f-91262d836c1f"
    },
-   "source": [
-    "n_steps = 100 #number of points to plot\n",
-    "n = int(df.shape[0]/n_steps) #number of data points to use in windowing\n",
-    "df_rolling_peak = df.abs().rolling(n).max().iloc[::n] #finds the absolute value of every datapoint, then does a rolling maximum of the defined window size, then subsamples every nth point\n",
-    "\n",
-    "df_rolling_peak"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -687,13 +666,22 @@
        "[101 rows x 3 columns]"
       ]
      },
+     "execution_count": 97,
      "metadata": {},
-     "execution_count": 97
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "n_steps = 100 #number of points to plot\n",
+    "n = int(df.shape[0]/n_steps) #number of data points to use in windowing\n",
+    "df_rolling_peak = df.abs().rolling(n).max().iloc[::n] #finds the absolute value of every datapoint, then does a rolling maximum of the defined window size, then subsamples every nth point\n",
+    "\n",
+    "df_rolling_peak"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -702,20 +690,8 @@
     "id": "6uubzmj7X8-V",
     "outputId": "3050a9a0-88ab-4451-9de6-67d82648bbdd"
    },
-   "source": [
-    "fig = xp.line(df_rolling_peak)\n",
-    "fig.update_layout(\n",
-    "    title=\"Rolling Peak\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('rolling_peak.html',full_html=False,include_plotlyjs='cdn')\n"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -751,8 +727,19 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "fig = xp.line(df_rolling_peak)\n",
+    "fig.update_layout(\n",
+    "    title=\"Rolling Peak\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('rolling_peak.html',full_html=False,include_plotlyjs='cdn')\n"
    ]
   },
   {
@@ -769,6 +756,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -777,23 +765,8 @@
     "id": "emiCK-7vYJP0",
     "outputId": "d9aa4fd8-b9ad-4eca-db73-93c962f4ce44"
    },
-   "source": [
-    "df_rolling_rms = df.rolling(n).std().iloc[::n] #does a rolling standard deviation of the defined window size, then subsamples every nth point\n",
-    "\n",
-    "fig = xp.line(df_rolling_rms)\n",
-    "fig.update_layout(\n",
-    "    title=\"Rolling RMS\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    "    template=\"plotly_dark\"\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('rolling_rms.html',full_html=False,include_plotlyjs='cdn')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -829,8 +802,22 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_rolling_rms = df.rolling(n).std().iloc[::n] #does a rolling standard deviation of the defined window size, then subsamples every nth point\n",
+    "\n",
+    "fig = xp.line(df_rolling_rms)\n",
+    "fig.update_layout(\n",
+    "    title=\"Rolling RMS\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    "    template=\"plotly_dark\"\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('rolling_rms.html',full_html=False,include_plotlyjs='cdn')"
    ]
   },
   {
@@ -845,6 +832,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -852,25 +840,25 @@
     "id": "EiNO0_vDKKsy",
     "outputId": "21220e37-f7b0-4aa7-e0ec-12183c3390cf"
    },
-   "source": [
-    "df.abs().max(axis=1).idxmax()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "8.659936"
       ]
      },
+     "execution_count": 100,
      "metadata": {},
-     "execution_count": 100
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.abs().max(axis=1).idxmax()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -879,28 +867,8 @@
     "id": "vbsRy0N0aY1E",
     "outputId": "bfdafee7-7c6e-4ee5-cedf-a1fe096580c7"
    },
-   "source": [
-    "peak_time = df.abs().max(axis=1).idxmax() #get the time at which the peak value occurs\n",
-    "d_t = (df.index[-1]-df.index[0])/(len(df.index)-1) #find the average time step\n",
-    "fs = 1/d_t #find the sampling rate\n",
-    "\n",
-    "num = 1000 / 2 #total number of datapoints to plot (divide by 2 because it will be two sided)\n",
-    "df_peak = df[peak_time - num / fs : peak_time + num / fs ] #segment the dataframe to be around that peak value\n",
-    "\n",
-    "fig = xp.line(df_peak)\n",
-    "fig.update_layout(\n",
-    "    title=\"Time History around Peak\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    "    template=\"plotly_white\"\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('time_history_peak.html',full_html=False,include_plotlyjs='cdn')\n"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -936,8 +904,27 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "peak_time = df.abs().max(axis=1).idxmax() #get the time at which the peak value occurs\n",
+    "d_t = (df.index[-1]-df.index[0])/(len(df.index)-1) #find the average time step\n",
+    "fs = 1/d_t #find the sampling rate\n",
+    "\n",
+    "num = 1000 / 2 #total number of datapoints to plot (divide by 2 because it will be two sided)\n",
+    "df_peak = df[peak_time - num / fs : peak_time + num / fs ] #segment the dataframe to be around that peak value\n",
+    "\n",
+    "fig = xp.line(df_peak)\n",
+    "fig.update_layout(\n",
+    "    title=\"Time History around Peak\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    "    template=\"plotly_white\"\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('time_history_peak.html',full_html=False,include_plotlyjs='cdn')\n"
    ]
   },
   {
@@ -952,9 +939,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "Ihz-UEolbyNT"
    },
+   "outputs": [],
    "source": [
     "def get_psd(df, bin_width=1.0, window=\"hanning\"):\n",
     "    d_t = (df.index[-1]-df.index[0])/(len(df.index)-1)\n",
@@ -967,12 +956,11 @@
     "    df_psd[\"Frequency (Hz)\"] = f\n",
     "    df_psd = df_psd.set_index(\"Frequency (Hz)\")\n",
     "    return df_psd\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -981,15 +969,8 @@
     "id": "9iXUTdMfodir",
     "outputId": "b5e8f5d9-e5a0-4e18-bd01-5ae033d62d76"
    },
-   "source": [
-    "df_psd = get_psd(df,bin_width=4) #compute a PSD with a 1 Hz bin width\n",
-    "df_psd.to_csv('psd.csv') #save to a CSV file\n",
-    "df_psd"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -1111,13 +1092,20 @@
        "[626 rows x 3 columns]"
       ]
      },
+     "execution_count": 121,
      "metadata": {},
-     "execution_count": 121
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df_psd = get_psd(df,bin_width=4) #compute a PSD with a 1 Hz bin width\n",
+    "df_psd.to_csv('psd.csv') #save to a CSV file\n",
+    "df_psd"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1126,22 +1114,8 @@
     "id": "jE2ZLBW-aeZr",
     "outputId": "2ff24aca-75ef-4434-c45d-37e988e426ce"
    },
-   "source": [
-    "fig = xp.line(df_psd)\n",
-    "fig.update_layout(\n",
-    "    title=\"Power Spectral Density (PSD)\",\n",
-    "    xaxis_title=\"Frequency (Hz)\",\n",
-    "    yaxis_title=\"Acceleration (g^2/Hz)\",\n",
-    "    xaxis_type=\"log\",\n",
-    "    yaxis_type=\"log\"\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('psd.html',full_html=False,include_plotlyjs='cdn')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -1177,8 +1151,21 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "fig = xp.line(df_psd)\n",
+    "fig.update_layout(\n",
+    "    title=\"Power Spectral Density (PSD)\",\n",
+    "    xaxis_title=\"Frequency (Hz)\",\n",
+    "    yaxis_title=\"Acceleration (g^2/Hz)\",\n",
+    "    xaxis_type=\"log\",\n",
+    "    yaxis_type=\"log\"\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('psd.html',full_html=False,include_plotlyjs='cdn')"
    ]
   },
   {
@@ -1192,16 +1179,18 @@
     "\n",
     "The nice thing about a PSD (in addition to the easy control of the bin width) is that the area directly relates to the RMS level in the time domain. The equation is as follows.\n",
     "\n",
-    "$$ g_{RMS}=\\sqrt{\\int PSD(f),df} $$\n",
+    "$$ g_{\\text{RMS}}=\\sqrt{\\int \\text{PSD}(f)\\ df} $$\n",
     "\n",
     "Let's demonstrate by quickly using the PSD just calculated, integrating, and taking the square root and compare to the values we calculated from the time domain."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "MIikvleC5BIe"
    },
+   "outputs": [],
    "source": [
     "def rms_from_psd(df_psd):\n",
     "    d_f = df_psd.index[1] - df_psd.index[0]\n",
@@ -1209,12 +1198,11 @@
     "    df_rms = df_rms*d_f\n",
     "    df_rms = df_rms.cumsum()\n",
     "    return(df_rms**0.5)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1223,24 +1211,8 @@
     "id": "5w283bcf5MVd",
     "outputId": "f4b6f52c-54fd-445f-d135-7bdf634e9360"
    },
-   "source": [
-    "df_rms = rms_from_psd(df_psd)\n",
-    "\n",
-    "fig = xp.line(df_rms)\n",
-    "fig.update_layout(\n",
-    "    title=\"Cumulative RMS\",\n",
-    "    xaxis_title=\"Frequency (Hz)\",\n",
-    "    yaxis_title=\"Acceleration (g RMS)\",\n",
-    "    xaxis_type=\"log\",\n",
-    "    #yaxis_type=\"log\"\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('cum_rms.html',full_html=False,include_plotlyjs='cdn')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -1276,8 +1248,23 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_rms = rms_from_psd(df_psd)\n",
+    "\n",
+    "fig = xp.line(df_rms)\n",
+    "fig.update_layout(\n",
+    "    title=\"Cumulative RMS\",\n",
+    "    xaxis_title=\"Frequency (Hz)\",\n",
+    "    yaxis_title=\"Acceleration (g RMS)\",\n",
+    "    xaxis_type=\"log\",\n",
+    "    #yaxis_type=\"log\"\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('cum_rms.html',full_html=False,include_plotlyjs='cdn')"
    ]
   },
   {
@@ -1301,9 +1288,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "rDTAargQjSNz"
    },
+   "outputs": [],
    "source": [
     "from scipy.fft import fft, fftfreq\n",
     "\n",
@@ -1330,23 +1319,22 @@
     "                                          name:y_plot[1:]}).set_index('Frequency (Hz)')],axis=1)\n",
     "    \n",
     "    return df_fft, df_phase"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "3qE8BdHX1pGu"
    },
+   "outputs": [],
    "source": [
     "df_fft, df_phase = get_fft(df)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1355,6 +1343,20 @@
     "id": "sEuX5lKd0cWo",
     "outputId": "0f55d51f-529f-41c3-ff42-67adafb5217a"
    },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXwV9b3/8dc7YQk7CBLWChJQQahCRHvdcAEVrRaXiq2Iu6LWq629Ymtba9WitV7vvWIVqz+graKVVtGqiEtqXZDFiyKgEhCvCRE0GCBICEk+vz9mEifhnJOTmJOE5PN8PM7jzPKd+X6/M3POZ9bvyMxwzjnn4klr6gI455xr3jxQOOecS8gDhXPOuYQ8UDjnnEvIA4VzzrmEPFA455xLqEUECkkbJJ3Y1OWojaTnJU1NMm2mpNckbZf0+1SXLUE5bpH056bKv6FJypF0aT2nTbgsJB0gaUW4zq6tfylBkknK+ibzaCzRskp6QNIvwu5xkvJSnPcPJb2Yyjzi5FvvukkaFC6zNg1drlRpEYEinlgrM9V/fJLaSfpCUuea/WZ2ipnNSXJWlwNfAF3N7CepKm9rUHOdpNB/AK+aWRcz++8kynWTpDu+SYb1/dOR1C/625D0A0nLJBVLKgh3ao6qa3nM7Eoz+01dp0tGrLqa2V/MbEKK8hsh6UVJWyQVSVouaWIq8mruWnSgaCLHACvMrDhOf7L2A1abPxHZEOq7DupqP2BVHdKfCjyXorLUZiLwAoCkHwP3AncAmcC3gPuBMxqzQJLSGzO/JDwDLAL6AL2Ba4FtTVqipmJme/0H2ADcALwHbAUeBzoBO4EKoDj8/AAoBXaH/e+G0+cAvwWWEGwITwP7hOMygD8DhUARsBTITFCWe4Afx+oP87k07L4QeB24G/gS+Bg4JRw3OyxjaVjOE4H2BD/mjeHnXqB9nDJ0Ax4GCoB84DYgvbZ8w/GDgX8C2wl+JPcBf46M/yvwWbicXwNGRMb1BBaEy3AJ8Bvg9QTL6gxgRZh+HXByOLxfOJ8tQC5wWWSaW8Iy/Dks40pgGHATsBn4FJgQb52E6+A3wBvh9C8CvcJx44C8GNvWiZG8nyTYvrYD7wDfDse9ApQDJeE6G0bwZ7w6TJsP3BCZb4+wvJXr5afh+toIXAwYkBWOOxX433A5fQrcEpnP/4VpK7fx7wBDwvIUEhyV/gXoXqNefwPODLeVYuCcBOtpLPAWwfZfEG4T7SLjo2WdDdwWXZ7Az8JybAB+GJluNvAHgmC5g2A7r2tdLySyjQH/RvAb3Rp+/1tkXNx1H6POvcK8uscZX1m3n4TrsQC4KDI+UT0GhfNuE/afFS6bgwl23qcT/B4KgScI/4vilOMyYE1Yn9XA6HD4jQTb3HbgQ+AEgt/Vzuj8gEPDddM24X9sY/2Zp/ITLuQl4YLYJ1xwVxL7h38LkT++yAaUH66oTsD8yjTAFQR7Fh2BdGAMwekgwhX6bI15fQAcEKufPQPF7nBFpwPTCP4kVPMHF/bfCiwm2LPZF3gT+E2c5fF34MGwLr3DZXNFkvm+RfDH2p5gT3w71QPFxUAXvg5cKyLj5oUbdqdwWeYTJ1AQ/PlsBcaHP47+wIHhuNcI9mgzgEOAz4HjI+uvBDgJaAPMJQh2PwfahvX6ON46CdfBOoI/8g5h/4zojz/GthUNFLuBs8O8bgjzbltz/Yb9BcDRYXcPwh9x2D8ZeCzsPhnYxNfb36NU//MdB4wMl9OoMO33Yv3phMOywuXanmBbeQ24NzK+LcGfQ5cw77Lo9DHW1RjgiHB5DyL4fV0XGZ8oUJTx9fZ0LEFAOCCSditwZFi3jHrU9ULCbYzgt/8lMCUs63lhf8/a1n2MOgtYCzwLfI8aO4eRut0aLs+JwFdAj7qsM+Aigp2hyuX37wS/8wHhMnuQcDuJUcZzCH5jh4XlzSI4qj2AIDj1i+Q3JOx+heo7Xr8DHqj1P7Yx/shT/SH4MZ8f6b8LeIC6BYoZkf7hBHvz6QR/jG8Co5IoxxAgN0F/DtUDRXRcx3Dj6VPzBxf2rwMmRvpPAjbEKEMmsAvoEBl2HsG584T5EpxyKAM6RcY/WnN5RcZ1D6ftFi6r3YR/9uH4O4gfKB4E/jPG8IEEe+ZdIsN+C8yOrL9FkXHfJdi7rNwz70JkTzDOOrg50n8V8ELYHWt72UD1QLE4Mi6N6sGgav2G/f9HsKPRNUY9/wRMCbsfqbH9DSPy5xtj2nsrlx0x/jxjpP8e8L+R/hOAl8PuHwKf1fH3dh3w90h/bYEiuj09AfwiknZuLXklrCvVA8UUYEmN6d8CLqxt3cfJewDB0dM6gjMTrwFDI3XbWaMsm4Ej6lCPGwiOAgZE0q0BToj09yX4Xe2xfoGFwL/HGJ4VluVEahwpAJcCr4TdIggox9S2zlvSNYrPIt1fAXW9cPlppPsTgr2EXgQ/6IXAPEkbJd0lqW2ceUwEnk/QH7fMZvZV2Bmv3P3CckXL2C9Guv3CsheEF+CKCP6UeyeRbz/gSzPbUSMfIDiHLGmGpHWSthH8iUKwnPYl2EOquRzjGUjwA6ypH7DFzLbXmE//SP+mSPdO4AszK4/0V9YHYq+Db7KtVNXPzCoITj/EWg8QnFKYCHwi6Z+SvgMgKY1gj/+FMF0/Eiw3SYdLelXS55K2Ehwt94pXwPCOuXmS8sP19Oca6Sfy9bWRQqBXoovhkoZJelbSZ+H87kiUfw2xtqfo8orWu851raHmb6Qyv+i2E3Pdh3drFYefnwGYWZ6ZXWNmQwh+VzsIjmArFZpZWZz5JVOPnwIzzSx6w81+wN8jv901BDtOmTHqG/M3ZGa5BMH8FmBzuC1ULvP5wHck9SU4Y1AB/CvGvKtpSYEiFktyGAQLvdK3CKL4F2a228x+bWbDCc5/ngZcEGce0R9grP5vYiPBRhQt48YY6T4lOKLoZWbdw09XMxuRRB4FQA9JnWrkU+kHBNcVTiQ4ihgUDhfB6aEy9lyO8XxKsLdf00ZgH0ldaswnP4nyx1KXdbCD4AgLqLq4um+NNAMj49MI9jpjrQfMbKmZnUEQpJ8i2JuG4FTBJ2b2edhfQOLl9ijBNZuBZtaN4GhZldnEyPqOcPhIM+sKnB9JD9WXyVsE28v3YtUh9AeC03dDw/n9rMb8Eom1PUWXV83y17WuUTV/I5X51brtWHC3Vufws8edaGb2KTCT4PRgMhLVo9IE4GZJZ0WGfUpwzbB75JNhZrHqEO83hJk9amZHESwPA+4Mh39JcG3mXILf8zwLDy8SaemBYhPQU1K3GsMGhT/yqPMlDZfUkeC845NmVi7pOEkjwz+NbQQBpKJmRuF0Y4FXY/U3gMcINqp9JfUCfkmwp1iNmRUQbAi/l9RVUpqkIZKOrS0DM/sEWAb8Oryl9CiCUzuVuhD8qRQS/KHeEZm2nOAC6S2SOkoaDkxNkN3DwEWSTgjL2F/SgeEP8k3gt5IyJI0CLolV19rUYx18BGRIOjU8aryZ4Dxx1BhJZ4Z74NcRLI/FMfJuF97j383MdhNsO5XbzUTgH5HkTwAXRra/X9WYXReCo6wSSWMJfuCVPg/nu3+N9MXAVkn9CfZcK8s1mOAmiDUAZraVYFuaKel74bprK+kUSXdF5rcNKJZ0IMF1rbqo3J6OJtjR+muCtHWta9RzwLDwVt82ks4lOI38bB3Li6Qekn4tKSvcPnsRnIbeY13Xox6VVhFcI5op6fRw2APA7ZL2C8uxr6R4d5/9EbhB0hgFsiTtp+B5nuMltSe4nld5U0+lRwl2ds8Ou2vVogOFmX1A8Ae7PjyU68fXG2mhpHciyf9EcM70M4KLapUPTPUhuNNlG8Fh4D/DtEj6maTK0xrHA2+ZWUmc/m/qNoI/8fcI7vR5JxxW+dBR9LbMC4B2BOc/vwzL3zfJfH4AHE5wx9GvqH6oPZfgUD4/nHfNH801BIfenxEsy/8XHSlplaQfApjZEoILef9JcEHzn3y9N3gewdHKRoIL878ys5eSLH9UndZB+Kd5FcEPMJ/gCKPmQ1VPE+yNVV40PTMMBLFMATaEp2uuJLgeADVuizWz5wnOYb9CcGHzlRrzuQq4VdJ2gj/1JyLTfgXcDrwRbuNHAL8GRhMs138QBPBKe9ySa2a/B35MEBg/J9hTvYbgKAiCc+k/ILix4SGCu76S9RnBstpIcPfVleHvMp661jVaj0KCQPQTgp2Z/wBOM7Mv6lDeSqUE2+BLBL/99wl2Ci5Mcvq49ahR5nfDMj8k6RTgvwiORF4Mp11M8HsEIDw1dnQ47V8JlsejBOvmKYIL+u2BGQQ3LHxGcER7UyTbBcBQgmtT7yZTGSVx1NHiScohuGD7x28wj/uB983s/lj9rZGkCwku7tb5wa0Gyr/ZrQNJmQS3TfZP5pA/Bfk/B9xnZk31/IbbC+01j5DvBVYQ3EYbr981vua4DroBP2mKIBHKoeFOh7pWwgNFAzGzWYn6XeNrjuvAzD4iuBbSVPnfVXsq56rzU0/OOecSatEXs51zzn1zLerUU69evWzQoEH1mnbHjh106tSp9oQtiNe55Wtt9QWvc10tX778CzOr+bxQNS0qUAwaNIhly5bVa9qcnBzGjRvXsAVq5rzOLV9rqy94netKUqIWFAA/9eScc64WHiicc84llLJTT5IeIXjicLOZ7dE+iqSf8vWTqm2Ag4B9zWyLpA0ETxqWA2Vmlp2qcjrnnEssldcoZhM00Ts31kgz+x1BW+hI+i5wvZltiSQ5rp6P3jvnmqHdu3eTl5dHSUlDtWoTW7du3VizZk1K82hukqlzRkYGAwYMoG3beI1fx5eyQGFmr0kalGTy8wjaZHLOtVB5eXl06dKFQYMGISXb+Gzdbd++nS5dutSesAWprc5mRmFhIXl5eQwePLjO80/pA3dhoHg21qmnSJqOBA2vZVUeUUj6mKAhMQMeTPSEraTLgcsBMjMzx8ybN69eZS0uLqZz57q+wmLv5nVu+ZpTfbt168aQIUNSGiQAysvLSU9vbq/fTq1k6mxmrFu3jq1bt1Ybftxxxy2v7fR+c7g99rvAGzVOOx1lZvmSegOLJH1gZq/FmjgMIrMAsrOzrb63iPktda1Da6tzc6rvmjVr6Nq1a8rz8SOK+DIyMjj00EPrPP/mcNfTZGqcdqp8SYeZbSZoZnpsE5Qrrnc/f5cPtiRqKdk551qOJg0U4QuFjiVo479yWKfKt5uFb8aaQNAWfLNx/nPnc84z5zR1MZxz9VTZgkPl97JlyxgxYgSlpaUArFu3jv33359t27btMW1BQQGnnXYaAIsWLWLMmDGMHDmSMWPG8MorX79KZPny5YwcOZKsrCyuvfbayndWs2XLFsaPH8/QoUMZP348X375JRCcGrr22mvJyspi1KhRvPPOO3vkXdPkyZNZu3Zt3Ho1lJQFCkmPEbxm8QBJeZIukXSlpCsjySYBL9Z4p24m8Lqkd4ElwD/M7AWccy5FsrOzOfbYY7n77rsBuPrqq7n99ttjniq75557uOyyywDo1asXzzzzDCtXrmTOnDlMmTKlKt20adN46KGHWLt2LWvXruWFF4K/sRkzZnDCCSewdu1aTjjhBGbMmAHA888/X5V21qxZTJtW+4sEp02bxl13pb5B4FTe9XReEmlmE9xGGx22Hvh2akrlnHOw7777VvsGuOOOOzj00ENp06YNZWVlnHde7L+w+fPnc9tttwFUO98/YsQIdu7cya5du9iyZQvbtm3jiCOCl/BdcMEFPPXUU5xyyik8/fTT5OTkADB16lTGjRvHnXfeydNPP80FF1yAJI444giKioooKCggMzOTa665hldeeYWBAwfStm1bLr74Ys4++2yOPvpoLrzwQsrKyuLWqyE0h4vZzrlW5tfPrGL1xj1P63wTw/t15VffHZFU2qVLl1b7BujevTvTp0/nqquuYvXq1TGn+/jjj+nRowft29d8lXoQQEaPHk379u3Jz89nwIABVeMGDBhAfn4+AJs2baJv3+DNxH369GHTpk0A5OfnM3DgwD2meeONN9iwYQOrV69m8+bNHHTQQVx88cUApKWlkZWVxcqVKznmmGNi1qshNIeL2c451yw8//zzZGZmxg0UBQUFMffWV61axY033siDDz5Yp/wk1Xq78Ouvv84555xDWloaffr04bjjjqs2vnfv3nz22Wd1yreu/IjCOdfokt3zb0zPPvssW7duZeHChUyaNImTTjqJjh07VkvToUOHPZ4sz8vLY9KkScydO5chQ4YA0L9/f/Ly8qql6d+/PwCZmZkUFBTQt29fCgoK6N27d9U0n376acxpEikpKSEjI6N+lU6SH1E451q9nTt38uMf/5iZM2cycuRIzjjjDG6//fY90g0bNowNGzZU9RcVFXHqqacyY8YMjjzyyKrhffv2pWvXrixevBgzY+7cuZxxxhkAnH766cyZMweAOXPmVBs+d+5czIzFixfTrVs3+vbty5FHHsn8+fOpqKhg06ZNVdc3Kn300UcMHz68gZdIdR4onHOt3m9+8xsmTZpU9Yd7yy238Nhjj1W79RSgU6dODBkyhNzcXADuu+8+cnNzufXWWznkkEM45JBD2Lx5MwD3338/l156KVlZWQwZMoRTTjkFgOnTp7No0SKGDh3KSy+9xPTp0wGYOHEi+++/P1lZWVx22WXcf//9AJx11lkMGDCA4cOHc/755zN69Gi6desGBNc7OnToQGZmZkqXj596cs61enfccUe1/i5durB+/fqYaa+55hpmz57Nbbfdxs0338zNN98cM112djbvv7/nI2A9e/bk5Zdf3mO4JGbOnLnH8LS0NO6++246d+5MYWEhY8eOZeTIkQA8+uijXHHFFbXW75vyQOGcc3UwadIkCgsLGzXP0047jaKiIkpLS/nFL35Bnz59gOBOrSlTprBz586U5u+Bwjnn6ujSSy9t1PxqXpeodNFFFzVK/n6NwjnnXEIeKJxzziXkgcI551xCHiicc84l5IHCOdfqRJvjLikp4cADD2TlypVV43/3u9/FvO10586dHHvssZSXl7NixQq+853vMGLECEaNGsXjjz9ele7jjz/m8MMPJysri3PPPbeq+fJdu3Zx7rnnkpWVxeGHH17t4b3f/va3ZGVlccABB7Bw4cJa63DDDTdUa9Z83LhxbNiwocGbGAcPFM65Vi4jI4N7772Xq666CjMjPz+fBx54oKr576hHHnmEM888k/T0dDp27MjcuXNZtWoVL7zwAtdddx1FRUUA3HjjjVx//fXk5ubSo0cPHn74YQAefvhhevToQW5uLtdffz033ngjAKtXr2bevHlV87rqqqsoLy9PWO4f/ehHMcuYCh4onHOtTs3muE8++WT69u3L3Llzuf7667nlllvo0aPHHtP95S9/qWpyY9iwYQwdOhSAfv360bt3bz7//HPMjFdeeYWzzz4bCJoSf+qppwB4+umnmTp1KgBnn302L7/8MmbG008/zeTJk2nfvj2DBw8mKyuLJUuWAMFT4wcccABHHXUU5513XtU7M/bbbz8KCwurGgTcZ599SE9Pb/AmxsGfo3DONYXnp8NnK2tPVxd9RsIpye1hx2qO+95772Xs2LEMHTq02guIKpWWlrJ+/fqYp3aWLFlCaWkpQ4YMobCwkO7du9OmTfD3Gm1iPNqUeJs2bejWrRuFhYXk5+dXvbsiOs3SpUuZP38+7777Lrt372b06NGMGTOmKt3o0aN54403mDBhAn/729/2qFND8UDhnHMERwXHH3981WtOa/riiy/o3r37HsMLCgqYMmUKc+bMIS2tYU/SvPHGG5xxxhlkZGSQkZHBd7/73Wrje/fuzcaNGxs0z1g8UDjnGl+Se/6NLS0tLe6ffawmxrdt28app57K7bffXnVE0LNnT4qKiigrK6NNmzbVmguvbEp8wIABlJWVsXXrVnr27Bm3ifFoU+WxlJSU0KFDh29S5aT4NQrnnEtCjx49KC8vrwoWpaWlTJo0iQsuuKDqegQEjfsdd9xxPPnkk8CeTYlXNjH+5JNPcvzxxyOJ008/nXnz5rFr1y4+/vhj1q5dy9ixYznyyCN55plnKCkpobi4mGeffbZamT766CMOPvjglNfdA4VzziVpwoQJvP766wA88cQTvPbaa8yePbuqifEVK1YAcOedd3LPPfeQlZVFYWEhl1xyCQCXXHIJhYWFZGVlcc8991TdtTRixAi+//3vM3z4cE4++WRmzpxJeno6hx12GKeffjqjRo3ilFNOYeTIkVVNjO/evZvc3Fyys7NTX3EzS8kHeATYDLwfZ/w4YCuwIvz8MjLuZOBDIBeYnmyeY8aMsfp69dVXk0578OyD7eDZB9c7r+aiLnVuKVpbnZtTfVevXt0o+Wzbti1l816+fLmdf/75KZt/LNu3bzczsx07dtiYMWNs+fLlZmb2t7/9zW6++WYzS77OsdYBsMxq+W9N5TWK2cB9wNwEaf5lZtWuHElKB2YC44E8YKmkBWYW+yW2zjnXSEaPHs1xxx1HeXk56enpjZLn5ZdfzurVqykpKWHq1KmMHj0agLKyMn7yk580ShlSFijM7DVJg+ox6Vgg18zWA0iaB5wBeKBwzjW5iy++uFHze/TRR2MOP+eccxqtDE1919N3JL0LbARuMLNVQH/g00iaPODweDOQdDlwOQQvLY/XbnttiouL6zxtffNqLupT571da6tzc6pvt27d2L59e8rzKS8vb5R8mpNk61xSUlKv7aEpA8U7wH5mVixpIvAUMLSuMzGzWcAsgOzsbBs3bly9CpOTk0PS0wY3LSSfvpmqU51biNZW5+ZU3zVr1tClS5eU57N9+/ZGyac5SbbOGRkZHHrooXWef5Pd9WRm28ysOOx+DmgrqReQDwyMJB0QDnPOOdcEmixQSOojSWH32LAshcBSYKikwZLaAZOBBU1VTueca+1SFigkPQa8BRwgKU/SJZKulHRlmORs4P3wGsV/A5PDu7XKgGuAhcAa4Inw2oVzzjWIaDPjADNnzqx6FuKQQw7h4IMPRhJr1qzZY9qCgoKqZj4WLVrEmDFjGDlyJGPGjKnW7Pfy5csZOXIkWVlZXHvttZW3/rNlyxbGjx/P0KFDGT9+PF9++SUQPKpw7bXXkpWVxahRo3jnnXdqrcfkyZNZu3Zt3Ho1lJQFCjM7z8z6mllbMxtgZg+b2QNm9kA4/j4zG2Fm3zazI8zszci0z5nZMDMbYma3p6qMzjkHcPXVV7NixYqqz+mnn84Pf/hDDjrooD3S3nPPPVx22WUA9OrVi2eeeYaVK1cyZ86cao0JTps2jYceeoi1a9eydu1aXnjhBQBmzJjBCSecwNq1aznhhBOqHrp7/vnnq9LOmjWLadOm1VruadOmcddddzXEIkjIn8x2zrU6NZsZj3rttdd44oknuP/++2NOO3/+fE4++WQADj30UPr16wcET1fv3LmTXbt2UVBQwLZt2zjiiCOQxAUXXBCzqfGaTZBfcMEFSOKII46gqKiIgoICKioquOqqqzjwwAMZP348EydOrGoe5Oijj+all16irKys1np9E019e6xzrhW6c8mdfLDlgwad54H7HMiNY29MKm2sZsYBioqKuPDCC/nTn/5E165d95ju448/pkePHrRv336PcfPnz2f06NG0b9+e/Px8BgwYUDUu2tT4pk2b6Nu3LwB9+vRh06ZNQPUmyKPTvPHGG2zYsIHVq1ezefNmDjrooKpnOdLS0sjKymLlypUcc8wxcev1TXmgcM650JVXXsmUKVM48sgjY44vKCiIube+atUqbrzxRl588cU65SeJ8J6euF5//XXOOecc0tLS6NOnD8cdd1y18b179656eVGqeKBwzjW6ZPf8G9OcOXP45JNP+POf/xw3TaymxvPy8pg0aRJz585lyJAhAHs0ER5tajwzM5OCggL69u1LQUEBvXv3rpomVlPjtSkpKSEjIyP5itaDX6NwzrV669ev52c/+xl/+ctfqt5MF8uwYcPYsGFDVX9RURGnnnoqM2bMqHYU0rdvX7p27crixYsxM+bOnRuzqfGaTZDPnTsXM2Px4sV069aNvn37cuSRRzJ//nwqKirYtGnTHk9Wf/TRRwwfPryBlkRsHiicc63enXfeyVdffcWZZ55Z7TbZf/3rX9XSderUiSFDhpCbmwvAfffdR25uLrfeemvVNJs3bwbg/vvv59JLLyUrK4shQ4ZwyimnADB9+nQWLVrE0KFDeemll5g+fToAEydOZP/99ycrK4vLLrus6mL6WWedxYABAxg+fDjnn38+o0ePrmpqfNOmTXTo0IHMzMyULh8/9eSca/UefPBBHnzwwaTSXnPNNcyePZvbbruNm2++mZtvvjlmuuzsbN5///09hvfs2ZOXX355j+GSmDlz5h7D09LSuPvuu+ncuTOFhYWMHTuWkSNHAkGDgVdccUVS5f4mPFA451wdTJo0icLCwkbN87TTTqOoqIjS0lJ+8Ytf0KdPHwC6d+/OlClT2LlzZ0rz90DhnHN1dOmllzZqfvFafL3ooosaJX+/RuGcazSVzVi4xvdNlr0HCudco8jIyKCwsNCDRRMwMwoLC+t9G62fenLONYoBAwaQl5fH559/ntJ8GuO5guYmmTpnZGRUe1q8LjxQOOcaRdu2bRk8eHDK88nJyanXy3n2Zqmus596cs45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCaUsUEh6RNJmSXu2ihWM/6Gk9yStlPSmpG9Hxm0Ih6+QtCxVZXTOOVe7VB5RzAZOTjD+Y+BYMxsJ/AaYVWP8cWZ2iJllp6h8zjnnkpCyB+7M7DVJgxKMfzPSuxio3yODzjnnUqq5PJl9CfB8pN+AFyUZ8KCZ1TzaqCLpcuByCF4xGK+VxdoUFxfXedr65tVc1KfOe7vWVufWVl/wOqeEmaXsAwwC3q8lzXHAGqBnZFj/8Ls38C5wTDL5jRkzxurr1VdfTTrtwbMPtoNnH1zvvJqLutS5pWhtdW5t9TXzOtcVsMxq+W9t0rueJI0C/gicYWZVbwIxs/zwezPwd2Bs05TQOedckwUKSd8C/gZMMbOPIsM7SRtZKUUAABo1SURBVOpS2Q1MAGLeOeWccy71UnaNQtJjwDigl6Q84FdAWwAzewD4JdATuF8SQJkFdzhlAn8Ph7UBHjWzF1JVTuecc4ml8q6n82oZfymwx/sEzWw98O09p3DOOdcU/Mls55xzCXmgcM45l1DCU0+SMoDTgKOBfsBOggvL/zCzVakvnnPOuaYWN1BI+jVBkMgB3gY2AxnAMGBGGER+YmbvNUI5nXPONZFERxRLzOxXccbdI6k38K0UlMk551wzEjdQmNk/Ek0YPgy3ucFL5Jxzrlmp9fZYSc8QtL0UtRVYRtAOU0kqCuacc655SOaup/VAMfBQ+NkGbCe4VvFQ6ormnHOuOUjmgbt/M7PDIv3PSFpqZodJ8jufnHOuhUvmiKJz2C4TUNVGU+ewtzQlpXLOOddsJHNE8RPgdUnrAAGDgavCBvvmpLJwzjnnml6tgcLMnpM0FDgwHPRh5AL2vSkrmXPOuWYh7qknSUdVdpvZLjN7N/yUhOO7Sjq4MQrpnHOu6SQ6ojhL0l3AC8By4HOCJ7OzCN5Ktx/BaSnnnHMtWKIH7q6XtA9wFnAO0Jegrac1BM9PvN44RXTOOdeUEl6jMLMtfP38hHPOuVbImxl3zjmXkAcK55xzCXmgcM45l1BS78yW9G/AoGh6M5ubojI555xrRmo9opD0J+Bu4CjgsPCTnczMJT0iabOk9+OMl6T/lpQr6T1JoyPjpkpaG36mJlUb55xzDS6ZI4psYLiZ1WxqPBmzgfuAeEcfpwBDw8/hwB+Aw8Pbcn8V5m3AckkLzOzLepTBOefcN5DMNYr3gT71mbmZvQZsSZDkDGCuBRYD3SX1BU4CFpnZljA4LAJOrk8ZnHPOfTPJHFH0AlZLWgLsqhxoZqc3QP79gU8j/XnhsHjD9yDpcuBygMzMTHJycupVkOLi4jpPW9+8mov61Hlv19rq3NrqC17nVEgmUNySstwbgJnNAmYBZGdn27hx4+o1n5ycHJKeNmwzt755NRd1qnML0drq3NrqC17nVKj11JOZ/RP4AOgSftaEwxpCPjAw0j8gHBZvuHPOuUaWzF1P3weWELT39H3gbUlnN1D+C4ALwrufjgC2mlkBsBCYIKmHpB7AhHCYc865RpbMqaefA4eZ2WYASfsCLwFP1jahpMeAcUAvSXkEdzK1BTCzB4DngIlALvAVcFE4bouk3wBLw1ndGrY75ZxzrpElEyjSKoNEqJAkn+g2s/NqGW/A1XHGPQI8kkw+zjnnUieZQPGCpIXAY2H/uQRHAs4551qBZF6F+lNJZwFHhoNmmdnfU1ss55xzzUVSbT2Z2XxgforL4pxzrhmKGygkvW5mR0naTtCMRtUogssLXVNeOuecc00u0atQjwq/uzRecZxzzjU3ybYeW+sw55xzLVMyt7mOiPZIagOMSU1xnHPONTdxA4Wkm8LrE6MkbQs/24FNwNONVkLnnHNNKm6gMLPfhtcnfmdmXcNPFzPraWY3NWIZnXPONaFknqO4KWxvaSiQERn+WioL5pxzrnmoNVBIuhT4d4IWXFcARwBvAcentmjOOeeag2QuZv87wXuyPzGz44BDgaKUlso551yzkUygKDGzEgBJ7c3sA+CA1BbLOedcc5FMEx55kroDTwGLJH0JfJLaYjnnnGsukrmYPSnsvEXSq0A34IWUlso551yzkTBQSEoHVpnZgVD1WlTnnHOtSMJrFGZWDnwo6VuNVB7nnHPNTDLXKHoAqyQtAXZUDjSz01NWKuecc81GMoHiFykvhXPOuWYrmYvZ/5S0HzDUzF6S1BFIT33RnHPONQfJNDN+GfAk8GA4qD/BrbK1knSypA8l5UqaHmP8f0paEX4+klQUGVceGbcgueo455xraMmceroaGAu8DWBmayX1rm2i8I6pmcB4IA9YKmmBma2uTGNm10fS/4jgqe9KO83skKRq4ZxzLmWSeTJ7l5mVVvaE76OwBOkrjQVyzWx9OP084IwE6c8DHktivs455xpRMkcU/5T0M6CDpPHAVcAzSUzXH/g00p8HHB4rYXgNZDDwSmRwhqRlQBkww8xinu6SdDlwOUBmZiY5OTlJFG1PxcXFdZ62vnk1F/Wp896utdW5tdUXvM6pkEygmA5cAqwErgCeA/7YwOWYDDwZPrdRaT8zy5e0P/CKpJVmtq7mhGY2C5gFkJ2dbePGjatXAXJyckh62jnBV33zai7qVOcWorXVubXVF7zOqZDMXU8VwEPhpy7ygYGR/gHhsFgmE1wLieabH36vl5RDcP1ij0DhnHMuteIGCkkrSXAtwsxG1TLvpcBQSYMJAsRk4Acx8jmQ4KG+tyLDegBfmdkuSb2AI4G7asmvyS3ftJwdu3dwzIBjmroozjnXYBIdUZz2TWZsZmWSrgEWEjx38YiZrZJ0K7DMzCpveZ0MzDOzaFA6CHhQUgXBBfcZ0bulmqsLX7gQgJVTVzZtQZxzrgHFDRRmVtWUeI0H7jokmq7GPJ4juKYRHfbLGv23xJjuTWBkMnk455xLrfo8cDeAJB+4c845t/dL5jmKqwmuEWyD4IE7oNYH7pxzzrUMqXzgzjnnXAuQTKCo+cDdX0nugTvnnHMtQDKBYjrwOdUfuLs5lYVyzjnXfCRz91IHgltbH4Kqxv46AF+lsmDOOeeah2SOKF4mCAyVOgAvpaY4zjnnmptkAkWGmRVX9oTdHVNXJOecc81JMoFih6TRlT2SxgA7U1ck55xzzUky1yiuA/4qaSMgoA9wbkpL5ZxzrtlIpvXYpWHDfQeEgz40s92pLZZzzrnmIpkmPK4GOpnZ+2b2PtBZ0lWpL5pzzrnmIJlrFJeZWVFlj5l9CVyWuiI555xrTpIJFOmSVNkTPkfRLnVFcs4515wkczH7BeBxSZWtx14RDnPOOdcKJBMobgQuB6aF/Yuo+2tRnXPO7aVqPfVkZhVm9oCZnW1mZwOrgf9JfdGcc841B0m9qU7SocB5wPeBj4G/pbJQzjnnmo+4gULSMILgcB7wBfA4IDM7rpHK5pxzrhlIdOrpA+B44DQzO8rM/gcor8vMJZ0s6UNJuZKmxxh/oaTPJa0IP5dGxk2VtDb8TK1Lvs455xpOolNPZwKTgVclvQDMI2jCIynhbbQzgfFAHrBU0gIzW10j6eNmdk2NafcBfgVkE7xNb3k47ZfJ5u+cc65hxD2iMLOnzGwycCDwKkGbT70l/UHShCTmPRbINbP14atU5wFnJFmuk4BFZrYlDA6LgJOTnNY551wDSuaupx1m9qiZfRcYAPwvwS2ztekPfBrpzwuH1XSWpPckPSlpYB2ndc45l2JJ3fVUKdy7nxV+GsIzwGNmtkvSFcAcgusiSZN0OcFzHmRmZpKTk1OvghQXF9d52njp61uGxlafOu/tWludW1t9weucCnUKFHWUDwyM9A8Ih1Uxs8JI7x+BuyLTjqsxbU6sTMysKnBlZ2fbuHHjYiWrVU5ODklPOyf42iN9vOHNVJ3q3EK0tjq3tvqC1zkVkmnrqb6WAkMlDZbUjuDC+IJoAkl9I72nA2vC7oXABEk9JPUAJoTDnHPONbKUHVGYWZmkawj+4NOBR8xslaRbgWVmtgC4VtLpQBmwBbgwnHaLpN8QBBuAW81sS6rK6pxzLr5UnnrCzJ4Dnqsx7JeR7puAm+JM+wjwSCrL55xzrnapPPXknHOuBfBA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLqGUBgpJJ0v6UFKupOkxxv9Y0mpJ70l6WdJ+kXHlklaEnwWpLKdzzrn42qRqxpLSgZnAeCAPWCppgZmtjiT7XyDbzL6SNA24Czg3HLfTzA5JVfmcc84lJ5VHFGOBXDNbb2alwDzgjGgCM3vVzL4KexcDA1JYHuecc/WQsiMKoD/waaQ/Dzg8QfpLgOcj/RmSlgFlwAwzeyrWRJIuBy4HyMzMJCcnp16FLS4urvO08dLXtwyNrT513tu1tjq3tvqC1zkVUhkokibpfCAbODYyeD8zy5e0P/CKpJVmtq7mtGY2C5gFkJ2dbePGjatXGXJyckh62jnB1x7p4w1vpupU5xaitdW5tdUXvM6pkMpTT/nAwEj/gHBYNZJOBH4OnG5muyqHm1l++L0eyAEOTWFZnXPOxZHKQLEUGCppsKR2wGSg2t1Lkg4FHiQIEpsjw3tIah929wKOBKIXwZ1zzjWSlJ16MrMySdcAC4F04BEzWyXpVmCZmS0Afgd0Bv4qCeD/zOx04CDgQUkVBMFsRo27pZxzzjWSlF6jMLPngOdqDPtlpPvEONO9CYxMZdmcc84lx5/Mds45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcM45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcM45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAeKGk77f9/nf566DoA31z3PB4+eCTuLWFe0jg1bNzRt4Zxzrgmk9FWoe4vZ78+mrKSMcYzjk7Q1zNq6hivKKrji9f8AYOU7c/le7kNB97BpTVlU55xrdH5EAfx++e/5r03/hZlVDdu8vaSqe+vO0q8TL7zp6+7Sr5Ka/49e/hEj5/grwJ1ze6eUBgpJJ0v6UFKupOkxxreX9Hg4/m1JgyLjbgqHfyjppFSWs1JFxdeBYseu8qruaACp5o6+bNqxidwv18JHC+PONycvp6q7ZGcRbxe8XdVfXFpcmTmUlwFQXlHOFzu/qEcNkjf/o/lsL9+e0jyccy1Dyk49SUoHZgLjgTxgqaQFZrY6kuwS4Eszy5I0GbgTOFfScGAyMALoB7wkaZiZlZNCh/z521XdZy/8t6ruozfOreoeOfhb1bufPHGP+USPHgaWpENGOJ+HR1DUJojN3XeLorZBAOpb0p7itjvZnr5n3D5gpyhNL6O9pbMzvTfdrZTP03fRYXtnhqVvJz+9HMjgvQ7bGfLlAEo7t6OszWcMsK6UlZbSJ703FWYsbPch+1cMpM9X7Uhv04l/ZbwHwMJH5tK9Ux8og50V2+ioLrTLKKdb+kGUlW7kwx1dKEvPYzlvMo5DqPhyO6/2WMuU9t8lzcrYP72cVdpKl5J9sd79KN32f+zfuScf7v6c8lIxqlMXiuhKQfFHdG+bQZdO2XxSupZeHQew4bPlfLD9bS4c8hNyi5aRlpFBp686Ud5xH0Zm7sfOnVtYt3MLUEav9gNJJ51uuzewo11f1hVv5J/Fr3BSz0vpXFZMehuxtegjhn3rQNZ98Rlj+45gK7uhoi3atYtuX63lgy6j0BfreXt1OvlFn5HRKYPBHfuw4atC2rbvRknxJg7aN4u31rzMxi/eY0TWWPr1+Dad2nfF2E1ndvJFwceU9RhG5/Ri2pbu5v+2ltGjR0faqQNFtoV9Swoppx27duyg46Ax5Bd8QLtdX5DV5wB27zLaduyBFX7Elvad6GglpHftR1pxETsy+tCjvSiyNvRKM3a370L6to20a9seddqHL7YUk/fBS3TsM5wDBx9AefsupLfJoLx0O1a6E7XJIL1tO9IFpeVl2NY8KjK6s277CkZtHUpa2S46d9wXlZewpayE7VuK6dJzX7qmVZDetgM7ykXHtu34rHgjvTtmkt6mHWkVpZSpLWlWBmlp7C4z0tPTSU8XVlFOhRmYUbx9E1269iZNbSirKEdqQ5os2PFKqwBrQxsZuysqaJPWBiREBZKoqDCUlkZFRRkind07Pqdtp14gkNLADMMwMySRpjTKKoy0tDQqystJTxMVZaWkt20PQLlV8FXZV1RUlAMKhlVUYIR5W5CfWQUgDKOiopy0tHTS09KDncLwY0CFQXqaqvKvMEhLE+LrHUgLczIgTaIiTGsYMigtL6WN0iAtnTSlYRUVQRkqykHVf/Pl5RVBfhgKFgKSwIwKjLSwTlUktpYUU16R0r9GFHdv+ZvOWPoOcIuZnRT23wRgZr+NpFkYpnlLUhvgM2BfYHo0bTRdojyzs7Nt2bJldSqnmTFq7qg6TeOcc83Nkh8so0MYMOtC0nIzy06UJpUXs/sDn0b684DD46UxszJJW4Ge4fDFNabtHysTSZcDlwNkZmaSk5NTp0KWV6QmUDrnXGN6+/U39jhCaSh7/V1PZjYLmAXBEcW4cePqPI+VrCQnJ4f6TLs38zq3fK2tvuB1ToVUXszOBwZG+geEw2KmCU89dQMKk5zWOedcI0hloFgKDJU0WFI7govTC2qkWQBMDbvPBl6x4KLJAmByeFfUYGAosCSFZXXOORdHyk49hdccrgEWAunAI2a2StKtwDIzWwA8DPxJUi6whSCYEKZ7AlgNlAFXp/qOJ+ecc7Gl9BqFmT0HPFdj2C8j3SXAOXGmvR24PZXlc845Vzt/Mts551xCHiicc84l5IHCOedcQh4onHPOJZSyJjyagqTPgU/qOXkvILUt8TU/XueWr7XVF7zOdbWfme2bKEGLChTfhKRltbV30tJ4nVu+1lZf8Dqngp96cs45l5AHCueccwl5oPjarKYuQBPwOrd8ra2+4HVucH6NwjnnXEJ+ROGccy4hDxTOOecSavWBQtLJkj6UlCtpelOXpyFJ2iBppaQVkpaFw/aRtEjS2vC7Rzhckv47XA7vSRrdtKVPjqRHJG2W9H5kWJ3rKGlqmH6tpKmx8mou4tT5Fkn54bpeIWliZNxNYZ0/lHRSZPhese1LGijpVUmrJa2S9O/h8Ba7nhPUuWnWs5m12g9B8+frgP2BdsC7wPCmLlcD1m8D0KvGsLuA6WH3dODOsHsi8DzBe+KPAN5u6vInWcdjgNHA+/WtI7APsD787hF292jqutWxzrcAN8RIOzzcrtsDg8PtPX1v2vaBvsDosLsL8FFYrxa7nhPUuUnWc2s/ohgL5JrZejMrBeYBZzRxmVLtDGBO2D0H+F5k+FwLLAa6S+rbFAWsCzN7jeBdJlF1reNJwCIz22JmXwKLgJNTX/r6iVPneM4A5pnZLjP7GMgl2O73mm3fzArM7J2wezuwBuhPC17PCeocT0rXc2sPFP2BTyP9eSReGXsbA16UtFzS5eGwTDMrCLs/AzLD7pa0LOpax5ZS92vCUy2PVJ6GoYXVWdIg4FDgbVrJeq5RZ2iC9dzaA0VLd5SZjQZOAa6WdEx0pAXHrC36/ujWUMfQH4AhwCFAAfD7pi1Ow5PUGZgPXGdm26LjWup6jlHnJlnPrT1Q5AMDI/0DwmEtgpnlh9+bgb8THIZuqjylFH5vDpO3pGVR1zru9XU3s01mVm5mFcBDBOsaWkidJbUl+MP8i5n9LRzcotdzrDo31Xpu7YFiKTBU0mBJ7Qje2b2gicvUICR1ktSlshuYALxPUL/Kuz2mAk+H3QuAC8I7Ro4AtkYO6/c2da3jQmCCpB7hofyEcNheo8b1pEkE6xqCOk+W1F7SYGAosIS9aNuXJOBhYI2Z3RMZ1WLXc7w6N9l6buqr+039IbhD4iOCOwN+3tTlacB67U9wh8O7wKrKugE9gZeBtcBLwD7hcAEzw+WwEshu6jokWc/HCA7BdxOcf72kPnUELia4AJgLXNTU9apHnf8U1um98I+gbyT9z8M6fwicEhm+V2z7wFEEp5XeA1aEn4kteT0nqHOTrGdvwsM551xCrf3Uk3POuVp4oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcC2OpPJI65orwiYQWgRJh0p6OOy+UNJ9NcbnSMpOMP08SUNTXU7XsrRp6gI4lwI7zeyQWCPCB5lkwZOte6OfAbd9g+n/APwHcFnDFMe1Bn5E4Vo8SYPC9vjnEjzJOlDSTyUtDRtX+3Uk7c8lfSTpdUmPSbohHF61py6pl6QNYXe6pN9F5nVFOHxcOM2Tkj6Q9JcwSCHpMElvSnpX0hJJXSS9JumQSDlel/TtGvXoAowys3eTqPPpkSOqDyV9HI76F3CiJN9JdEnzjcW1RB0krQi7PwauJ2jSYKqZLZY0IewfS/AU74KwwcQdBE0cHELw23gHWF5LXpcQNBFxmKT2wBuSXgzHHQqMADYCbwBHSloCPA6ca2ZLJXUFdhI013AhcJ2kYUBGjICQzddNNlQ6V9JRkf4sADNbQNhUg6QngH+Gwysk5QLfTqJuzgEeKFzLVO3UU3iN4hML3k0AQRs/E4D/Dfs7EwSOLsDfzeyrcLpk2sSZAIySdHbY3y2cVymwxMzywnmtAAYBW4ECM1sKYGErqJL+CvxC0k8JmpmYHSOvvsDnNYY9bmbXROqaEx0p6T8IlsfMyODNQD88ULgkeaBwrcWOSLeA35rZg9EEkq5LMH0ZX5+qzagxrx+ZWbXG5SSNA3ZFBpWT4PdmZl9JWkTwUpnvA2NiJNtZI++EJJ0InEPwRryojHBeziXFr1G41mghcLGCtv6R1F9Sb+A14HuSOoTXA74bmWYDX/95n11jXtMUNAmNpGFha73xfAj0lXRYmL5L5HrBH4H/BpZa8Aa2mtYQnlqqjaT9CBrGO8fMagaFYex5Csu5uPyIwrU6ZvaipIOAt8Lry8XA+Wb2jqTHCVrc3UzQRHOlu4EnFLwp8B+R4X8kOKX0Tnix+nO+fiVnrLxLJZ0L/I+kDgR79icCxWa2XNI24P/FmfYDSd0kdbHg9ZiJXEjQuupTYR03mtlESZkEp6I+q2V656p467HOxSHpFoI/8LsbKb9+QA5wYLzbdyVdD2w3sz/WM4/rgW1m9nC9C+paHT/15FwzIOkCgnci/7yWZzz+QPVrH3VVBMz5BtO7VsiPKJxzziXkRxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xL6/5osO8ZjIYM1AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots() #create an empty plot\n",
     "\n",
@@ -1367,21 +1369,6 @@
     "\n",
     "fig.savefig('fft.png')\n",
     "plt.show()"
-   ],
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXwV9b3/8dc7YQk7CBLWChJQQahCRHvdcAEVrRaXiq2Iu6LWq629Ymtba9WitV7vvWIVqz+graKVVtGqiEtqXZDFiyKgEhCvCRE0GCBICEk+vz9mEifhnJOTmJOE5PN8PM7jzPKd+X6/M3POZ9bvyMxwzjnn4klr6gI455xr3jxQOOecS8gDhXPOuYQ8UDjnnEvIA4VzzrmEPFA455xLqEUECkkbJJ3Y1OWojaTnJU1NMm2mpNckbZf0+1SXLUE5bpH056bKv6FJypF0aT2nTbgsJB0gaUW4zq6tfylBkknK+ibzaCzRskp6QNIvwu5xkvJSnPcPJb2Yyjzi5FvvukkaFC6zNg1drlRpEYEinlgrM9V/fJLaSfpCUuea/WZ2ipnNSXJWlwNfAF3N7CepKm9rUHOdpNB/AK+aWRcz++8kynWTpDu+SYb1/dOR1C/625D0A0nLJBVLKgh3ao6qa3nM7Eoz+01dp0tGrLqa2V/MbEKK8hsh6UVJWyQVSVouaWIq8mruWnSgaCLHACvMrDhOf7L2A1abPxHZEOq7DupqP2BVHdKfCjyXorLUZiLwAoCkHwP3AncAmcC3gPuBMxqzQJLSGzO/JDwDLAL6AL2Ba4FtTVqipmJme/0H2ADcALwHbAUeBzoBO4EKoDj8/AAoBXaH/e+G0+cAvwWWEGwITwP7hOMygD8DhUARsBTITFCWe4Afx+oP87k07L4QeB24G/gS+Bg4JRw3OyxjaVjOE4H2BD/mjeHnXqB9nDJ0Ax4GCoB84DYgvbZ8w/GDgX8C2wl+JPcBf46M/yvwWbicXwNGRMb1BBaEy3AJ8Bvg9QTL6gxgRZh+HXByOLxfOJ8tQC5wWWSaW8Iy/Dks40pgGHATsBn4FJgQb52E6+A3wBvh9C8CvcJx44C8GNvWiZG8nyTYvrYD7wDfDse9ApQDJeE6G0bwZ7w6TJsP3BCZb4+wvJXr5afh+toIXAwYkBWOOxX433A5fQrcEpnP/4VpK7fx7wBDwvIUEhyV/gXoXqNefwPODLeVYuCcBOtpLPAWwfZfEG4T7SLjo2WdDdwWXZ7Az8JybAB+GJluNvAHgmC5g2A7r2tdLySyjQH/RvAb3Rp+/1tkXNx1H6POvcK8uscZX1m3n4TrsQC4KDI+UT0GhfNuE/afFS6bgwl23qcT/B4KgScI/4vilOMyYE1Yn9XA6HD4jQTb3HbgQ+AEgt/Vzuj8gEPDddM24X9sY/2Zp/ITLuQl4YLYJ1xwVxL7h38LkT++yAaUH66oTsD8yjTAFQR7Fh2BdGAMwekgwhX6bI15fQAcEKufPQPF7nBFpwPTCP4kVPMHF/bfCiwm2LPZF3gT+E2c5fF34MGwLr3DZXNFkvm+RfDH2p5gT3w71QPFxUAXvg5cKyLj5oUbdqdwWeYTJ1AQ/PlsBcaHP47+wIHhuNcI9mgzgEOAz4HjI+uvBDgJaAPMJQh2PwfahvX6ON46CdfBOoI/8g5h/4zojz/GthUNFLuBs8O8bgjzbltz/Yb9BcDRYXcPwh9x2D8ZeCzsPhnYxNfb36NU//MdB4wMl9OoMO33Yv3phMOywuXanmBbeQ24NzK+LcGfQ5cw77Lo9DHW1RjgiHB5DyL4fV0XGZ8oUJTx9fZ0LEFAOCCSditwZFi3jHrU9ULCbYzgt/8lMCUs63lhf8/a1n2MOgtYCzwLfI8aO4eRut0aLs+JwFdAj7qsM+Aigp2hyuX37wS/8wHhMnuQcDuJUcZzCH5jh4XlzSI4qj2AIDj1i+Q3JOx+heo7Xr8DHqj1P7Yx/shT/SH4MZ8f6b8LeIC6BYoZkf7hBHvz6QR/jG8Co5IoxxAgN0F/DtUDRXRcx3Dj6VPzBxf2rwMmRvpPAjbEKEMmsAvoEBl2HsG584T5EpxyKAM6RcY/WnN5RcZ1D6ftFi6r3YR/9uH4O4gfKB4E/jPG8IEEe+ZdIsN+C8yOrL9FkXHfJdi7rNwz70JkTzDOOrg50n8V8ELYHWt72UD1QLE4Mi6N6sGgav2G/f9HsKPRNUY9/wRMCbsfqbH9DSPy5xtj2nsrlx0x/jxjpP8e8L+R/hOAl8PuHwKf1fH3dh3w90h/bYEiuj09AfwiknZuLXklrCvVA8UUYEmN6d8CLqxt3cfJewDB0dM6gjMTrwFDI3XbWaMsm4Ej6lCPGwiOAgZE0q0BToj09yX4Xe2xfoGFwL/HGJ4VluVEahwpAJcCr4TdIggox9S2zlvSNYrPIt1fAXW9cPlppPsTgr2EXgQ/6IXAPEkbJd0lqW2ceUwEnk/QH7fMZvZV2Bmv3P3CckXL2C9Guv3CsheEF+CKCP6UeyeRbz/gSzPbUSMfIDiHLGmGpHWSthH8iUKwnPYl2EOquRzjGUjwA6ypH7DFzLbXmE//SP+mSPdO4AszK4/0V9YHYq+Db7KtVNXPzCoITj/EWg8QnFKYCHwi6Z+SvgMgKY1gj/+FMF0/Eiw3SYdLelXS55K2Ehwt94pXwPCOuXmS8sP19Oca6Sfy9bWRQqBXoovhkoZJelbSZ+H87kiUfw2xtqfo8orWu851raHmb6Qyv+i2E3Pdh3drFYefnwGYWZ6ZXWNmQwh+VzsIjmArFZpZWZz5JVOPnwIzzSx6w81+wN8jv901BDtOmTHqG/M3ZGa5BMH8FmBzuC1ULvP5wHck9SU4Y1AB/CvGvKtpSYEiFktyGAQLvdK3CKL4F2a228x+bWbDCc5/ngZcEGce0R9grP5vYiPBRhQt48YY6T4lOKLoZWbdw09XMxuRRB4FQA9JnWrkU+kHBNcVTiQ4ihgUDhfB6aEy9lyO8XxKsLdf00ZgH0ldaswnP4nyx1KXdbCD4AgLqLq4um+NNAMj49MI9jpjrQfMbKmZnUEQpJ8i2JuG4FTBJ2b2edhfQOLl9ijBNZuBZtaN4GhZldnEyPqOcPhIM+sKnB9JD9WXyVsE28v3YtUh9AeC03dDw/n9rMb8Eom1PUWXV83y17WuUTV/I5X51brtWHC3Vufws8edaGb2KTCT4PRgMhLVo9IE4GZJZ0WGfUpwzbB75JNhZrHqEO83hJk9amZHESwPA+4Mh39JcG3mXILf8zwLDy8SaemBYhPQU1K3GsMGhT/yqPMlDZfUkeC845NmVi7pOEkjwz+NbQQBpKJmRuF0Y4FXY/U3gMcINqp9JfUCfkmwp1iNmRUQbAi/l9RVUpqkIZKOrS0DM/sEWAb8Oryl9CiCUzuVuhD8qRQS/KHeEZm2nOAC6S2SOkoaDkxNkN3DwEWSTgjL2F/SgeEP8k3gt5IyJI0CLolV19rUYx18BGRIOjU8aryZ4Dxx1BhJZ4Z74NcRLI/FMfJuF97j383MdhNsO5XbzUTgH5HkTwAXRra/X9WYXReCo6wSSWMJfuCVPg/nu3+N9MXAVkn9CfZcK8s1mOAmiDUAZraVYFuaKel74bprK+kUSXdF5rcNKJZ0IMF1rbqo3J6OJtjR+muCtHWta9RzwLDwVt82ks4lOI38bB3Li6Qekn4tKSvcPnsRnIbeY13Xox6VVhFcI5op6fRw2APA7ZL2C8uxr6R4d5/9EbhB0hgFsiTtp+B5nuMltSe4nld5U0+lRwl2ds8Ou2vVogOFmX1A8Ae7PjyU68fXG2mhpHciyf9EcM70M4KLapUPTPUhuNNlG8Fh4D/DtEj6maTK0xrHA2+ZWUmc/m/qNoI/8fcI7vR5JxxW+dBR9LbMC4B2BOc/vwzL3zfJfH4AHE5wx9GvqH6oPZfgUD4/nHfNH801BIfenxEsy/8XHSlplaQfApjZEoILef9JcEHzn3y9N3gewdHKRoIL878ys5eSLH9UndZB+Kd5FcEPMJ/gCKPmQ1VPE+yNVV40PTMMBLFMATaEp2uuJLgeADVuizWz5wnOYb9CcGHzlRrzuQq4VdJ2gj/1JyLTfgXcDrwRbuNHAL8GRhMs138QBPBKe9ySa2a/B35MEBg/J9hTvYbgKAiCc+k/ILix4SGCu76S9RnBstpIcPfVleHvMp661jVaj0KCQPQTgp2Z/wBOM7Mv6lDeSqUE2+BLBL/99wl2Ci5Mcvq49ahR5nfDMj8k6RTgvwiORF4Mp11M8HsEIDw1dnQ47V8JlsejBOvmKYIL+u2BGQQ3LHxGcER7UyTbBcBQgmtT7yZTGSVx1NHiScohuGD7x28wj/uB983s/lj9rZGkCwku7tb5wa0Gyr/ZrQNJmQS3TfZP5pA/Bfk/B9xnZk31/IbbC+01j5DvBVYQ3EYbr981vua4DroBP2mKIBHKoeFOh7pWwgNFAzGzWYn6XeNrjuvAzD4iuBbSVPnfVXsq56rzU0/OOecSatEXs51zzn1zLerUU69evWzQoEH1mnbHjh106tSp9oQtiNe55Wtt9QWvc10tX778CzOr+bxQNS0qUAwaNIhly5bVa9qcnBzGjRvXsAVq5rzOLV9rqy94netKUqIWFAA/9eScc64WHiicc84llLJTT5IeIXjicLOZ7dE+iqSf8vWTqm2Ag4B9zWyLpA0ETxqWA2Vmlp2qcjrnnEssldcoZhM00Ts31kgz+x1BW+hI+i5wvZltiSQ5rp6P3jvnmqHdu3eTl5dHSUlDtWoTW7du3VizZk1K82hukqlzRkYGAwYMoG3beI1fx5eyQGFmr0kalGTy8wjaZHLOtVB5eXl06dKFQYMGISXb+Gzdbd++nS5dutSesAWprc5mRmFhIXl5eQwePLjO80/pA3dhoHg21qmnSJqOBA2vZVUeUUj6mKAhMQMeTPSEraTLgcsBMjMzx8ybN69eZS0uLqZz57q+wmLv5nVu+ZpTfbt168aQIUNSGiQAysvLSU9vbq/fTq1k6mxmrFu3jq1bt1Ybftxxxy2v7fR+c7g99rvAGzVOOx1lZvmSegOLJH1gZq/FmjgMIrMAsrOzrb63iPktda1Da6tzc6rvmjVr6Nq1a8rz8SOK+DIyMjj00EPrPP/mcNfTZGqcdqp8SYeZbSZoZnpsE5Qrrnc/f5cPtiRqKdk551qOJg0U4QuFjiVo479yWKfKt5uFb8aaQNAWfLNx/nPnc84z5zR1MZxz9VTZgkPl97JlyxgxYgSlpaUArFu3jv33359t27btMW1BQQGnnXYaAIsWLWLMmDGMHDmSMWPG8MorX79KZPny5YwcOZKsrCyuvfbayndWs2XLFsaPH8/QoUMZP348X375JRCcGrr22mvJyspi1KhRvPPOO3vkXdPkyZNZu3Zt3Ho1lJQFCkmPEbxm8QBJeZIukXSlpCsjySYBL9Z4p24m8Lqkd4ElwD/M7AWccy5FsrOzOfbYY7n77rsBuPrqq7n99ttjniq75557uOyyywDo1asXzzzzDCtXrmTOnDlMmTKlKt20adN46KGHWLt2LWvXruWFF4K/sRkzZnDCCSewdu1aTjjhBGbMmAHA888/X5V21qxZTJtW+4sEp02bxl13pb5B4FTe9XReEmlmE9xGGx22Hvh2akrlnHOw7777VvsGuOOOOzj00ENp06YNZWVlnHde7L+w+fPnc9tttwFUO98/YsQIdu7cya5du9iyZQvbtm3jiCOCl/BdcMEFPPXUU5xyyik8/fTT5OTkADB16lTGjRvHnXfeydNPP80FF1yAJI444giKioooKCggMzOTa665hldeeYWBAwfStm1bLr74Ys4++2yOPvpoLrzwQsrKyuLWqyE0h4vZzrlW5tfPrGL1xj1P63wTw/t15VffHZFU2qVLl1b7BujevTvTp0/nqquuYvXq1TGn+/jjj+nRowft29d8lXoQQEaPHk379u3Jz89nwIABVeMGDBhAfn4+AJs2baJv3+DNxH369GHTpk0A5OfnM3DgwD2meeONN9iwYQOrV69m8+bNHHTQQVx88cUApKWlkZWVxcqVKznmmGNi1qshNIeL2c451yw8//zzZGZmxg0UBQUFMffWV61axY033siDDz5Yp/wk1Xq78Ouvv84555xDWloaffr04bjjjqs2vnfv3nz22Wd1yreu/IjCOdfokt3zb0zPPvssW7duZeHChUyaNImTTjqJjh07VkvToUOHPZ4sz8vLY9KkScydO5chQ4YA0L9/f/Ly8qql6d+/PwCZmZkUFBTQt29fCgoK6N27d9U0n376acxpEikpKSEjI6N+lU6SH1E451q9nTt38uMf/5iZM2cycuRIzjjjDG6//fY90g0bNowNGzZU9RcVFXHqqacyY8YMjjzyyKrhffv2pWvXrixevBgzY+7cuZxxxhkAnH766cyZMweAOXPmVBs+d+5czIzFixfTrVs3+vbty5FHHsn8+fOpqKhg06ZNVdc3Kn300UcMHz68gZdIdR4onHOt3m9+8xsmTZpU9Yd7yy238Nhjj1W79RSgU6dODBkyhNzcXADuu+8+cnNzufXWWznkkEM45JBD2Lx5MwD3338/l156KVlZWQwZMoRTTjkFgOnTp7No0SKGDh3KSy+9xPTp0wGYOHEi+++/P1lZWVx22WXcf//9AJx11lkMGDCA4cOHc/755zN69Gi6desGBNc7OnToQGZmZkqXj596cs61enfccUe1/i5durB+/fqYaa+55hpmz57Nbbfdxs0338zNN98cM112djbvv7/nI2A9e/bk5Zdf3mO4JGbOnLnH8LS0NO6++246d+5MYWEhY8eOZeTIkQA8+uijXHHFFbXW75vyQOGcc3UwadIkCgsLGzXP0047jaKiIkpLS/nFL35Bnz59gOBOrSlTprBz586U5u+Bwjnn6ujSSy9t1PxqXpeodNFFFzVK/n6NwjnnXEIeKJxzziXkgcI551xCHiicc84l5IHCOdfqRJvjLikp4cADD2TlypVV43/3u9/FvO10586dHHvssZSXl7NixQq+853vMGLECEaNGsXjjz9ele7jjz/m8MMPJysri3PPPbeq+fJdu3Zx7rnnkpWVxeGHH17t4b3f/va3ZGVlccABB7Bw4cJa63DDDTdUa9Z83LhxbNiwocGbGAcPFM65Vi4jI4N7772Xq666CjMjPz+fBx54oKr576hHHnmEM888k/T0dDp27MjcuXNZtWoVL7zwAtdddx1FRUUA3HjjjVx//fXk5ubSo0cPHn74YQAefvhhevToQW5uLtdffz033ngjAKtXr2bevHlV87rqqqsoLy9PWO4f/ehHMcuYCh4onHOtTs3muE8++WT69u3L3Llzuf7667nlllvo0aPHHtP95S9/qWpyY9iwYQwdOhSAfv360bt3bz7//HPMjFdeeYWzzz4bCJoSf+qppwB4+umnmTp1KgBnn302L7/8MmbG008/zeTJk2nfvj2DBw8mKyuLJUuWAMFT4wcccABHHXUU5513XtU7M/bbbz8KCwurGgTcZ599SE9Pb/AmxsGfo3DONYXnp8NnK2tPVxd9RsIpye1hx2qO+95772Xs2LEMHTq02guIKpWWlrJ+/fqYp3aWLFlCaWkpQ4YMobCwkO7du9OmTfD3Gm1iPNqUeJs2bejWrRuFhYXk5+dXvbsiOs3SpUuZP38+7777Lrt372b06NGMGTOmKt3o0aN54403mDBhAn/729/2qFND8UDhnHMERwXHH3981WtOa/riiy/o3r37HsMLCgqYMmUKc+bMIS2tYU/SvPHGG5xxxhlkZGSQkZHBd7/73Wrje/fuzcaNGxs0z1g8UDjnGl+Se/6NLS0tLe6ffawmxrdt28app57K7bffXnVE0LNnT4qKiigrK6NNmzbVmguvbEp8wIABlJWVsXXrVnr27Bm3ifFoU+WxlJSU0KFDh29S5aT4NQrnnEtCjx49KC8vrwoWpaWlTJo0iQsuuKDqegQEjfsdd9xxPPnkk8CeTYlXNjH+5JNPcvzxxyOJ008/nXnz5rFr1y4+/vhj1q5dy9ixYznyyCN55plnKCkpobi4mGeffbZamT766CMOPvjglNfdA4VzziVpwoQJvP766wA88cQTvPbaa8yePbuqifEVK1YAcOedd3LPPfeQlZVFYWEhl1xyCQCXXHIJhYWFZGVlcc8991TdtTRixAi+//3vM3z4cE4++WRmzpxJeno6hx12GKeffjqjRo3ilFNOYeTIkVVNjO/evZvc3Fyys7NTX3EzS8kHeATYDLwfZ/w4YCuwIvz8MjLuZOBDIBeYnmyeY8aMsfp69dVXk0578OyD7eDZB9c7r+aiLnVuKVpbnZtTfVevXt0o+Wzbti1l816+fLmdf/75KZt/LNu3bzczsx07dtiYMWNs+fLlZmb2t7/9zW6++WYzS77OsdYBsMxq+W9N5TWK2cB9wNwEaf5lZtWuHElKB2YC44E8YKmkBWYW+yW2zjnXSEaPHs1xxx1HeXk56enpjZLn5ZdfzurVqykpKWHq1KmMHj0agLKyMn7yk580ShlSFijM7DVJg+ox6Vgg18zWA0iaB5wBeKBwzjW5iy++uFHze/TRR2MOP+eccxqtDE1919N3JL0LbARuMLNVQH/g00iaPODweDOQdDlwOQQvLY/XbnttiouL6zxtffNqLupT571da6tzc6pvt27d2L59e8rzKS8vb5R8mpNk61xSUlKv7aEpA8U7wH5mVixpIvAUMLSuMzGzWcAsgOzsbBs3bly9CpOTk0PS0wY3LSSfvpmqU51biNZW5+ZU3zVr1tClS5eU57N9+/ZGyac5SbbOGRkZHHrooXWef5Pd9WRm28ysOOx+DmgrqReQDwyMJB0QDnPOOdcEmixQSOojSWH32LAshcBSYKikwZLaAZOBBU1VTueca+1SFigkPQa8BRwgKU/SJZKulHRlmORs4P3wGsV/A5PDu7XKgGuAhcAa4Inw2oVzzjWIaDPjADNnzqx6FuKQQw7h4IMPRhJr1qzZY9qCgoKqZj4WLVrEmDFjGDlyJGPGjKnW7Pfy5csZOXIkWVlZXHvttZW3/rNlyxbGjx/P0KFDGT9+PF9++SUQPKpw7bXXkpWVxahRo3jnnXdqrcfkyZNZu3Zt3Ho1lJQFCjM7z8z6mllbMxtgZg+b2QNm9kA4/j4zG2Fm3zazI8zszci0z5nZMDMbYma3p6qMzjkHcPXVV7NixYqqz+mnn84Pf/hDDjrooD3S3nPPPVx22WUA9OrVi2eeeYaVK1cyZ86cao0JTps2jYceeoi1a9eydu1aXnjhBQBmzJjBCSecwNq1aznhhBOqHrp7/vnnq9LOmjWLadOm1VruadOmcddddzXEIkjIn8x2zrU6NZsZj3rttdd44oknuP/++2NOO3/+fE4++WQADj30UPr16wcET1fv3LmTXbt2UVBQwLZt2zjiiCOQxAUXXBCzqfGaTZBfcMEFSOKII46gqKiIgoICKioquOqqqzjwwAMZP348EydOrGoe5Oijj+all16irKys1np9E019e6xzrhW6c8mdfLDlgwad54H7HMiNY29MKm2sZsYBioqKuPDCC/nTn/5E165d95ju448/pkePHrRv336PcfPnz2f06NG0b9+e/Px8BgwYUDUu2tT4pk2b6Nu3LwB9+vRh06ZNQPUmyKPTvPHGG2zYsIHVq1ezefNmDjrooKpnOdLS0sjKymLlypUcc8wxcev1TXmgcM650JVXXsmUKVM48sgjY44vKCiIube+atUqbrzxRl588cU65SeJ8J6euF5//XXOOecc0tLS6NOnD8cdd1y18b179656eVGqeKBwzjW6ZPf8G9OcOXP45JNP+POf/xw3TaymxvPy8pg0aRJz585lyJAhAHs0ER5tajwzM5OCggL69u1LQUEBvXv3rpomVlPjtSkpKSEjIyP5itaDX6NwzrV669ev52c/+xl/+ctfqt5MF8uwYcPYsGFDVX9RURGnnnoqM2bMqHYU0rdvX7p27crixYsxM+bOnRuzqfGaTZDPnTsXM2Px4sV069aNvn37cuSRRzJ//nwqKirYtGnTHk9Wf/TRRwwfPryBlkRsHiicc63enXfeyVdffcWZZ55Z7TbZf/3rX9XSderUiSFDhpCbmwvAfffdR25uLrfeemvVNJs3bwbg/vvv59JLLyUrK4shQ4ZwyimnADB9+nQWLVrE0KFDeemll5g+fToAEydOZP/99ycrK4vLLrus6mL6WWedxYABAxg+fDjnn38+o0ePrmpqfNOmTXTo0IHMzMyULh8/9eSca/UefPBBHnzwwaTSXnPNNcyePZvbbruNm2++mZtvvjlmuuzsbN5///09hvfs2ZOXX355j+GSmDlz5h7D09LSuPvuu+ncuTOFhYWMHTuWkSNHAkGDgVdccUVS5f4mPFA451wdTJo0icLCwkbN87TTTqOoqIjS0lJ+8Ytf0KdPHwC6d+/OlClT2LlzZ0rz90DhnHN1dOmllzZqfvFafL3ooosaJX+/RuGcazSVzVi4xvdNlr0HCudco8jIyKCwsNCDRRMwMwoLC+t9G62fenLONYoBAwaQl5fH559/ntJ8GuO5guYmmTpnZGRUe1q8LjxQOOcaRdu2bRk8eHDK88nJyanXy3n2Zqmus596cs45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCaUsUEh6RNJmSXu2ihWM/6Gk9yStlPSmpG9Hxm0Ih6+QtCxVZXTOOVe7VB5RzAZOTjD+Y+BYMxsJ/AaYVWP8cWZ2iJllp6h8zjnnkpCyB+7M7DVJgxKMfzPSuxio3yODzjnnUqq5PJl9CfB8pN+AFyUZ8KCZ1TzaqCLpcuByCF4xGK+VxdoUFxfXedr65tVc1KfOe7vWVufWVl/wOqeEmaXsAwwC3q8lzXHAGqBnZFj/8Ls38C5wTDL5jRkzxurr1VdfTTrtwbMPtoNnH1zvvJqLutS5pWhtdW5t9TXzOtcVsMxq+W9t0rueJI0C/gicYWZVbwIxs/zwezPwd2Bs05TQOedckwUKSd8C/gZMMbOPIsM7SRtZKUUAABo1SURBVOpS2Q1MAGLeOeWccy71UnaNQtJjwDigl6Q84FdAWwAzewD4JdATuF8SQJkFdzhlAn8Ph7UBHjWzF1JVTuecc4ml8q6n82oZfymwx/sEzWw98O09p3DOOdcU/Mls55xzCXmgcM45l1DCU0+SMoDTgKOBfsBOggvL/zCzVakvnnPOuaYWN1BI+jVBkMgB3gY2AxnAMGBGGER+YmbvNUI5nXPONZFERxRLzOxXccbdI6k38K0UlMk551wzEjdQmNk/Ek0YPgy3ucFL5Jxzrlmp9fZYSc8QtL0UtRVYRtAOU0kqCuacc655SOaup/VAMfBQ+NkGbCe4VvFQ6ormnHOuOUjmgbt/M7PDIv3PSFpqZodJ8jufnHOuhUvmiKJz2C4TUNVGU+ewtzQlpXLOOddsJHNE8RPgdUnrAAGDgavCBvvmpLJwzjnnml6tgcLMnpM0FDgwHPRh5AL2vSkrmXPOuWYh7qknSUdVdpvZLjN7N/yUhOO7Sjq4MQrpnHOu6SQ6ojhL0l3AC8By4HOCJ7OzCN5Ktx/BaSnnnHMtWKIH7q6XtA9wFnAO0Jegrac1BM9PvN44RXTOOdeUEl6jMLMtfP38hHPOuVbImxl3zjmXkAcK55xzCXmgcM45l1BS78yW9G/AoGh6M5ubojI555xrRmo9opD0J+Bu4CjgsPCTnczMJT0iabOk9+OMl6T/lpQr6T1JoyPjpkpaG36mJlUb55xzDS6ZI4psYLiZ1WxqPBmzgfuAeEcfpwBDw8/hwB+Aw8Pbcn8V5m3AckkLzOzLepTBOefcN5DMNYr3gT71mbmZvQZsSZDkDGCuBRYD3SX1BU4CFpnZljA4LAJOrk8ZnHPOfTPJHFH0AlZLWgLsqhxoZqc3QP79gU8j/XnhsHjD9yDpcuBygMzMTHJycupVkOLi4jpPW9+8mov61Hlv19rq3NrqC17nVEgmUNySstwbgJnNAmYBZGdn27hx4+o1n5ycHJKeNmwzt755NRd1qnML0drq3NrqC17nVKj11JOZ/RP4AOgSftaEwxpCPjAw0j8gHBZvuHPOuUaWzF1P3weWELT39H3gbUlnN1D+C4ALwrufjgC2mlkBsBCYIKmHpB7AhHCYc865RpbMqaefA4eZ2WYASfsCLwFP1jahpMeAcUAvSXkEdzK1BTCzB4DngIlALvAVcFE4bouk3wBLw1ndGrY75ZxzrpElEyjSKoNEqJAkn+g2s/NqGW/A1XHGPQI8kkw+zjnnUieZQPGCpIXAY2H/uQRHAs4551qBZF6F+lNJZwFHhoNmmdnfU1ss55xzzUVSbT2Z2XxgforL4pxzrhmKGygkvW5mR0naTtCMRtUogssLXVNeOuecc00u0atQjwq/uzRecZxzzjU3ybYeW+sw55xzLVMyt7mOiPZIagOMSU1xnHPONTdxA4Wkm8LrE6MkbQs/24FNwNONVkLnnHNNKm6gMLPfhtcnfmdmXcNPFzPraWY3NWIZnXPONaFknqO4KWxvaSiQERn+WioL5pxzrnmoNVBIuhT4d4IWXFcARwBvAcentmjOOeeag2QuZv87wXuyPzGz44BDgaKUlso551yzkUygKDGzEgBJ7c3sA+CA1BbLOedcc5FMEx55kroDTwGLJH0JfJLaYjnnnGsukrmYPSnsvEXSq0A34IWUlso551yzkTBQSEoHVpnZgVD1WlTnnHOtSMJrFGZWDnwo6VuNVB7nnHPNTDLXKHoAqyQtAXZUDjSz01NWKuecc81GMoHiFykvhXPOuWYrmYvZ/5S0HzDUzF6S1BFIT33RnHPONQfJNDN+GfAk8GA4qD/BrbK1knSypA8l5UqaHmP8f0paEX4+klQUGVceGbcgueo455xraMmceroaGAu8DWBmayX1rm2i8I6pmcB4IA9YKmmBma2uTGNm10fS/4jgqe9KO83skKRq4ZxzLmWSeTJ7l5mVVvaE76OwBOkrjQVyzWx9OP084IwE6c8DHktivs455xpRMkcU/5T0M6CDpPHAVcAzSUzXH/g00p8HHB4rYXgNZDDwSmRwhqRlQBkww8xinu6SdDlwOUBmZiY5OTlJFG1PxcXFdZ62vnk1F/Wp896utdW5tdUXvM6pkEygmA5cAqwErgCeA/7YwOWYDDwZPrdRaT8zy5e0P/CKpJVmtq7mhGY2C5gFkJ2dbePGjatXAXJyckh62jnBV33zai7qVOcWorXVubXVF7zOqZDMXU8VwEPhpy7ygYGR/gHhsFgmE1wLieabH36vl5RDcP1ij0DhnHMuteIGCkkrSXAtwsxG1TLvpcBQSYMJAsRk4Acx8jmQ4KG+tyLDegBfmdkuSb2AI4G7asmvyS3ftJwdu3dwzIBjmroozjnXYBIdUZz2TWZsZmWSrgEWEjx38YiZrZJ0K7DMzCpveZ0MzDOzaFA6CHhQUgXBBfcZ0bulmqsLX7gQgJVTVzZtQZxzrgHFDRRmVtWUeI0H7jokmq7GPJ4juKYRHfbLGv23xJjuTWBkMnk455xLrfo8cDeAJB+4c845t/dL5jmKqwmuEWyD4IE7oNYH7pxzzrUMqXzgzjnnXAuQTKCo+cDdX0nugTvnnHMtQDKBYjrwOdUfuLs5lYVyzjnXfCRz91IHgltbH4Kqxv46AF+lsmDOOeeah2SOKF4mCAyVOgAvpaY4zjnnmptkAkWGmRVX9oTdHVNXJOecc81JMoFih6TRlT2SxgA7U1ck55xzzUky1yiuA/4qaSMgoA9wbkpL5ZxzrtlIpvXYpWHDfQeEgz40s92pLZZzzrnmIpkmPK4GOpnZ+2b2PtBZ0lWpL5pzzrnmIJlrFJeZWVFlj5l9CVyWuiI555xrTpIJFOmSVNkTPkfRLnVFcs4515wkczH7BeBxSZWtx14RDnPOOdcKJBMobgQuB6aF/Yuo+2tRnXPO7aVqPfVkZhVm9oCZnW1mZwOrgf9JfdGcc841B0m9qU7SocB5wPeBj4G/pbJQzjnnmo+4gULSMILgcB7wBfA4IDM7rpHK5pxzrhlIdOrpA+B44DQzO8rM/gcor8vMJZ0s6UNJuZKmxxh/oaTPJa0IP5dGxk2VtDb8TK1Lvs455xpOolNPZwKTgVclvQDMI2jCIynhbbQzgfFAHrBU0gIzW10j6eNmdk2NafcBfgVkE7xNb3k47ZfJ5u+cc65hxD2iMLOnzGwycCDwKkGbT70l/UHShCTmPRbINbP14atU5wFnJFmuk4BFZrYlDA6LgJOTnNY551wDSuaupx1m9qiZfRcYAPwvwS2ztekPfBrpzwuH1XSWpPckPSlpYB2ndc45l2JJ3fVUKdy7nxV+GsIzwGNmtkvSFcAcgusiSZN0OcFzHmRmZpKTk1OvghQXF9d52njp61uGxlafOu/tWludW1t9weucCnUKFHWUDwyM9A8Ih1Uxs8JI7x+BuyLTjqsxbU6sTMysKnBlZ2fbuHHjYiWrVU5ODklPOyf42iN9vOHNVJ3q3EK0tjq3tvqC1zkVkmnrqb6WAkMlDZbUjuDC+IJoAkl9I72nA2vC7oXABEk9JPUAJoTDnHPONbKUHVGYWZmkawj+4NOBR8xslaRbgWVmtgC4VtLpQBmwBbgwnHaLpN8QBBuAW81sS6rK6pxzLr5UnnrCzJ4Dnqsx7JeR7puAm+JM+wjwSCrL55xzrnapPPXknHOuBfBA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xLyQOGccy4hDxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLqGUBgpJJ0v6UFKupOkxxv9Y0mpJ70l6WdJ+kXHlklaEnwWpLKdzzrn42qRqxpLSgZnAeCAPWCppgZmtjiT7XyDbzL6SNA24Czg3HLfTzA5JVfmcc84lJ5VHFGOBXDNbb2alwDzgjGgCM3vVzL4KexcDA1JYHuecc/WQsiMKoD/waaQ/Dzg8QfpLgOcj/RmSlgFlwAwzeyrWRJIuBy4HyMzMJCcnp16FLS4urvO08dLXtwyNrT513tu1tjq3tvqC1zkVUhkokibpfCAbODYyeD8zy5e0P/CKpJVmtq7mtGY2C5gFkJ2dbePGjatXGXJyckh62jnB1x7p4w1vpupU5xaitdW5tdUXvM6pkMpTT/nAwEj/gHBYNZJOBH4OnG5muyqHm1l++L0eyAEOTWFZnXPOxZHKQLEUGCppsKR2wGSg2t1Lkg4FHiQIEpsjw3tIah929wKOBKIXwZ1zzjWSlJ16MrMySdcAC4F04BEzWyXpVmCZmS0Afgd0Bv4qCeD/zOx04CDgQUkVBMFsRo27pZxzzjWSlF6jMLPngOdqDPtlpPvEONO9CYxMZdmcc84lx5/Mds45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcM45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcM45l5AHCueccwl5oHDOOZeQBwrnnHMJeaBwzjmXkAeKGk77f9/nf566DoA31z3PB4+eCTuLWFe0jg1bNzRt4Zxzrgmk9FWoe4vZ78+mrKSMcYzjk7Q1zNq6hivKKrji9f8AYOU7c/le7kNB97BpTVlU55xrdH5EAfx++e/5r03/hZlVDdu8vaSqe+vO0q8TL7zp6+7Sr5Ka/49e/hEj5/grwJ1ze6eUBgpJJ0v6UFKupOkxxreX9Hg4/m1JgyLjbgqHfyjppFSWs1JFxdeBYseu8qruaACp5o6+bNqxidwv18JHC+PONycvp6q7ZGcRbxe8XdVfXFpcmTmUlwFQXlHOFzu/qEcNkjf/o/lsL9+e0jyccy1Dyk49SUoHZgLjgTxgqaQFZrY6kuwS4Eszy5I0GbgTOFfScGAyMALoB7wkaZiZlZNCh/z521XdZy/8t6ruozfOreoeOfhb1bufPHGP+USPHgaWpENGOJ+HR1DUJojN3XeLorZBAOpb0p7itjvZnr5n3D5gpyhNL6O9pbMzvTfdrZTP03fRYXtnhqVvJz+9HMjgvQ7bGfLlAEo7t6OszWcMsK6UlZbSJ703FWYsbPch+1cMpM9X7Uhv04l/ZbwHwMJH5tK9Ux8og50V2+ioLrTLKKdb+kGUlW7kwx1dKEvPYzlvMo5DqPhyO6/2WMuU9t8lzcrYP72cVdpKl5J9sd79KN32f+zfuScf7v6c8lIxqlMXiuhKQfFHdG+bQZdO2XxSupZeHQew4bPlfLD9bS4c8hNyi5aRlpFBp686Ud5xH0Zm7sfOnVtYt3MLUEav9gNJJ51uuzewo11f1hVv5J/Fr3BSz0vpXFZMehuxtegjhn3rQNZ98Rlj+45gK7uhoi3atYtuX63lgy6j0BfreXt1OvlFn5HRKYPBHfuw4atC2rbvRknxJg7aN4u31rzMxi/eY0TWWPr1+Dad2nfF2E1ndvJFwceU9RhG5/Ri2pbu5v+2ltGjR0faqQNFtoV9Swoppx27duyg46Ax5Bd8QLtdX5DV5wB27zLaduyBFX7Elvad6GglpHftR1pxETsy+tCjvSiyNvRKM3a370L6to20a9seddqHL7YUk/fBS3TsM5wDBx9AefsupLfJoLx0O1a6E7XJIL1tO9IFpeVl2NY8KjK6s277CkZtHUpa2S46d9wXlZewpayE7VuK6dJzX7qmVZDetgM7ykXHtu34rHgjvTtmkt6mHWkVpZSpLWlWBmlp7C4z0tPTSU8XVlFOhRmYUbx9E1269iZNbSirKEdqQ5os2PFKqwBrQxsZuysqaJPWBiREBZKoqDCUlkZFRRkind07Pqdtp14gkNLADMMwMySRpjTKKoy0tDQqystJTxMVZaWkt20PQLlV8FXZV1RUlAMKhlVUYIR5W5CfWQUgDKOiopy0tHTS09KDncLwY0CFQXqaqvKvMEhLE+LrHUgLczIgTaIiTGsYMigtL6WN0iAtnTSlYRUVQRkqykHVf/Pl5RVBfhgKFgKSwIwKjLSwTlUktpYUU16R0r9GFHdv+ZvOWPoOcIuZnRT23wRgZr+NpFkYpnlLUhvgM2BfYHo0bTRdojyzs7Nt2bJldSqnmTFq7qg6TeOcc83Nkh8so0MYMOtC0nIzy06UJpUXs/sDn0b684DD46UxszJJW4Ge4fDFNabtHysTSZcDlwNkZmaSk5NTp0KWV6QmUDrnXGN6+/U39jhCaSh7/V1PZjYLmAXBEcW4cePqPI+VrCQnJ4f6TLs38zq3fK2tvuB1ToVUXszOBwZG+geEw2KmCU89dQMKk5zWOedcI0hloFgKDJU0WFI7govTC2qkWQBMDbvPBl6x4KLJAmByeFfUYGAosCSFZXXOORdHyk49hdccrgEWAunAI2a2StKtwDIzWwA8DPxJUi6whSCYEKZ7AlgNlAFXp/qOJ+ecc7Gl9BqFmT0HPFdj2C8j3SXAOXGmvR24PZXlc845Vzt/Mts551xCHiicc84l5IHCOedcQh4onHPOJZSyJjyagqTPgU/qOXkvILUt8TU/XueWr7XVF7zOdbWfme2bKEGLChTfhKRltbV30tJ4nVu+1lZf8Dqngp96cs45l5AHCueccwl5oPjarKYuQBPwOrd8ra2+4HVucH6NwjnnXEJ+ROGccy4hDxTOOecSavWBQtLJkj6UlCtpelOXpyFJ2iBppaQVkpaFw/aRtEjS2vC7Rzhckv47XA7vSRrdtKVPjqRHJG2W9H5kWJ3rKGlqmH6tpKmx8mou4tT5Fkn54bpeIWliZNxNYZ0/lHRSZPhese1LGijpVUmrJa2S9O/h8Ba7nhPUuWnWs5m12g9B8+frgP2BdsC7wPCmLlcD1m8D0KvGsLuA6WH3dODOsHsi8DzBe+KPAN5u6vInWcdjgNHA+/WtI7APsD787hF292jqutWxzrcAN8RIOzzcrtsDg8PtPX1v2vaBvsDosLsL8FFYrxa7nhPUuUnWc2s/ohgL5JrZejMrBeYBZzRxmVLtDGBO2D0H+F5k+FwLLAa6S+rbFAWsCzN7jeBdJlF1reNJwCIz22JmXwKLgJNTX/r6iVPneM4A5pnZLjP7GMgl2O73mm3fzArM7J2wezuwBuhPC17PCeocT0rXc2sPFP2BTyP9eSReGXsbA16UtFzS5eGwTDMrCLs/AzLD7pa0LOpax5ZS92vCUy2PVJ6GoYXVWdIg4FDgbVrJeq5RZ2iC9dzaA0VLd5SZjQZOAa6WdEx0pAXHrC36/ujWUMfQH4AhwCFAAfD7pi1Ow5PUGZgPXGdm26LjWup6jlHnJlnPrT1Q5AMDI/0DwmEtgpnlh9+bgb8THIZuqjylFH5vDpO3pGVR1zru9XU3s01mVm5mFcBDBOsaWkidJbUl+MP8i5n9LRzcotdzrDo31Xpu7YFiKTBU0mBJ7Qje2b2gicvUICR1ktSlshuYALxPUL/Kuz2mAk+H3QuAC8I7Ro4AtkYO6/c2da3jQmCCpB7hofyEcNheo8b1pEkE6xqCOk+W1F7SYGAosIS9aNuXJOBhYI2Z3RMZ1WLXc7w6N9l6buqr+039IbhD4iOCOwN+3tTlacB67U9wh8O7wKrKugE9gZeBtcBLwD7hcAEzw+WwEshu6jokWc/HCA7BdxOcf72kPnUELia4AJgLXNTU9apHnf8U1um98I+gbyT9z8M6fwicEhm+V2z7wFEEp5XeA1aEn4kteT0nqHOTrGdvwsM551xCrf3Uk3POuVp4oHDOOZeQBwrnnHMJeaBwzjmXkAcK55xzCXmgcC2OpPJI65orwiYQWgRJh0p6OOy+UNJ9NcbnSMpOMP08SUNTXU7XsrRp6gI4lwI7zeyQWCPCB5lkwZOte6OfAbd9g+n/APwHcFnDFMe1Bn5E4Vo8SYPC9vjnEjzJOlDSTyUtDRtX+3Uk7c8lfSTpdUmPSbohHF61py6pl6QNYXe6pN9F5nVFOHxcOM2Tkj6Q9JcwSCHpMElvSnpX0hJJXSS9JumQSDlel/TtGvXoAowys3eTqPPpkSOqDyV9HI76F3CiJN9JdEnzjcW1RB0krQi7PwauJ2jSYKqZLZY0IewfS/AU74KwwcQdBE0cHELw23gHWF5LXpcQNBFxmKT2wBuSXgzHHQqMADYCbwBHSloCPA6ca2ZLJXUFdhI013AhcJ2kYUBGjICQzddNNlQ6V9JRkf4sADNbQNhUg6QngH+Gwysk5QLfTqJuzgEeKFzLVO3UU3iN4hML3k0AQRs/E4D/Dfs7EwSOLsDfzeyrcLpk2sSZAIySdHbY3y2cVymwxMzywnmtAAYBW4ECM1sKYGErqJL+CvxC0k8JmpmYHSOvvsDnNYY9bmbXROqaEx0p6T8IlsfMyODNQD88ULgkeaBwrcWOSLeA35rZg9EEkq5LMH0ZX5+qzagxrx+ZWbXG5SSNA3ZFBpWT4PdmZl9JWkTwUpnvA2NiJNtZI++EJJ0InEPwRryojHBeziXFr1G41mghcLGCtv6R1F9Sb+A14HuSOoTXA74bmWYDX/95n11jXtMUNAmNpGFha73xfAj0lXRYmL5L5HrBH4H/BpZa8Aa2mtYQnlqqjaT9CBrGO8fMagaFYex5Csu5uPyIwrU6ZvaipIOAt8Lry8XA+Wb2jqTHCVrc3UzQRHOlu4EnFLwp8B+R4X8kOKX0Tnix+nO+fiVnrLxLJZ0L/I+kDgR79icCxWa2XNI24P/FmfYDSd0kdbHg9ZiJXEjQuupTYR03mtlESZkEp6I+q2V656p467HOxSHpFoI/8LsbKb9+QA5wYLzbdyVdD2w3sz/WM4/rgW1m9nC9C+paHT/15FwzIOkCgnci/7yWZzz+QPVrH3VVBMz5BtO7VsiPKJxzziXkRxTOOecS8kDhnHMuIQ8UzjnnEvJA4ZxzLiEPFM455xL6/5osO8ZjIYM1AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     }
-    }
    ]
   },
   {
@@ -1396,6 +1383,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1404,13 +1392,8 @@
     "id": "s1EOA2jaOnMF",
     "outputId": "0cef351f-f361-43ac-92d3-2d285a43bf73"
    },
-   "source": [
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -1532,16 +1515,22 @@
        "[138440 rows x 3 columns]"
       ]
      },
+     "execution_count": 117,
      "metadata": {},
-     "execution_count": 117
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "RD-ya2m7jUfb"
    },
+   "outputs": [],
    "source": [
     "def get_fft_from_psd(df,bin_width):\n",
     "  fs = len(df)/(df.index[-1]-df.index[0])\n",
@@ -1557,12 +1546,11 @@
     "  df_psd.columns\n",
     "  df_psd['Frequency (Hz)'] = f\n",
     "  return df_psd.set_index('Frequency (Hz)')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1571,24 +1559,8 @@
     "id": "axwfbM7T1Gvs",
     "outputId": "ea167946-0426-49e5-8e02-228616f8c3ea"
    },
-   "source": [
-    "df_fft_from_psd = get_fft_from_psd(df,.25)\n",
-    "\n",
-    "fig = xp.line(df_fft_from_psd)\n",
-    "fig.update_layout(\n",
-    "    title=\"FFT from PSD\",\n",
-    "    xaxis_title=\"Frequency (Hz)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    "    #xaxis_type=\"log\",\n",
-    "    #yaxis_type=\"log\"\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('fft_from_psd.html',full_html=False,include_plotlyjs='cdn')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -1624,8 +1596,23 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_fft_from_psd = get_fft_from_psd(df,.25)\n",
+    "\n",
+    "fig = xp.line(df_fft_from_psd)\n",
+    "fig.update_layout(\n",
+    "    title=\"FFT from PSD\",\n",
+    "    xaxis_title=\"Frequency (Hz)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    "    #xaxis_type=\"log\",\n",
+    "    #yaxis_type=\"log\"\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('fft_from_psd.html',full_html=False,include_plotlyjs='cdn')"
    ]
   },
   {
@@ -1640,9 +1627,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "kLcuacqMnlQA"
    },
+   "outputs": [],
    "source": [
     "def moving_frequency(df,steps):\n",
     "  #df.index = np.linspace(df.index[0],df.index[-1],num=df.shape[0]) #resample to have uniform sampling\n",
@@ -1659,12 +1648,11 @@
     "    df_peak_freqs.loc[time] = df_psd.idxmax()\n",
     "  return df_peak_freqs\n",
     "    \n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1673,22 +1661,8 @@
     "id": "ZDARGyY_pGc3",
     "outputId": "d516952c-3d85-4061-dc3f-b11e2e901466"
    },
-   "source": [
-    "df_peak_freqs = moving_frequency(df,40) #get rolling peak frequency for 20 different steps\n",
-    "\n",
-    "fig = xp.line(df_peak_freqs)\n",
-    "fig.update_layout(\n",
-    "    title=\"Rolling Peak Frequency\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Peak Frequency (Hz)\",\n",
-    ")\n",
-    "fig.show()\n",
-    "fig.write_html('rolling_peak_frequency.html',full_html=False,include_plotlyjs='cdn')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -1724,20 +1698,57 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_peak_freqs = moving_frequency(df,40) #get rolling peak frequency for 20 different steps\n",
+    "\n",
+    "fig = xp.line(df_peak_freqs)\n",
+    "fig.update_layout(\n",
+    "    title=\"Rolling Peak Frequency\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Peak Frequency (Hz)\",\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_html('rolling_peak_frequency.html',full_html=False,include_plotlyjs='cdn')"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "FkRATc7ImdFo"
    },
-   "source": [
-    ""
-   ],
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "name": "Webinar-Intro-Python-Acceleration-CSV-Analysis.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
+++ b/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
@@ -517,6 +517,7 @@
     "The trouble is that plotting too many data points may be sluggish. I've long maintained that plotting 10s of thousands of data points isn't very useful anyways, you just get a shaded mess. \n",
     "\n",
     "So here we'll plot:\n",
+    "\n",
     "- The moving peak value\n",
     "- The moving RMS\n",
     "- The time history around the peak"

--- a/docs/webinars/Webinar_Introduction_NumPy_and_Pandas.ipynb
+++ b/docs/webinars/Webinar_Introduction_NumPy_and_Pandas.ipynb
@@ -1,21 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "Webinar-Introduction-NumPy-and-Pandas.ipynb",
-   "provenance": [],
-   "collapsed_sections": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -29,9 +12,9 @@
     "\n",
     "This notebook and accompanying webinar was developed and released by the [enDAQ team](https://endaq.com/). This is the second \"chapter\" of our series on *Python for Mechanical Engineers*:\n",
     "1. [Get Started with Python](https://colab.research.google.com/drive/1_pcGtgJleapV9tz5WfuRuqfWryjqhPHy#scrollTo=ikUJITDDIp19)\n",
-    "  * Blog: [Get Started with Python: Why and How Mechanical Engineers Should Make the Switch](https://blog.endaq.com/get-started-with-python-why-how-mechanical-engineers-should-make-the-switch)\n",
+    "   * Blog: [Get Started with Python: Why and How Mechanical Engineers Should Make the Switch](https://blog.endaq.com/get-started-with-python-why-how-mechanical-engineers-should-make-the-switch)\n",
     "2. **Introduction to Numpy & Pandas**\n",
-    "  * [Watch Recording of This](https://info.endaq.com/pandas-and-numpy-for-data-analysis-webinar)\n",
+    "   * [Watch Recording of This](https://info.endaq.com/pandas-and-numpy-for-data-analysis-webinar)\n",
     "3. [Introduction to Plotly](https://colab.research.google.com/drive/1pag2pKQQW5amWgRykAH8uMAPqHA2yUfU?usp=sharing)\n",
     "4. [Introduction of the enDAQ Library](https://colab.research.google.com/drive/1WAtQ8JJC_ny0fki7eUABACMA-isZzKB6)\n",
     "\n",
@@ -48,14 +31,14 @@
     "\n",
     "1. Python is popular for good reason\n",
     "2. There are many ways to interact with Python\n",
-    "  * Here we are in Google Colab based on Jupyter Notebooks\n",
+    "   * Here we are in Google Colab based on Jupyter Notebooks\n",
     "3. There are many open source libraries to use\n",
-    "  * Today we are covering two of the most popular:\n",
-    "    * Numpy\n",
-    "    * Pandas\n",
-    "  * And teasing a bit of:\n",
-    "    * Plotly\n",
-    "    * enDAQ\n",
+    "   * Today we are covering two of the most popular:\n",
+    "     * Numpy\n",
+    "     * Pandas\n",
+    "   * And teasing a bit of:\n",
+    "     * Plotly\n",
+    "     * enDAQ\n",
     "\n",
     "<img src=\"https://info.endaq.com/hubfs/20210928-python-ide-libraries-inforgraphic-FINAL-2.png\" width=\"700\">"
    ]
@@ -74,6 +57,7 @@
     "* Do both!\n",
     "\n",
     "**Here are a few resources:**\n",
+    "\n",
     "* [Jake VanderPlas Python Data Science Handbook](https://colab.research.google.com/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/Index.ipynb)\n",
     "  * [Buy the book](https://www.amazon.com/Python-Data-Science-Handbook-Essential-ebook-dp-B01N2JT3ST/dp/B01N2JT3ST/ref=mt_other?_encoding=UTF8&me=&qid=) for $35\n",
     "  * Go through a series of [well documented Colab Notebooks](https://colab.research.google.com/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/Index.ipynb)\n",
@@ -102,21 +86,22 @@
     ">*At the core of the NumPy package, is the ndarray object. This encapsulates n-dimensional arrays of homogeneous data types, with many operations being performed in compiled code for performance.*\n",
     "\n",
     "Let's get started by importing it, typically shortened to `np` because of how frequently it's called. This will come standard in most Python distributions such as Anaconda. If you need to install it simply:\n",
-    "~~~\n",
+    "\n",
+    "```\n",
     "!pip install numpy\n",
-    "~~~"
+    "```"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "VLP6WeFY8UWo"
    },
+   "outputs": [],
    "source": [
     "import numpy as np"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -139,6 +124,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -146,22 +132,21 @@
     "id": "RFL-_fg5IDeg",
     "outputId": "373c2282-92f1-4dab-b75f-55fcf5764575"
    },
-   "source": [
-    "lst = [0, 1, 2, 3]\n",
-    "lst * 2"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "[0, 1, 2, 3, 0, 1, 2, 3]"
       ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 2
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "lst = [0, 1, 2, 3]\n",
+    "lst * 2"
    ]
   },
   {
@@ -175,6 +160,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -182,21 +168,20 @@
     "id": "zMQ03IPWIS7S",
     "outputId": "f1ba686c-6261-408a-aae7-ea49e83e9141"
    },
-   "source": [
-    "[i * 2 for i in lst]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "[0, 2, 4, 6]"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "[i * 2 for i in lst]"
    ]
   },
   {
@@ -210,6 +195,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -217,23 +203,22 @@
     "id": "qkFeoqrRIn-r",
     "outputId": "c62abf15-989d-4a01-cdb3-8b8af8c8fd5e"
    },
-   "source": [
-    "array = np.array(lst)\n",
-    "print(array)\n",
-    "print(array * 2)\n",
-    "print(array + 2)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0 1 2 3]\n",
       "[0 2 4 6]\n",
       "[2 3 4 5]\n"
      ]
     }
+   ],
+   "source": [
+    "array = np.array(lst)\n",
+    "print(array)\n",
+    "print(array * 2)\n",
+    "print(array + 2)"
    ]
   },
   {
@@ -247,6 +232,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -254,15 +240,8 @@
     "id": "DLQY2HN_JdcB",
     "outputId": "d4a0c081-676a-43a9-b08d-84f33a613170"
    },
-   "source": [
-    "np.array([[1, 0, 0],\n",
-    "          [0, 1, 0],\n",
-    "          [0, 0, 1]], dtype=np.float32)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[1., 0., 0.],\n",
@@ -270,9 +249,15 @@
        "       [0., 0., 1.]], dtype=float32)"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.array([[1, 0, 0],\n",
+    "          [0, 1, 0],\n",
+    "          [0, 0, 1]], dtype=np.float32)"
    ]
   },
   {
@@ -288,6 +273,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -295,25 +281,25 @@
     "id": "CQyecbfVL3F9",
     "outputId": "fb2c7665-6da1-4299-c57d-2cd26348b699"
    },
-   "source": [
-    "np.zeros(5)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0., 0., 0., 0., 0.])"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "execution_count": 6
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.zeros(5)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -321,26 +307,26 @@
     "id": "1TP42y0nL5iq",
     "outputId": "49751d7a-31ca-4205-e2ca-1e4abd980a7a"
    },
-   "source": [
-    "np.zeros([2, 3])"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0., 0., 0.],\n",
        "       [0., 0., 0.]])"
       ]
      },
+     "execution_count": 7,
      "metadata": {},
-     "execution_count": 7
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.zeros([2, 3])"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -348,13 +334,8 @@
     "id": "22P2Xf2aL-T8",
     "outputId": "797a529d-9e08-48e5-cddb-ada72817ed66"
    },
-   "source": [
-    "np.eye(3)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[1., 0., 0.],\n",
@@ -362,9 +343,13 @@
        "       [0., 0., 1.]])"
       ]
      },
+     "execution_count": 8,
      "metadata": {},
-     "execution_count": 8
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.eye(3)"
    ]
   },
   {
@@ -378,32 +363,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "vVFX3uuD-E0G",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "vVFX3uuD-E0G",
     "outputId": "37e76848-9dee-4296-f453-e531243fd469"
    },
-   "source": [
-    "np.arange(10)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])"
       ]
      },
+     "execution_count": 9,
      "metadata": {},
-     "execution_count": 9
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.arange(10)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -411,26 +397,26 @@
     "id": "-ZkTkdK5EtRg",
     "outputId": "dc486237-4d77-4be8-f2b8-89fad6726b5b"
    },
-   "source": [
-    "np.arange(0,  #start\n",
-    "          10) #stop (not included in array)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "execution_count": 10
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.arange(0,  #start\n",
+    "          10) #stop (not included in array)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -438,27 +424,27 @@
     "id": "a5OIfwPN-O48",
     "outputId": "b4768962-0028-469d-c194-af02dd98f1a7"
    },
-   "source": [
-    "np.arange(0,  #start\n",
-    "          10, #stop (not included in array)\n",
-    "          2)  #step size"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0, 2, 4, 6, 8])"
       ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "execution_count": 11
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.arange(0,  #start\n",
+    "          10, #stop (not included in array)\n",
+    "          2)  #step size"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -466,27 +452,27 @@
     "id": "yAO2opdCKMVE",
     "outputId": "911b0441-5f17-4886-dfeb-f30150a133ac"
    },
-   "source": [
-    "np.linspace(0,  #start\n",
-    "            10, #stop (default to be included, can pass in endpoint=False)\n",
-    "            6)  #number of data points evenly spaced"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 0.,  2.,  4.,  6.,  8., 10.])"
       ]
      },
+     "execution_count": 12,
      "metadata": {},
-     "execution_count": 12
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.linspace(0,  #start\n",
+    "            10, #stop (default to be included, can pass in endpoint=False)\n",
+    "            6)  #number of data points evenly spaced"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -494,23 +480,22 @@
     "id": "x0xigPrOK4Y1",
     "outputId": "f2f023ee-94f7-44da-a7b1-7b7bc89dc776"
    },
-   "source": [
-    "np.logspace(0, #output starts being raised to this value\n",
-    "            3, #ending raised value\n",
-    "            4) #number of data points"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([   1.,   10.,  100., 1000.])"
       ]
      },
+     "execution_count": 13,
      "metadata": {},
-     "execution_count": 13
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.logspace(0, #output starts being raised to this value\n",
+    "            3, #ending raised value\n",
+    "            4) #number of data points"
    ]
   },
   {
@@ -524,6 +509,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -531,25 +517,25 @@
     "id": "J3txdCX2LTjy",
     "outputId": "de2c4c21-ea5d-4bb3-9b5f-ebc1b138357f"
    },
-   "source": [
-    "10 ** np.linspace(0,3,4)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([   1.,   10.,  100., 1000.])"
       ]
      },
+     "execution_count": 14,
      "metadata": {},
-     "execution_count": 14
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "10 ** np.linspace(0,3,4)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -557,21 +543,20 @@
     "id": "Ew2EuHuELa-A",
     "outputId": "30ca9d00-eabb-4826-e6d0-e3d41f262c0d"
    },
-   "source": [
-    "np.logspace(0, 4, 5, base=2)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1.,  2.,  4.,  8., 16.])"
       ]
      },
+     "execution_count": 15,
      "metadata": {},
-     "execution_count": 15
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.logspace(0, 4, 5, base=2)"
    ]
   },
   {
@@ -585,6 +570,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -592,21 +578,20 @@
     "id": "ytK6IH_HLnXF",
     "outputId": "bf3d4c46-b54a-4703-e32b-55c3f3d1d4ed"
    },
-   "source": [
-    "np.geomspace(1, 1000, 4)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([   1.,   10.,  100., 1000.])"
       ]
      },
+     "execution_count": 16,
      "metadata": {},
-     "execution_count": 16
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.geomspace(1, 1000, 4)"
    ]
   },
   {
@@ -620,6 +605,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -627,25 +613,25 @@
     "id": "CNipvh8wMi5t",
     "outputId": "28a12c88-6e3b-4d1f-d571-495db1fcc42b"
    },
-   "source": [
-    "np.random.rand(5)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0.05057259, 0.19699801, 0.46727495, 0.67357217, 0.60387782])"
       ]
      },
+     "execution_count": 17,
      "metadata": {},
-     "execution_count": 17
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.random.rand(5)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -653,22 +639,21 @@
     "id": "YtcgKwEhMosI",
     "outputId": "e632e6a6-5b74-4b64-a0b8-00c4e94fd72b"
    },
-   "source": [
-    "np.random.rand(2, 3)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0.76299702, 0.06301467, 0.92031266],\n",
        "       [0.42219446, 0.73721929, 0.39450975]])"
       ]
      },
+     "execution_count": 18,
      "metadata": {},
-     "execution_count": 18
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.random.rand(2, 3)"
    ]
   },
   {
@@ -684,6 +669,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -691,22 +677,21 @@
     "id": "qkWur-4ARuBa",
     "outputId": "b2d0a3a6-2c5a-4e24-e849-5ca49ba53aff"
    },
-   "source": [
-    "array = np.arange(1, 11, 1)\n",
-    "array"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10])"
       ]
      },
+     "execution_count": 19,
      "metadata": {},
-     "execution_count": 19
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array = np.arange(1, 11, 1)\n",
+    "array"
    ]
   },
   {
@@ -720,6 +705,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -727,21 +713,20 @@
     "id": "OFCBTk5qTvLp",
     "outputId": "a7f71372-c785-46f5-ea94-3c11437fe9b5"
    },
-   "source": [
-    "array[0]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "1"
       ]
      },
+     "execution_count": 20,
      "metadata": {},
-     "execution_count": 20
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[0]"
    ]
   },
   {
@@ -755,6 +740,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -762,21 +748,20 @@
     "id": "7Ct2CXINT_HH",
     "outputId": "5571a5f0-e08c-4a1f-cacf-a5158d5691d7"
    },
-   "source": [
-    "array[-1]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "10"
       ]
      },
+     "execution_count": 21,
      "metadata": {},
-     "execution_count": 21
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[-1]"
    ]
   },
   {
@@ -790,6 +775,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -797,21 +783,20 @@
     "id": "Ec6mWL-5UAok",
     "outputId": "5177ffee-2c8d-4b76-b54a-8abdeebca2d3"
    },
-   "source": [
-    "array[::2]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([1, 3, 5, 7, 9])"
       ]
      },
+     "execution_count": 22,
      "metadata": {},
-     "execution_count": 22
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[::2]"
    ]
   },
   {
@@ -825,6 +810,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -832,21 +818,20 @@
     "id": "Kpwn_NT3UCdR",
     "outputId": "1b19b929-d194-491d-c2c9-15f281b86683"
    },
-   "source": [
-    "array[1::2]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 2,  4,  6,  8, 10])"
       ]
      },
+     "execution_count": 23,
      "metadata": {},
-     "execution_count": 23
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[1::2]"
    ]
   },
   {
@@ -860,6 +845,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -867,21 +853,20 @@
     "id": "8q-r1nFgUF5Z",
     "outputId": "cc8fd7bf-887b-4674-88ad-d2e5acde32b5"
    },
-   "source": [
-    "array[1:6:2]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([2, 4, 6])"
       ]
      },
+     "execution_count": 24,
      "metadata": {},
-     "execution_count": 24
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[1:6:2]"
    ]
   },
   {
@@ -895,6 +880,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -902,21 +888,20 @@
     "id": "HLv2rpV5jna1",
     "outputId": "9781f215-afc2-4d28-c1bc-83f106176a34"
    },
-   "source": [
-    "array[::-1]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([10,  9,  8,  7,  6,  5,  4,  3,  2,  1])"
       ]
      },
+     "execution_count": 25,
      "metadata": {},
-     "execution_count": 25
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[::-1]"
    ]
   },
   {
@@ -930,6 +915,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -937,25 +923,25 @@
     "id": "vAbOU4ayUqDD",
     "outputId": "ceece14d-1c76-4610-8dc4-4d652503e9c2"
    },
-   "source": [
-    "array[array < 5]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([1, 2, 3, 4])"
       ]
      },
+     "execution_count": 26,
      "metadata": {},
-     "execution_count": 26
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[array < 5]"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -963,21 +949,20 @@
     "id": "kSxUAD5Vk8p9",
     "outputId": "cd032815-3669-4a27-fee3-80f6bd5baf66"
    },
-   "source": [
-    "array[array * 2 < 5]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([1, 2])"
       ]
      },
+     "execution_count": 27,
      "metadata": {},
-     "execution_count": 27
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[array * 2 < 5]"
    ]
   },
   {
@@ -991,6 +976,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -998,21 +984,20 @@
     "id": "1uUNfzc7huzw",
     "outputId": "0a0aa077-08d3-4f75-a720-67d2073182d5"
    },
-   "source": [
-    "array[[1,3,5]]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([2, 4, 6])"
       ]
      },
+     "execution_count": 28,
      "metadata": {},
-     "execution_count": 28
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array[[1,3,5]]"
    ]
   },
   {
@@ -1026,6 +1011,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1033,23 +1019,22 @@
     "id": "4Vz5G3PNc2cZ",
     "outputId": "16662c03-c015-4806-8ec3-6be75ea72c6c"
    },
-   "source": [
-    "array_2d = np.arange(10).reshape((2, 5))\n",
-    "array_2d"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0, 1, 2, 3, 4],\n",
        "       [5, 6, 7, 8, 9]])"
       ]
      },
+     "execution_count": 29,
      "metadata": {},
-     "execution_count": 29
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array_2d = np.arange(10).reshape((2, 5))\n",
+    "array_2d"
    ]
   },
   {
@@ -1063,6 +1048,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1070,21 +1056,20 @@
     "id": "WbYDyf-KiJzr",
     "outputId": "139e6975-5656-49e4-9adf-3a17ca561e5d"
    },
-   "source": [
-    "array_2d[:, 1]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([1, 6])"
       ]
      },
+     "execution_count": 30,
      "metadata": {},
-     "execution_count": 30
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array_2d[:, 1]"
    ]
   },
   {
@@ -1098,6 +1083,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1105,25 +1091,25 @@
     "id": "SW9G--6JiQfp",
     "outputId": "001a5226-7cd0-43bd-a3a3-d39effd809f4"
    },
-   "source": [
-    "array_2d[[True, False], 1::2]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[1, 3]])"
       ]
      },
+     "execution_count": 31,
      "metadata": {},
-     "execution_count": 31
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array_2d[[True, False], 1::2]"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1131,21 +1117,20 @@
     "id": "aJqko5CBimsB",
     "outputId": "cb1faf48-1bb1-4220-db95-df40e6972fa3"
    },
-   "source": [
-    "array_2d[1, [0,1,4]]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([5, 6, 9])"
       ]
      },
+     "execution_count": 32,
      "metadata": {},
-     "execution_count": 32
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array_2d[1, [0,1,4]]"
    ]
   },
   {
@@ -1159,6 +1144,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1166,25 +1152,25 @@
     "id": "_1Rs1BpJltMH",
     "outputId": "a4a0f90f-df5a-4c50-f184-610bcd66bdb3"
    },
-   "source": [
-    "array"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10])"
       ]
      },
+     "execution_count": 33,
      "metadata": {},
-     "execution_count": 33
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1192,25 +1178,25 @@
     "id": "oxc2cNL4lyKw",
     "outputId": "b1e1b39a-64e6-438c-f35b-bbb076fae6c1"
    },
-   "source": [
-    "array + 100"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([101, 102, 103, 104, 105, 106, 107, 108, 109, 110])"
       ]
      },
+     "execution_count": 34,
      "metadata": {},
-     "execution_count": 34
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array + 100"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1218,21 +1204,20 @@
     "id": "-N2RQG6Ilo2X",
     "outputId": "1bea148b-72c4-413c-bf8c-5f2cc17d7a37"
    },
-   "source": [
-    "array * 2"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 2,  4,  6,  8, 10, 12, 14, 16, 18, 20])"
       ]
      },
+     "execution_count": 35,
      "metadata": {},
-     "execution_count": 35
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array * 2"
    ]
   },
   {
@@ -1246,6 +1231,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1253,21 +1239,20 @@
     "id": "H0pp6Rt-ls7K",
     "outputId": "912abeb5-d74f-4e31-c151-fd449f85feaa"
    },
-   "source": [
-    "array ** 2"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([  1,   4,   9,  16,  25,  36,  49,  64,  81, 100])"
       ]
      },
+     "execution_count": 36,
      "metadata": {},
-     "execution_count": 36
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array ** 2"
    ]
   },
   {
@@ -1281,6 +1266,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1288,26 +1274,26 @@
     "id": "wX4Rudonl1Xb",
     "outputId": "00f7b08f-7dfe-4748-dafb-0e7ede76d066"
    },
-   "source": [
-    "array2 = np.arange(array.shape[0]) * 5\n",
-    "array2"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 0,  5, 10, 15, 20, 25, 30, 35, 40, 45])"
       ]
      },
+     "execution_count": 37,
      "metadata": {},
-     "execution_count": 37
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array2 = np.arange(array.shape[0]) * 5\n",
+    "array2"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1315,21 +1301,20 @@
     "id": "IRvsl8qEl9V3",
     "outputId": "d238cdb2-3630-4fb0-e651-712eb9a36c63"
    },
-   "source": [
-    "array2 + array"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1,  7, 13, 19, 25, 31, 37, 43, 49, 55])"
       ]
      },
+     "execution_count": 38,
      "metadata": {},
-     "execution_count": 38
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array2 + array"
    ]
   },
   {
@@ -1343,6 +1328,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1350,25 +1336,25 @@
     "id": "m6KX660In-f2",
     "outputId": "43020216-077c-4503-fec8-239dff49cff6"
    },
-   "source": [
-    "print(array)\n",
-    "print(array_2d)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[ 1  2  3  4  5  6  7  8  9 10]\n",
       "[[0 1 2 3 4]\n",
       " [5 6 7 8 9]]\n"
      ]
     }
+   ],
+   "source": [
+    "print(array)\n",
+    "print(array_2d)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1376,24 +1362,24 @@
     "id": "9NkWPeaknIj1",
     "outputId": "c51538dd-7c08-4926-8445-0b65e729ed30"
    },
-   "source": [
-    "print(array.shape)\n",
-    "print(array_2d.shape)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "(10,)\n",
       "(2, 5)\n"
      ]
     }
+   ],
+   "source": [
+    "print(array.shape)\n",
+    "print(array_2d.shape)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1401,24 +1387,24 @@
     "id": "nPrYLzs_nxgh",
     "outputId": "65d85450-b74a-4d90-8ac4-25bd7e9b71e7"
    },
-   "source": [
-    "print(len(array))\n",
-    "print(len(array_2d))"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "10\n",
       "2\n"
      ]
     }
+   ],
+   "source": [
+    "print(len(array))\n",
+    "print(len(array_2d))"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1426,24 +1412,24 @@
     "id": "z8bhAHwFnO_D",
     "outputId": "99546b5c-3606-4713-e29b-7b2a6447e169"
    },
-   "source": [
-    "print(array.max())\n",
-    "print(array_2d.max())"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "10\n",
       "9\n"
      ]
     }
+   ],
+   "source": [
+    "print(array.max())\n",
+    "print(array_2d.max())"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1451,24 +1437,24 @@
     "id": "n6SSOUXtnaXc",
     "outputId": "89eb2d31-8edb-45b6-fd94-13ddc0944b20"
    },
-   "source": [
-    "print(array.min())\n",
-    "print(array_2d.min())"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "1\n",
       "0\n"
      ]
     }
+   ],
+   "source": [
+    "print(array.min())\n",
+    "print(array_2d.min())"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1476,25 +1462,25 @@
     "id": "zZSRKnF6nbas",
     "outputId": "9cf0ecd3-7abe-4d94-8a64-36c623ff51da"
    },
-   "source": [
-    "array.std()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "2.8722813232690143"
       ]
      },
+     "execution_count": 44,
      "metadata": {},
-     "execution_count": 44
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array.std()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1502,25 +1488,25 @@
     "id": "jdMsJndyndOQ",
     "outputId": "6f3d707e-2963-4388-e8ce-f2297df4b6fb"
    },
-   "source": [
-    "array.cumsum()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1,  3,  6, 10, 15, 21, 28, 36, 45, 55])"
       ]
      },
+     "execution_count": 45,
      "metadata": {},
-     "execution_count": 45
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array.cumsum()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1528,22 +1514,21 @@
     "id": "VRpZYL4YnfUb",
     "outputId": "dfdb683c-ed16-4f16-f9f8-05b173349f08"
    },
-   "source": [
-    "array.cumprod()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([      1,       2,       6,      24,     120,     720,    5040,\n",
        "         40320,  362880, 3628800])"
       ]
      },
+     "execution_count": 46,
      "metadata": {},
-     "execution_count": 46
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array.cumprod()"
    ]
   },
   {
@@ -1557,6 +1542,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1564,25 +1550,25 @@
     "id": "aMGMdwaqoXkn",
     "outputId": "68025722-d17c-4c87-e958-40988b6f79ee"
    },
-   "source": [
-    "np.pi"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "3.141592653589793"
       ]
      },
+     "execution_count": 47,
      "metadata": {},
-     "execution_count": 47
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.pi"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1590,25 +1576,25 @@
     "id": "jLhkYK-zoYo6",
     "outputId": "21e3820a-bb77-41bf-e52e-d648cbc8ff3c"
    },
-   "source": [
-    "np.e"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "2.718281828459045"
       ]
      },
+     "execution_count": 48,
      "metadata": {},
-     "execution_count": 48
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.e"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1616,21 +1602,20 @@
     "id": "0H-XpiGNoZgG",
     "outputId": "88623e5a-fcee-4076-81da-b9efda2f3234"
    },
-   "source": [
-    "np.inf"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "inf"
       ]
      },
+     "execution_count": 49,
      "metadata": {},
-     "execution_count": 49
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.inf"
    ]
   },
   {
@@ -1644,6 +1629,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1651,25 +1637,25 @@
     "id": "eG1GKzVuovNY",
     "outputId": "eecdf4ad-89b7-447a-e4a8-4a2758af972c"
    },
-   "source": [
-    "np.sin(np.pi / 2)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "1.0"
       ]
      },
+     "execution_count": 50,
      "metadata": {},
-     "execution_count": 50
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.sin(np.pi / 2)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1677,25 +1663,25 @@
     "id": "tWQ3xUExo7Bn",
     "outputId": "ffabcf03-ea44-4f68-dfdc-d3dc16c7ca4b"
    },
-   "source": [
-    "np.cos(np.pi)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "-1.0"
       ]
      },
+     "execution_count": 51,
      "metadata": {},
-     "execution_count": 51
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.cos(np.pi)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1703,25 +1689,25 @@
     "id": "gk6bP-m-o9gC",
     "outputId": "c1b67bd1-1cb5-436c-92db-1ca0263a734f"
    },
-   "source": [
-    "np.log(np.e)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "1.0"
       ]
      },
+     "execution_count": 52,
      "metadata": {},
-     "execution_count": 52
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.log(np.e)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1729,25 +1715,25 @@
     "id": "WHZQnDRzpENN",
     "outputId": "0ca8e0ff-f6aa-46ab-c019-057e555ab342"
    },
-   "source": [
-    "np.log10(100)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "2.0"
       ]
      },
+     "execution_count": 53,
      "metadata": {},
-     "execution_count": 53
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.log10(100)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1755,21 +1741,20 @@
     "id": "hAxm918epGJj",
     "outputId": "d2a60bf9-123d-44ca-b875-a0ddd0a25013"
    },
-   "source": [
-    "np.log2(64)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "6.0"
       ]
      },
+     "execution_count": 54,
      "metadata": {},
-     "execution_count": 54
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.log2(64)"
    ]
   },
   {
@@ -1783,6 +1768,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1790,30 +1776,29 @@
     "id": "VSJgi2IQpYXa",
     "outputId": "e437c7a9-e4fe-4499-b7ee-b0db39da7eeb"
    },
-   "source": [
-    "array = np.arange(4) / 3\n",
-    "print(array)\n",
-    "np.around(array, 2)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0.         0.33333333 0.66666667 1.        ]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([0.  , 0.33, 0.67, 1.  ])"
       ]
      },
+     "execution_count": 55,
      "metadata": {},
-     "execution_count": 55
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "array = np.arange(4) / 3\n",
+    "print(array)\n",
+    "np.around(array, 2)"
    ]
   },
   {
@@ -1829,13 +1814,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "mX9awPKn-ZlU",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "mX9awPKn-ZlU",
     "outputId": "29c7994e-1b18-4885-ceea-4f5e363c2c3c"
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1001,)"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fs = 500 #sampling rate in Hz\n",
     "d_t = 1 / fs #time steps in seconds\n",
@@ -1848,19 +1846,6 @@
     "                   n_step * d_t,    #end time\n",
     "                   num=n_step + 1)  #number of data points, one more than the steps to include an endpoint\n",
     "time.shape"
-   ],
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "(1001,)"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 56
-    }
    ]
   },
   {
@@ -1874,9 +1859,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "wqVZJKtwTB8l"
    },
+   "outputs": [],
    "source": [
     "def sine_wave_with_loop(time, amp, f, phase=0):\n",
     "  length = time.shape[0]\n",
@@ -1885,9 +1872,7 @@
     "  for i in range(length-1):\n",
     "    wave[i] = np.sin(2 * np.pi * f * time[i] + phase * np.pi / 180)*amp\n",
     "  return wave"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1900,6 +1885,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1907,19 +1893,18 @@
     "id": "CMwHGKrITpN4",
     "outputId": "950cebd8-3bb5-4062-cbde-15b4b4727eb3"
    },
-   "source": [
-    "%timeit sine_wave_with_loop(time, amp, f)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "The slowest run took 7.52 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
       "100 loops, best of 5: 2.55 ms per loop\n"
      ]
     }
+   ],
+   "source": [
+    "%timeit sine_wave_with_loop(time, amp, f)"
    ]
   },
   {
@@ -1933,16 +1918,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "89xWQJpzAdal"
    },
+   "outputs": [],
    "source": [
     "def sine_wave_with_numpy(time, amp, f, phase=0):\n",
     "  \"\"\"Takes in a time array and sine wave parameters, returns an array of the sine wave amplitude.\"\"\"  \n",
     "  return np.sin(2 * np.pi * f * time + phase * np.pi / 180) * amp"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1955,6 +1940,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1962,14 +1948,10 @@
     "id": "AsVkSRvtV3HI",
     "outputId": "c2da90a6-e914-4964-c53b-2f1b2924a1e8"
    },
-   "source": [
-    "help(sine_wave_with_numpy)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Help on function sine_wave_with_numpy in module __main__:\n",
       "\n",
@@ -1978,10 +1960,14 @@
       "\n"
      ]
     }
+   ],
+   "source": [
+    "help(sine_wave_with_numpy)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1989,19 +1975,18 @@
     "id": "Q5S5fTrw--Z3",
     "outputId": "cb83ee47-de30-4215-9624-9c55571f30ce"
    },
-   "source": [
-    "%timeit sine_wave_with_numpy(time, amp, f)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "The slowest run took 4.34 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
       "10000 loops, best of 5: 27.9 µs per loop\n"
      ]
     }
+   ],
+   "source": [
+    "%timeit sine_wave_with_numpy(time, amp, f)"
    ]
   },
   {
@@ -2027,20 +2012,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "cX8PSvkRoJR3"
    },
+   "outputs": [],
    "source": [
     "from numba import njit\n",
     "\n",
     "numba_sine_wave_with_loop = njit(sine_wave_with_loop)\n",
     "numba_sine_wave_with_numpy = njit(sine_wave_with_numpy)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2048,15 +2034,10 @@
     "id": "T_ckZKtlo1IJ",
     "outputId": "da56b3e6-205c-4da7-8b89-b622903a94e1"
    },
-   "source": [
-    "%timeit numba_sine_wave_with_loop(time, amp, f)\n",
-    "%timeit numba_sine_wave_with_numpy(time, amp, f)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "The slowest run took 14426.53 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
       "1 loop, best of 5: 22.8 µs per loop\n",
@@ -2064,6 +2045,10 @@
       "1 loop, best of 5: 22.1 µs per loop\n"
      ]
     }
+   ],
+   "source": [
+    "%timeit numba_sine_wave_with_loop(time, amp, f)\n",
+    "%timeit numba_sine_wave_with_numpy(time, amp, f)"
    ]
   },
   {
@@ -2077,6 +2062,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2085,19 +2071,8 @@
     "id": "U2y5ggCUpEHh",
     "outputId": "b87bf24b-7621-4553-e384-5a0b14bd3035"
    },
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "time_data = pd.DataFrame({'Time (us)':[2.77*100, 27.5, 23.1, 22.6],\n",
-    "                          'Method':['Loop','NumPy','Loop','NumPy'],\n",
-    "                          'Numba?':['w/o','w/o','w','w']}\n",
-    ")\n",
-    "time_data"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -2160,9 +2135,19 @@
        "3       22.6  NumPy      w"
       ]
      },
+     "execution_count": 64,
      "metadata": {},
-     "execution_count": 64
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "time_data = pd.DataFrame({'Time (us)':[2.77*100, 27.5, 23.1, 22.6],\n",
+    "                          'Method':['Loop','NumPy','Loop','NumPy'],\n",
+    "                          'Numba?':['w/o','w/o','w','w']}\n",
+    ")\n",
+    "time_data"
    ]
   },
   {
@@ -2176,6 +2161,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2184,31 +2170,16 @@
     "id": "qxZGaIywpPBr",
     "outputId": "a0fda4c9-0df4-4412-abe0-9e440f820206"
    },
-   "source": [
-    "!pip install --upgrade -q plotly\n",
-    "import plotly.express as px\n",
-    "import plotly.io as pio; pio.renderers.default = \"iframe\"\n",
-    "\n",
-    "fig = px.bar(time_data, \n",
-    "             x=\"Method\", \n",
-    "             y=\"Time (us)\", \n",
-    "             color=\"Numba?\", \n",
-    "             title=\"Compute Time of a Sine Wave for 1000 Elements\",\n",
-    "             barmode='group')\n",
-    "fig.show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "\u001B[K     |████████████████████████████████| 23.9 MB 1.5 MB/s \n",
-      "\u001B[?25h"
+      "\u001b[K     |████████████████████████████████| 23.9 MB 1.5 MB/s \n",
+      "\u001b[?25h"
      ]
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -2244,8 +2215,22 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "!pip install --upgrade -q plotly\n",
+    "import plotly.express as px\n",
+    "import plotly.io as pio; pio.renderers.default = \"iframe\"\n",
+    "\n",
+    "fig = px.bar(time_data, \n",
+    "             x=\"Method\", \n",
+    "             y=\"Time (us)\", \n",
+    "             color=\"Numba?\", \n",
+    "             title=\"Compute Time of a Sine Wave for 1000 Elements\",\n",
+    "             barmode='group')\n",
+    "fig.show()"
    ]
   },
   {
@@ -2261,21 +2246,22 @@
     ">*At the very basic level, Pandas objects can be thought of as enhanced versions of NumPy structured arrays in which the rows and columns are identified with labels rather than simple integer indices.*\n",
     "\n",
     "To start, import pandas as `pd`, again this will come standard in virtually all Python distributions such as Anaconda. But to install is simply:\n",
-    "~~~\n",
+    "\n",
+    "```\n",
     "!pip install pandas\n",
-    "~~~"
+    "```"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "zigCIKBhNkNl"
    },
+   "outputs": [],
    "source": [
     "import pandas as pd"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2284,7 +2270,8 @@
    },
    "source": [
     "There are three types of Pandas objects, we'll only focus on the first two:\n",
-    "1. **Series** – 1D labeled homogeneous array, sizeimmutable\n",
+    "\n",
+    "1. **Series** – 1D labeled homogeneous array, size-immutable\n",
     "2. **Data Frames** – 2D labeled, size-mutable tabular structure with heterogenic columns\n",
     "3. **Panel** – 3D labeled size mutable array."
    ]
@@ -2301,6 +2288,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2308,22 +2296,21 @@
     "id": "Slfe4gYJuKZL",
     "outputId": "b14099a3-7fd2-4c23-b9fb-b5eccf322338"
    },
-   "source": [
-    "amplitude = sine_wave_with_numpy(time, amp, f, 180)\n",
-    "print(time)\n",
-    "print(amplitude)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0.    0.002 0.004 ... 1.996 1.998 2.   ]\n",
       "[ 1.22464680e-16 -2.51300954e-02 -5.02443182e-02 ...  5.02443182e-02\n",
       "  2.51300954e-02  1.10218212e-15]\n"
      ]
     }
+   ],
+   "source": [
+    "amplitude = sine_wave_with_numpy(time, amp, f, 180)\n",
+    "print(time)\n",
+    "print(amplitude)"
    ]
   },
   {
@@ -2337,6 +2324,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2344,13 +2332,8 @@
     "id": "Ke_Vt_SmBrl0",
     "outputId": "4e323c4a-ef2d-40a0-c44d-0511336ba3e5"
    },
-   "source": [
-    "pd.Series(amplitude)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "0       1.224647e-16\n",
@@ -2367,9 +2350,13 @@
        "Length: 1001, dtype: float64"
       ]
      },
+     "execution_count": 68,
      "metadata": {},
-     "execution_count": 68
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "pd.Series(amplitude)"
    ]
   },
   {
@@ -2383,6 +2370,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2390,16 +2378,8 @@
     "id": "OQ11y3klvvLj",
     "outputId": "5dfe9f12-e4a2-4cc4-d234-dd048046d477"
    },
-   "source": [
-    "series = pd.Series(data=amplitude,\n",
-    "                   index=time,\n",
-    "                   name='Amplitude')\n",
-    "series"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "0.000    1.224647e-16\n",
@@ -2416,9 +2396,16 @@
        "Name: Amplitude, Length: 1001, dtype: float64"
       ]
      },
+     "execution_count": 69,
      "metadata": {},
-     "execution_count": 69
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "series = pd.Series(data=amplitude,\n",
+    "                   index=time,\n",
+    "                   name='Amplitude')\n",
+    "series"
    ]
   },
   {
@@ -2432,6 +2419,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2439,13 +2427,8 @@
     "id": "VTqpSZl9lyIl",
     "outputId": "3a92856e-0677-4c80-f52f-7d0e2fd9e80a"
    },
-   "source": [
-    "series[0: 0.01]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "0.000    1.224647e-16\n",
@@ -2457,9 +2440,13 @@
        "Name: Amplitude, dtype: float64"
       ]
      },
+     "execution_count": 70,
      "metadata": {},
-     "execution_count": 70
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "series[0: 0.01]"
    ]
   },
   {
@@ -2473,6 +2460,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2481,23 +2469,18 @@
     "id": "YbluH1OXu-0f",
     "outputId": "f1a137b5-b116-4ef8-e9de-4458e1510bcf"
    },
-   "source": [
-    "series.plot()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<matplotlib.axes._subplots.AxesSubplot at 0x7f51188d8310>"
       ]
      },
+     "execution_count": 71,
      "metadata": {},
-     "execution_count": 71
+     "output_type": "execute_result"
     },
     {
-     "output_type": "display_data",
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO29eXhj13Xg+TsAV4AbuBaLa+2bdlGyLNmOJEuW7MQuZ+JFTjyRE2fUTuxkOs5mt2ecjLsz7Uy+iT3pdsdRHDt24ra8JbGcyLEWS/GitSSVal/IKlYRLO4EV4AgAdz5A++xIBRZXPB2vN/34SPwNhwe3HvPufeec68opfDx8fHxKV4Cdgvg4+Pj42MvviHw8fHxKXJ8Q+Dj4+NT5PiGwMfHx6fI8Q2Bj4+PT5FTYrcAm6GxsVF1d3fbLYaPj4+Pq3j55ZfHlVJN+cddaQi6u7s5dOiQ3WL4+Pj4uAoRubDScX9oyMfHx6fI8Q2Bj4+PT5HjGwIfHx+fIsc3BD4+Pj5Fjm8IfHx8fIocQwyBiHxZREZF5Ngq50VE/lJEekXkiIjclHPuQRE5q70eNEIeHx8fH5/1Y1SP4O+A+69y/u3ALu31EPBXACJSD/wx8AbgVuCPRSRikEw+Pj4+PuvAkDwCpdSPRaT7KpccBL6msmtePy8idSLSCtwJPKGUmgQQkSfIGpRvGCFXsRFfTPG9w5eYT6Z45/VbaampsFskR7OYyvD91y4xNpfk569tpaM+ZLdIjiadUfzg2BAXJ+Pcu6+FXS3VdovkaJRSPHVylNMjs7x5VyPXtdfZLdKqWJVQ1gYM5HyOasdWO34FIvIQ2d4EnZ2d5kjpYqbii7z3i89xdnQOgL986ix//+E3cH2HcwufnSQW0/zKl57nlYtTAHz+yTP8za/28OZdVyRd+gCpdIaH/v5lfnRqFIC/ePwMn3v/Dbzz+q02S+ZMlFL8/reP8N1XogD8+Q9P85mDB/jVN3bbK9gquGayWCn1sFKqRynV09TkV9ZclFL8ziOHuTAR5ysfuoUnP/5z1FSW8h/+/mWmE0t2i+dIPvXPR3l1YIrPv/8GfvpHd9HdEOajX3+FoemE3aI5kj//4Wl+dGqUT//Cfl781Fu5qTPC7337Nc6MzNotmiP525+e57uvRPntu3fyyv95L/fsa+FPHj3OS/2Tdou2IlYZgkGgI+dzu3ZsteM+G+CJEyP8+MwY/+kde7lrbzM7m6v4wi/fxPDMAl/89z67xXMcL1+I8Y+vDPLRO3fy7hvbaI+E+OIHb2ZhKcNfPH7GbvEcR9/YHF/66Xne39PBr79pG83VFfyPD95ERUmA//uxk3aL5zjGZpN87okz3LOvmY/fu5v6cBn/3wM30FpbyWe+f4JMxnm7QlplCB4FflWLHroNmFZKDQE/BN4mIhFtkvht2jGfdaKU4v99/Azbm8J88Lau5ePXd9Txize28eWfnmdiLmmjhM7jL544TVN1Ob95547lY92NYR68vYvvvBLl3NicjdI5j7986iwVJQF+/749y8caq8r52N07eeb0GIcc6uXaxV//ex8LqQz/6R37EBEAwuUl/N7bdnN0cJrHTwzbLOGVGBU++g3gOWCPiERF5MMi8hER+Yh2yWPAOaAX+BvgtwC0SeL/DLykvT6jTxz7rI8Xzk9yemSWj/zcDkqCr/85f+vOHSRTGb51KGqTdM6jd3SWn/VO8Gt3dBMuf/0U2f/2lu2UBISvv3DRJumcx9hskseODvH+Wzppqi5/3bkP3tZFdUUJX3tuxXXMipL4YopvHhrgHde2sr2p6nXnDt7QRltdpSP1ZYghUEp9QCnVqpQqVUq1K6X+Vin1RaXUF7XzSin1UaXUDqXUtUqpQzn3flkptVN7fcUIeYqJr79wkdrKUt553ZWTdrtaqnnDtnr+54sXHNkdtYP/+cIAZcEA7+vpuOJcc3UF9x3YwrcPDbCwlLZBOufx7ZcHWEorfuW2KwM0QmUl/NJN7fzg2JDf69T4lyNDzC6k+F9zeuc6wYDwy2/o5Nm+Ccf1Ol0zWexzJYnFNE+eGOEXrmulsiy44jXv6+lgYDLB4eiUxdI5j0xG8a9HL3HX3iYaq8pXvOZ9PR3MLKT49zNjFkvnTP7ltSFu6qxjR553q/O+ng6W0op/O+684Q47+JcjQ3Q1hLile+V0qPfc3I4IfP+1IYsluzq+IXAxPz47RmIpzTuubV31mnv2t1AWDPDYEWcVPDt4dWCKkZkkb79mdX29cUcDkVApjx319XVxIs6JoZmrlq99rdVsbwz7+gKm40s82zvO/ddsWZ4byKelpoJbuuodpy/fELiYfzs2TF2olFu31a96TW1lKW/e1cgPjg2TzecrXv7t2BClQeHufc2rXlMaDHDfgS08dXKUxVTGQumcxw+OZRur+w5sWfUaEeEd17byXN8EsflFq0RzJE+eHCGVUdx/FX0BvOPaLZwemaXPQcNDviFwKal0hqdOjnDPvhZKg1f/Ge/a28zgVIJz4/MWSedMHj8xwu07GqmpKL3qdXftbWYumeLVizGLJHMmj58Y4cDWmjUzru/a20xGwc/6xi2SzJk8fmKY1toKrl8jg/juvS0A/MRBw4++IXApRwenmVlIceeetZPr3qJlyzqp4FnNwGScCxPxdenrjTsaCAaEn5wt3oZtdmGJwwNT69LX9e21VFeU8JMzxauvdEbxXN8Eb9nVRCCw8rCQTmdDiK6GkKPKl28IXMqzfRMAvHF7w5rXdjaE6HZYwbOaZzVv9Y6djWteW1NRyo0ddfzkbPEazhfPT5LOKO7Ysba+SoIB7tjRyE/OjhXt8OMxzTG7fefa9RHgzbsaee7chGOGH31D4FJ+1jvOvtYaGlaJfsnnzbuaHFXwrObZvgmaqsvZ1bxy9Es+b97VxJHB6aId9362b4KykgA3da1vMeA3727k0vQCfWPFOfyoO2a3r8NwQrZ8xRfTvOKQ4UffELiQhaU0hy7EuH3H+rwPgNt3NBBfTHPs0rSJkjkTpRTP9k1w+46GVaM58rl9ZwNK4di1YczmZ73j9HRFqChdOSw5H70BfOH8hJliOZZn+8bZ3VJ1RdLdaty2vQEReOGcM8qXbwhcyGsDUyymMusaFtK5WYtrfuWCMzwQKzk/Ps/YbHJD+rq2rZayYICXi1Bf0/ElTg3Pbkhf3Q0hGsJlRamvVDrDof7YhvRVW1nK7uZqXvZ7BD6b5dWBbHLYjZ3rX2K6ubqCzvoQh/qdUfCs5FVtqen1DnMAVJQGuaatpigbNj35cCP6EhFu7ooUpb5Oj8ySWEpvSF+Qdc5evRAj7YCsf98QuJDDF6forA+te35A5+auCC9fjBXdhN7hgSmqyktWzY5djZu7IhwZnCaZKq7lJg5fnEIErmuv3dB9N3dFuDARZ2y2uJabOKw5ZjdscO+PmzsjzCZTnB21fylv3xC4kMMDUxsudJCtqGOzSQYmi2vN/cMDU1zXXktwjbC+fG7uqmcxleHYYHHNqxweiLGzqYrqNfIt8unRhh+LrVdw+OIU9eEyOje4w52uLyf00n1D4DKGphMMzyxsaFhI56bObMF7dcD+gmcVC0tpTg7NbE5fXdl79KGlYkApxeGBqU3p65q2WkqDUlTlC7JDtTd01K07EEGnsz5EY1WZI8qXbwhcxuGLm+uGAuxuqaK8JFBUHu6xwWlSGcUNHRsbv4XsvMqWmoqi0teFiTix+NKm9FVeEmTPlmqOD86YIJkzmVlYom9sblP1UUS4pq2W4w6I5PMNgcs4PDBFWTDA/q01G763JBhgb2sNx4qoom52/FbnmrYajl3y9bVertlay7FL00UzD3VkYBqlCtPX2dE525c99w2By3gtOsW+1mrKS9YX353PNVtriqqivhadpq2uct3x3fkc2FpL39gc8cWUwZI5k9eiU1SWBtndsrGJdZ0DbbVMxZcYnCqOeajXtAirtdYXWo1r2mpIZxSnhu2dMDZqh7L7ReS0iPSKyCdWOP85ETmsvc6IyFTOuXTOuUeNkMerKKU4cWmG/Vs3Fs2RyzVttcwupIpmwvjEpelN9Z50rmmrRSk4OWR/ZIcVnLg0w54t1VfsdrdertF0fbxIelEnhmZoj1RSG9rYxLrOAa0u2z38WLAhEJEg8AXg7cB+4AMisj/3GqXU7yqlblBK3QD8N+Afc04n9HNKqXcVKo+XuTS9wMxCiv2t1Zt+xjV6wXPAuKTZLCylOT8+z77WQgyB3rB5X19KKU4OzRSkr32tNQQDwvEimVcpVF/tkUpqK0ttL19G9AhuBXqVUueUUovAI8DBq1z/AeAbBnxv0XFS87IKKXi7t1RREhDbPRArOD08S0ZRkOHcUlNBQ7isKPRlhKNRURpkV3NVUcyrJBbT9BfoaIgI17bV2j5vZ4QhaAMGcj5HtWNXICJdwDbgRzmHK0TkkIg8LyLvXu1LROQh7bpDY2PFuSrkyaFsYdlbQMErLwmyu6W6KCqqrq9CK+oBB1RUKzDC0YDscEcxGM7TI4U7GgAH2mo4PTxr64KQVk8WPwB8RymVO0XepZTqAX4Z+LyI7FjpRqXUw0qpHqVUT1PT2muke5GTwzN0NYSoKi8p6Dn7t9ZwokgMQbgsSEdkY4k++exvreHs6CxLaW+v3GqEowHZ8jU6m2Tc4xva6/ra37r5Obvs/TUspjO27lhmhCEYBDpyPrdrx1biAfKGhZRSg9rfc8AzwI0GyORJTg7Nsm9LYZUUYE9LNeNzSSY9vsTyiaEZ9rbWrLlRyFrs2VLFUlrR7/Ed3k4MGeNo7GnJeshnRrw9wX5yaIaq8hLaI5UFPWfPFvv1ZYQheAnYJSLbRKSMbGN/RfSPiOwFIsBzOcciIlKuvW8E7gBOGCCT54gvpuifKGw8UmeXFhro5YqqlOLU0Cz7Cuy2A+xqzj7jtIf1BdrEpwGOhh56esbmkEizOTk0w94t1QU7GtsawwQD4m5DoJRKAR8DfgicBL6llDouIp8RkdwooAeAR9TrA9j3AYdE5DXgaeCzSinfEKzA6eFZlMKQhk33QM56uGGLxhLMJlOGGM6dzVUEBM6MOGezcaOJL6a4MBk3RF9N1eXUhUo5M+pdfV12NArXV3lJkG2NYVvLV2F9QA2l1GPAY3nHPp33+U9WuO9Z4FojZPA6Z7VKtbulcEOwpaaC6ooST3u4vQbqq6I0SHdD2NMebt/oPEqx6USyXESE3S3VntbXyEyS2WTKEH1BdjjNzpBuP7PYJfSNzlFWEqBjgyscrsRyRfWwh6sbgp0bXHp6NXa1VHHGAcsFm0XvWPZ/27nOrTzXYndLFadHZj2bwa6Xrx0G6WtXSxUXJ+MkFu1ZasI3BC6hd3SO7dpYohFkDYG3K2pDuIxIuMyQ5+1pqaZ/fN72NWHMond0jmBA6GoIG/K8PS3VzC6kGJnxZuRQ76ixhnNPSzVKXTYwVuMbApdwdnTOMO8Dsh7bVHyJMY+G+J0dnTVUX7taqskoOOfRzdnPjszR1RCirMSYJmFXi7cn2M+OzlFTUULTBjeHWo1dNkda+YbABSwspRmIxdllYMO2HOI37L3hIaUUvaNzxurLASF+ZtI7Zqy+di+XL4/qa3SOXS3VG96DYDW6G0KUBQO+IfBZnXNj2Yk8o7qhADu1Sa5eD457j80lmVlIGaqv7obssJxdXXczWUxluDARN1Rf9eEyGqvKPKkvgL6xOcPmnyC7RPz2prA/NOSzOr1axqGRFbWpqpzq8hLOeTBJanmi2EB9lZUE6KwPcW7cew3bhYl50hllqL4AtjdWeVJfU/FFxucWjddXU9i2+ugbAhfQOzpHQLKJJ0YhItmC58Ex7z4TDAHA9kZv6utyhFXhoba5eLV8meFoQNZwXpyM27LmkG8IXEDf6Byd9aFNb0azGtubqjhn4/omZtE7OkdVeQlbaioMfe72pjDnx+fJZLwVaXU5FNI4RwOy+pqYX2Q6vmToc+3GNEPQFCadUVycjBv63PXgGwIXcHZ01vBCB9kexqXpBdtil83i7OgcO5rChk3k6WxrrCKZynBp2lub+pwdnaOtrpJQmSH5pctsa8yWWa8ND50dnaOiNEBbXWFrDOWj9/jP2zA85BsCh5NKZ+gfj7Oz2dhuO2Q9ELCn4JlJ7+icqfry2nBHVl/GOxpe1teOpqqC1xjKZ7s2+WxHL903BA5ncCrBYjqzXKmMZLsHPba5ZIrR2aQ5+lpu2LyjL6UU/RPzpuirsz5ESUA8Vb4g6zhtNzBiSKe2spTGqjJbDKdvCByO7q0bOVGsoz/TSx5bv4n68mKk1ehskvhi2hR9lQa1SCsPla/FVIZoLM62hsKXelkJuyKtfEPgcC5MZCeOukwoeJVlQdrqKj3l4ZqpLy9GWumG06ilJfLxmr6isTgZ5T19+YbA4ZwfnydcFjQslT2fbY1hT80R9E9k/5dukyqqV/W1zUx9TXgn0mq5fJnQg4KsvuyItPINgcPpn5inu9H4CBgd3QPxyuJz58fnaa4uJ1zgLlursb2pisGphGcirc6PxykNClvrjA211dneVMViKsPglDcirc6PZ3ucZgylQc6EscXDQ4YYAhG5X0ROi0iviHxihfMfEpExETmsvX4j59yDInJWez1ohDxe4sJE3DTvFrJJUrPJlGcWn7swMW+uvjwWaXVhYp6OSIiSoDk+4XZ9HspD+qquKCESKjXl+XZFWhX864tIEPgC8HZgP/ABEdm/wqXfVErdoL2+pN1bD/wx8AbgVuCPRSRSqExeIZXOMDAZp7vRnIkpgG2aB9I/bn0SixmcHzdZX1rDpg8RuJ3z4/OmDXMAbNMaNq/s93x+fJ5tJvbQO+tDBANiefkywg24FehVSp1TSi0CjwAH13nvfcATSqlJpVQMeAK43wCZPMHgVIJURpk2MQXQpW10c8EDDdtcMsX4XNJcfWnP1iel3YxSigsTcVMm1nWaqsoJlQU9oS9A05d55as0GGBrXYXl+jLCELQBAzmfo9qxfH5JRI6IyHdEpGOD9xYlZoaO6rRFKgkGxBMV1czQUZ2q8hIawmWeMJyjs0kSS+aEjuqICJ31IS5Oul9fZoeO6nTVhy0vX1ZNFn8f6FZKXUfW6//qRh8gIg+JyCEROTQ2Nma4gE5Eb9jMHPNe9kBsWN/EaMyOGNLpbAh5wnCet6B8QXa4o98D+hrQQkfNHEoDrXxZXB+NMASDQEfO53bt2DJKqQmllD4b+SXg5vXem/OMh5VSPUqpnqamJgPEdj79E3HCZUEaq4zZbnE1uurDXPSAh2tmDkEuXfUhWxYGM5oLFhnOroasvtweQqrry8yhIciWr6n4EtMJ60JIjTAELwG7RGSbiJQBDwCP5l4gIq05H98FnNTe/xB4m4hEtEnit2nHfDA/dFSnywYPxAzMDh3V6WoIc2k6QTLl7hBSs0NHdboawiymMozMLpj6PWZjduiojm5oLlrYiyrYECilUsDHyDbgJ4FvKaWOi8hnRORd2mW/IyLHReQ14HeAD2n3TgL/mawxeQn4jHbMh+zQkNndUMgaAqs9EDOwUl9KQTTm7tj4/vF5OurNCx3V0Xtobh9O6x+fp8bE0FGdZX1ZOK9iSAlQSj2mlNqtlNqhlPpT7dinlVKPau8/qZQ6oJS6Xil1l1LqVM69X1ZK7dReXzFCHi+wlM4QjSXoNnmYA6Cz3noPxAz6J+KW6EuvqO7Xl7k5Fzpdnilf1vTQO+utN5x+ZrFDGYyZHzqqozdsbo6NtyJ0VEc3nG7WlxWhozpb6yooCYilHq4Z9E/MW1K+wuUlNFaVWxo55BsChzIQ0yY+663oEWgerovnCQYmrZkoBmisKnN9bPz43CKJpbQl5askGKAtUulqfaXSGS5NLViiL9Dm7fwegY8+/txhQcGzwwMxmmV9RczX1+XYePc2bFHN0bCifAGu19fwzALpjKKj3thdyVbD6sg03xA4lGgsTklAaDF4393VsNoDMRq9YWuPWFRRG0KeMJztFhhO8EL5slZfnQ0hhmcWWFiyJjLNNwQOZWAywda6bNavFbg9Nn5gMkFlaZD6sLk5FzpdDWEGYgnXxsbrQ49tVhnO+jDTiSXXbmSvDz1a6WhkI9OsqZO+IXAo0VjcskIH2YbNSg/EaHR9mR3RodPVEGIxlWF4xp2x8dFYgkiolCqTcy507AiJNJJoLIEItNZaZQisXdPKNwQOJRpLWGwIrPVAjMZyfdW7e/G5rL6sGeaAyw2bW5eaiMYSbKmpoKzEmiazy+IQUt8QOJCFpTSjs0lLK2qnHkLq0uWoo7G4ZROfkJsk5VYPN27ZxCfkRKa5WF9WOhr14TKqykssK1++IXAgl6b0iCHrCp4ebePGHsF0YomZhZSlFbW1toJgQFyZXayUYtDiHkFlWZDGqnJX6guyPQIrItJ0RIT2SKVl+vINgQMZsDhCAbKx8RWlgeXvdhOXI4as01dJMEBrbcXypKubGJtNkkxlLDWckHVs3KivpXSGoWlrhx4hG9prlb58Q+BArA6FBN0DCbmyR3A5tM/aimqlx2YkA7bpK+RKfQ1PL5BR1joacLl8WbGfuG8IHEg0lqA0KDRXW5NDoNPh0obN6hhvnY5IaDms0E3Y0YOCbPm6NJUg7bKQ2wEbHDPIlq/4YpqYBSG3viFwINGYtTkEOu0ubtjCZUHTV4XMpz0SYnQ26bqQW/t6UCGW0ooRl4Xc2uVo6L+PFXXSNwQOJBqLWzoxpdNRX8nMQsp1y1HroZBW5RDo6JP5g1Pu6kVFYwkawmWEyqzJIdDR9eU2ZyMaSxAQaDV534Z89Cg4K3rpviFwIFbHxOu0uzRyyH59uc0QWBsKqeNmfbXWVlJq8r4N+Sz3CCyoj74hcBgLS2nGZpO2VNQOF1ZUpRTRSXsaNjd7uFYPc0B2OWoRaxo2I4lOJixbiiOX6opS6kKlljhmhhgCEblfRE6LSK+IfGKF8x8XkRMickREnhKRrpxzaRE5rL0ezb+32LBrPDL7ne5r2GYSKWaTKVv01VxdQWnQXbkEmYyeQ2B9w1ZeEqSlusJV+gL7elCQrZMDk+brq+BBQhEJAl8A7gWiwEsi8qhS6kTOZa8CPUqpuIj8JvD/AO/XziWUUjcUKodXsCN0VKcuVEq4LOiqijqwvJyy9foKBoS2OnfFxo/NJVlMZ2i3MAs7l2zD5h596etJ2eFoALTXhTg7Omv69xjRI7gV6FVKnVNKLQKPAAdzL1BKPa2U0n/954F2A77Xk9jZIxAROurdlUtgp77073WT4bTT0QC08uUefV3OIbBLX9bkEhhhCNqAgZzPUe3YanwY+EHO5woROSQiz4vIu1e7SUQe0q47NDY2VpjEDiYaS1AWDNBcXW7L97stScr+hq2SqIs83Msb+Ng31DE0nWApnbHl+zfK8gY+NjoayVSGsbmkqd9j6WSxiHwQ6AH+POdwl1KqB/hl4PMismOle5VSDyulepRSPU1NTRZIaw8DsThtkUoCFucQ6Oi5BFZkMxpBNJagqryE2kprcwh02iMhJuYXiS+mbPn+jaIPy7TV2dOwdURCZFTW03YDdiWT6VwOSDDXOTPCEAwCHTmf27Vjr0NE7gE+BbxLKbVs3pRSg9rfc8AzwI0GyORa7AqF1GmPVDK/mGbKJRuIWL0PQT76b+WWXlQ0lqCxqozKsqAt3++2gIRoLEEwILTWWptDoGNVSLcRhuAlYJeIbBORMuAB4HXRPyJyI/DXZI3AaM7xiIiUa+8bgTuA3EnmomPQxggFsDaJxQjsCoXUcVvuhd36cmP52lJTQYnFOQQ6VjkaBf93SqkU8DHgh8BJ4FtKqeMi8hkReZd22Z8DVcC388JE9wGHROQ14Gngs3nRRkVFYjHN+NyizQ2bdUkshaKUsr0HZVXX3SjsDIUE2FJbQcBFuQR26ytUVkJDuMx0R8OQHHOl1GPAY3nHPp3z/p5V7nsWuNYIGbzA4JS945HZ73aPhzudWGIuae0+BPk0VZVTXhJwhb4yGcXgVIL7r2m1TYbSYIDWWvcEJERjCe7Y2WirDO0WRFr5mcUOQvcq7ewR1FaWUlNR4goP1wn60jcQcYO+RmYXWEorWw0nuCeXIJlKazkE3teXbwgcxOVQNXsLnltyCewOHdVpj4SITrlBX/asOpqPW3IJhqYWUDbsQ5BPRyTE4FSCjInLd/uGwEFEYwnKSgI0VtmTQ6DTHql0xU5lyzHxNmXJ6nTUu6NHsOxo2Kyv9kglI7MLJFPOXr7bKYazPVKZXb571ryQW98QOIhoLEF7nX05BDod2k5lTs8liMbiVFfYl0Og0x4JafsmOzvkNqoZq7Y6m3sEkRBKwaUpZ+cSOKXHaUWklW8IHERUSyazm/ZIJQtLGcbnFu0W5arYHQqps7xqq8N7BdFYgqbqcipK7ckh0HFLLoGeQ7Clxp4cAh0r9OUbAgcxEEvY3m2HXA/E2RV1wObQPp3Lsd6+vtaDW3IJBmJxttbZl0Ogo/fg/B5BETCfTDE5v+iIiqp72U6eJ3BCDoGO3rA5WV/gnB5US012+W6n5xJkh2rt11dFaZDm6nK/R1AM6NsdOqGi6sNTgw5u2GLxJeKLadsWA8slEiolVBZ0tL7SGcWlqYTtEWmAtmRDpaP1BfYnk+XSHqk0dUtU3xA4BKdMTAFUlZcQsWhnpM3iJH3puQRO1tfIzAKpjHKEowE4Xl/JVJqRmaRj9NVm8nLnviFwCE4JVdNx+jr7du9DkI979OWU8uXs7GI9oslJ+hqaNi+XwDcEDmFgMk55SYAmm3MIdDrqnb3z1vJyyg6qqG7Ql3MathCjs0kWlpyZS6DrywnBG5CdMF5KK0ZnzdmXwDcEDkGf+LRrOeV82iMhBi3YGWmzRGMJahyQQ6DTHqlkdiHFdMKZuQS6973V5hwCHd0gmTnuXQhO7EGBeZFpviFwCE6J6NBpj1RasjPSZonG4o7x1iAnl8ChvYJoLE5Ljf05BDpODyGNxuKUBIQWm3MIdMw2nL4hcAhOilAA52+44pTQUZ3Lq7Y6WV/OMZxOz72IxhJsraskaHOWv85Wk3MJfEPgAOaSKWLxJYdVVOc2bJdzCJykL4cbzoxc2G4AACAASURBVClnORrN1dlcAsfqy2GO2eV9CXxD4FkGHTYeCbnZjM7z2CbnF0kspR2lr7pQKeGyoCP1lUpnGJqyfznlXIIBYWudcyOHnNbjhGxghKPnCETkfhE5LSK9IvKJFc6Xi8g3tfMviEh3zrlPasdPi8h9RsjjNpwWoQAQLi+h3kQPpBAGHBY6CnougTNDSIcdlkOg49RcgoWlNKOzSUckK+ZiZlJZwYZARILAF4C3A/uBD4jI/rzLPgzElFI7gc8Bf6bdu5/sHscHgPuB/6E9r6hwUnJULk6N9b68nLKvr/WwvFy30xq2OmcazuUsf4eVr7a6StMi+YzoEdwK9CqlzimlFoFHgIN51xwEvqq9/w7wVsnGSR4EHlFKJZVS54Fe7Xmm8IWne/mvPzhp1uM3TTSWoKI0QEO4zG5RXodTPTa98bB7OeV8nK4vJzoaYw7MJXBasqJOeyREMmXOqsBGGII2YCDnc1Q7tuI12mb300DDOu8FQEQeEpFDInJobGxsU4KeGJrh8eMjm7rXTPSJT6fkEOg4NZcgGotTFyqlusIZOQQ67ZGQI3MJorE4ItBa54xQSB3d43ZaLoFTe+jbGsPsaalm1oR9L1wzWayUelgp1aOU6mlqatrUM9oj2a6VmVu+bQanRXToODWXwIkTeeDckMhoLEFLdQXlJc4adXVqZFo0lqA0KDRXO8twvmV3Ez/83bewvanK8GcbYQgGgY6cz+3asRWvEZESoBaYWOe9htEeCbGYdl7DNjCZcNz4LTg3JHJgMu6I5YHzcWrDNjDpXEcDnGc4BybjtDkoh8AKjDAELwG7RGSbiJSRnfx9NO+aR4EHtffvAX6ksuMNjwIPaFFF24BdwIsGyLQiTix4MwtLTCeWHFpRndew6TkETpsoBucazqhDNjzKx6m5BE7LUbGCgg2BNub/MeCHwEngW0qp4yLyGRF5l3bZ3wINItILfBz4hHbvceBbwAng34CPKqVMmznqcGBFHXToxBQ4M5dgfG6RZCrjSH05MZcglc4wPOOsHAIdp+YSOHXo0UxKjHiIUuox4LG8Y5/Oeb8AvHeVe/8U+FMj5FiLtjrnebhOjegAZ+YSOHUiD5yZSzA0vUA6oxypL3BepNXCUprxuaRj9WUWrpksNoLKsiCNVWWO2jTbyQ0bOC823qmhfTq+vjaG03IJnK4vsygqQwDm7/SzUQYmE1SWBql3WA6BjtM8Nn3Nf6fsQ5CPU/XlZEfDSbkETteXWRSdIehwWEXNLqfsnH0I8nFaLkE0liASKqWq3JBRTcNxWi5BNJbI5hDUOrNhc1ouwXIWtgMn182k6AxBeyTE4JRzcgmcHqHgtFwCp0bA6DgtMi0ai9NaU0FZiTOrutMi06KxOGVB5+wUaBXOLB0m0h4xd8u3jeK05W7zcVpIpPP15bSGzfmOBjjJcCZoi1QSKKIcAihSQwDOKHjTiSVmFlKObtg6HNSwKaUYdE3DZr++AE1fzi1fTsslKMbQUShKQ+Cchu1yxJBzG7Y2BxnOsdmklkPg3IrqpFyCpXSGoWlnN2xOyyWIOjQL22yK0BA4p2Fz6vLAuZi9M9JGGHBwzoWOk3IJhqYWyChnOxrgnEir+GKKiflFx+vLDIrOEFSUBmmsKndERXVyMlkuTomNX96HwOEV1Wn6ctq6+vk4JZfAiTsFWkXRGQLI/tADDvBAorE44bIgdSFnLaecT9bDdYK+tH0IHF5RneLhuqHHCc7JJSjWZDIoYkPgBA/EqfsQ5KMv3213LkE0lqAhXEaozJk5BDpOySWIxuIEBLbUOms55XyckktwucfpbEfDDIrUEIS4NJUgbXMugVOXB87HKbkETg8d1XHKPNRALEFrbSWlQWdXc6cEcAzEEpSVBGgsshwCKFJD0FGv5xIs2CbD5eWUnd8NdUxFnYzT7utr3bjJ0QAHGE5NX8WWQwBFagicUFGn4kvMJZ2dQ6DjhNj4dEYxOOXMDXzycYK+ILtujhscDafkEgzE4q4oX2ZQpIbAfg/ETRNT+uSsnau2js4usJR27nLKuei5BHbqK5lKMzLjjuWU9VwCu1cFLtZkMihSQ7C84cqkfR6IHrXkxJ228nFCLsHApHsWA3NCLsGgSyKGdOwO4JhdWGIqvuSK8mUGBRkCEakXkSdE5Kz2N7LCNTeIyHMiclxEjojI+3PO/Z2InBeRw9rrhkLkWS8VpUGaqu3NJdC9H7cUPLtDIpf15RKPzXZ9uWwVTbtzCZYdDZcYTqMptEfwCeAppdQu4Cntcz5x4FeVUgeA+4HPi0hdzvk/UErdoL0OFyjPummPVBKdsrOixqmtLKWmwtk5BDr6ctR24fR9CPKxO+T2sqPhHn2Nz9mXS+CmHroZFGoIDgJf1d5/FXh3/gVKqTNKqbPa+0vAKNBU4PcWTHsktOwF2IFTN2BfjazhtG/57mgsQUtNOeUlQVu+f6O0R0LMJlPMJFK2fH80lqA0KDRXOzuHQEfPJbCrV+CW5DuzKNQQtCilhrT3w0DL1S4WkVuBMqAv5/CfakNGnxORVQN4ReQhETkkIofGxsYKFDvbsNmZSzAw6a4IhfZIJYupDOM25RK4UV+AbRnsA7E4bXWVBF0SCnk5ks8mfU3GqSovcXyWv1msaQhE5EkRObbC62DudSrbB161VRWRVuDvgV9TSmW0w58E9gK3APXAH612v1LqYaVUj1Kqp6mp8A5Fe6SSVEYxMmN9LoGeQ+CmCAW9og7Y6LG5Zbwb7A9Rjk66I3RUx+6QWz1Z0elZ/maxZq6+Uuqe1c6JyIiItCqlhrSGfnSV62qAfwU+pZR6PufZem8iKSJfAX5/Q9IXQG5F3VpnbYOsL6fszooa5+auK2ICTEVfTtktE8VweazZNg83luC+rbW2fPdmaLE5l2Bg0l2OhtEUOjT0KPCg9v5B4Hv5F4hIGfBPwNeUUt/JO9eq/RWy8wvHCpRn3XTYmEsw4JJVNHNps9FjuzSVcMVyyrnUVmb3VbZDX/PJFJPzi67qcQYCQludPZFWSikt+c49+jKaQg3BZ4F7ReQscI/2GRHpEZEvade8D3gL8KEVwkS/LiJHgaNAI/BfCpRn3ei9ADsq6uUNst1T8OzMJVhOvnORvrK5BPbExrt1A3a7ci9i8SXii2lXOWZGU9AyjkqpCeCtKxw/BPyG9v4fgH9Y5f67C/n+QqgoDdJcXW5Pj2DS+TuTrYRdsfGXcwh8fa0Ht+Vc6LRHKnny5Iqjy6bitpweMyjKzGIduzy2gckEjVXlVJS6IxRSx65cgoFYnGBAaHX4csr56PqyOpfgcky8uxo2u3IJdH25aSjNaIrcENjTFXXreGR7vT25BAOTCbbWVVDi8OWU82mPVNqSSzAwmaCyNEhDuMzS7y0UuyKt3LR8iVm4q2YZjF25BG5d5bA9ErIll2AgFqe9zo36sieXYMCloZB2LQY5EIsTCWUn94uVIjcEIVIZxbCFuQSpdIahqQV39giWGzZrPTa3ZWHr2OXhui3nQsfXl30UuSHQVyG1zgMZnlkglVGu7BHYEXK7sJRmbDbpSn3Z4eEqpbLJZC4c726uLrcllyDqsqx1M/ANAdZ6uG4ej2yrs95ji7p04hPsySWYTiwxm0y5Ul925BJkMlqWvwt7nEZS5IYgREDg4sS8Zd/p5giFyrIgjVXW5hLohtON+rIjl8DN+gLrAzhGZ5MspjOuC+U2mqI2BGUlAbbWVXLBwqGh6GScgGD5shZG0RYJWeqxuTUUUsfqXILLjoavr/VwOcvfnfXRKIraEAB0NYTon7Cu4F2cjLO1rpJSl4VC6nTWh7hooeG8OBGnojRAU9WqC9M6mg5NX1blEui/TWeDOw1BR32I8blF5pPWhNxe1Op+V0PYku9zKu5sjQyksz5s6dBQ/0ScLpdWUoDuhmzXfSmdWftiA+ifiNNVHybgkuWU8+luCBNfTDNmUcjthYl5GsJlrtnwKJ9urUG+YJFzdmFinqA2N1HMFL0h6G4IEYsvMZ1YsuT7LkzMu9r76GoIk84oyzKML0zMu9a7BZaNvlUNW/943CP6ssY565+Is7WugrKS4m4Ki/u/53LBu2hBRZ1OLBGLL9Ht4oqqy95vQUXNZBQXJ+Mu11fW6PePW9OwZfXlZkdDL18W9Qhcri+j8A2B3hWdNL+i6sams969Ba/TQg93ZHaBZCpDp4sralsku0uYFfpKptJcmk7Q6dKJdYDqilIaq8os6xFcmJh3tb6MougNgV4IrKiourHpbnRvwWuqKidUFrSkR6D/Jm7uEZQGA7RHKi3R18BkAqXcXb4g65xZoa/p+BJT8SW/R4BvCAiXl9BYVW6JB3JhuUfg3ooqInQ1hK0xnNpv4vaK2lkfslRfbp6DAuiySl+Tur7cWx+NoiBDICL1IvKEiJzV/q64h6GIpHM2pXk05/g2EXlBRHpF5JvabmaW091gTcHrH5+nubqcUJm7F7fK6st8w9k/EafEhctP59Otebhmh5Dq4+pdLnY0IGvIhqYXTF+Out8PHV2m0B7BJ4CnlFK7gKe0zyuRUErdoL3elXP8z4DPKaV2AjHgwwXKsyk6LTIEFybdHTqq09UQZmDS/FVbL05kN2B32/LT+XQ1hJhdSDEVNzcy7eLEPNXlJdS7bPnpfPShrQGT81UuaBP4bu6hG0WhNewg8FXt/VfJ7ju8LrR9iu8G9H2MN3S/kXQ3hBmeMd8DcXvoqE5XQ4hFbUN5M+n3yETecuSQyb2o/ols6Kjblp/Op2tZXyYbgsk4LTXlVJa5a4MoMyjUELQopYa098NAyyrXVYjIIRF5XkT0xr4BmFJK6SmEUaCtQHk2he6lm+mBJBbTjMwkXd9tB2ti45VSXJxwd+ioju7hmt3rdHvoqE63RbkEXnHMjGBNQyAiT4rIsRVeB3OvU9kB0NXGCrqUUj3ALwOfF5EdGxVURB7SjMmhsbGxjd5+VXSv00wPRE/972p0f8GzwsOdnF9kNpnyREVtj4QQMVdfqXSGAY8MPdaFyqitLLWkB+UFR8MI1py1VErds9o5ERkRkVal1JCItAIr7jytlBrU/p4TkWeAG4HvAnUiUqL1CtqBwavI8TDwMEBPT4+hg9OX09rNK3jLER0e6BFsqclmYprp4eoLAXqhYasoDbK1ttJUfQ1NZ/e58IK+wPwAjvhiirHZpCccDSModGjoUeBB7f2DwPfyLxCRiIiUa+8bgTuAE1oP4mngPVe73wrqQqVUV5SYupja5Zh49xe8QEDoqg+Zmi3rlVBInezihubpq99z+jI3l+DChHccDSMo1BB8FrhXRM4C92ifEZEeEfmSds0+4JCIvEa24f+sUuqEdu6PgI+LSC/ZOYO/LVCeTSEiWoifeYagf2KeulAptSF3LgaWj9m5BP3jcURw5RaVK9Flsofb7yFHA7L6GowlWEyZs7ihV3JUjKKggHal1ATw1hWOHwJ+Q3v/LHDtKvefA24tRAaj6GoIcSQ6bdrz+z02MdXVEOKnvWMopUyJUumfmGdrbSXlJd6I6OhqCDM5v8jMwpIpK4P2j89TURqgudqdy3Xn09UQJqNgcCrBNhPm1c6Pu3u5bqNxd4C2gexoqmIgFjcthLRvdJ4dTd4xBN0NIRaWMozOmrO8ct/YHDuaq0x5th10m7y4Yd/YHNsbq1y7XHc+Zi9u2Dc2R3N1uWuX6zYa3xBobG8Ko5Q5IX5zyRTDMwvsaPJQw6Z5aX1jc4Y/WynFubF5tnsgwkrHTH0BWX15ydHQ9HVuzBxDcG5szlP6KhTfEGjojbQZFfW8Vpi91CO4rC/jK+rwzALxxbTHegRhAmJOw7awlGYgFveUo9EQzoaQmuVo9I3Ne0pfheIbAg3dOzhnQsE7Nz6nfYd3Cl5rbQWhsiB9oyboSzecHuoRVJQG6agP0WtC+bowEUcpPOXhigg7m6tMKV+T84tMJ5Y8VR8LxTcEGqGyErbWVpji4faNzhEQb4WqiQg7mqpM8dj0Z3qpRwDZXpQZDduyvjzWsO1oCptTHz3YQy8U3xDksN20hi27Zo5XImB0djSFzWnYRueoKi/xTASMzo6mMOfH5w1frE//DbzUI4CsYRufSzJt8GJ9XjWcheAbghx2NIU5N2b8csF9Y3Oe7IbubK7i0vQC88nU2hdvgHPj2YlPty+els/O5iqSqQyXpoxdrO/c+Dxbaytcv7x5Pju1HqHRw2nnxuYoLwkU/Yb1ufiGIIcdzVXMJVOGhkRmMorz494KHdXRParzBmcY943OedJb0/+nXoN7UV4LtdUxK4Cjb2yebY1hz4TaGoFvCHLY3mh8wRucSpBMZTzZI9AbHyMbtvhiikvTC54KHdUxo2HzYqitTnukkrJgwPDhx3Nj3nQ0CsE3BDnsaNZjvY3zcL08HtnVECIYEEMbtuWIIQ96uJFwGQ3hMkP1NTqbZC6Z8qS+SoIBtjWGDdVXMpXm4mTckz30QvANQQ5baowPidQbNq9N5AGUlwTprA8ZawjGvasv0COHjHc09N6s19jRbGzk0MWJOBnlrVBuI/ANQQ567PLZ0VnDnnlmZJZIqJQGl28fuBo7msKGDg2dGZ4lGBDPLga2ozls6OTnmeFsWd3V4s2GbUdTFRcm5kmmjFn65cxIVvc7PdiDKgTfEOSxd0s1p4eNMwSnR2bZs6XacxEwOjuaq+gfj5NKG7NK5OmRWbY1hqko9Vaorc6Opiom5xeZnF805HmnR+aoC5V6LtRWZ2dzFRmVXY3WCE4PzxAQ3xDk4xuCPPZsqWF8bpExAyKHMhnFmeFZ9m6pMUAyZ7KnpZrFdMawxcFOD2cNp1fZ3ZL934xyNk4Pz7C7xbuOxq5mTV8jxujr1PAs3R52NDaLbwjy2LvFuIo6OJVgfjG9XPm9iN5onxwqXF/zyRQXJ+Ps8bC+9rZm/7dTwzMFP0spxZmRueUy60V2NIcpCQinhgrXF2SHar2sr83iG4I89EJiREXVjYmXPdydzVUEA2KIvs5qcw1e1ldTVTkN4TJOGWA4B6cSzCVTntZXeUmQHU1VnDLAMYsvprgwGWdPi3d76JulIEMgIvUi8oSInNX+Rla45i4ROZzzWhCRd2vn/k5Ezuecu6EQeYygoaqcxqpyQwqe3p3d7dGJPNAratiQhu20Zky87LGJCHtbq411NDzcg4JsL8qIHnrv6BxKwZ4t3q2Pm6XQHsEngKeUUruAp7TPr0Mp9bRS6gal1A3A3UAceDznkj/QzyulDhcojyEYNWF8aniWtrpKqj2++cXeLTWGGM5Tw7NUlgbpiHhncb6V2LulhtMjswWvOaTrfLeHDSdk9TU4lWA6UdiaQ6eWe+h+jyCfQg3BQeCr2vuvAu9e4/r3AD9QSpm3easB7N1SzRkDKmp2otjblRSyHtvgVIKZhcIq6pmRWXa3eGeXrdXYs6WahaUMFycLqwZnRmbZWlvh+V22jJq3OzM8S0VpgM56bzsam6FQQ9CilBrS3g8DLWtc/wDwjbxjfyoiR0TkcyKyagyciDwkIodE5NDY2FgBIq/Nni3VJFOZ5Q2uN0MylaZvbM7T47c6+zQPq5CKqpTi1JC3I4Z0dH0VOgFaLPoyaoL91PAsu5qrCXrc0dgMaxoCEXlSRI6t8DqYe53KLtm5qgstIq1kN7H/Yc7hTwJ7gVuAeuCPVrtfKfWwUqpHKdXT1NS0ltgFoYd7FjLccXp4llRGcU1brVFiOZblilpAwzY8s8DE/GJR6GtXSxUBgZMFlK/EYpresbmi0NeWmgpqK0sLqo9KKY4OTnNNmz8stBJrrlurlLpntXMiMiIirUqpIa2hH73Ko94H/JNSann8IKc3kRSRrwC/v065TWVXSzYS5vilad5xbeumnnF0cBqAa4ukotaFSjk2uHlDcCSa1VcxNGwVpUG2N1VxXCsjm+HE0AzpjCqK8iUi7GutLkhf0Vh2juHatjoDJfMOhQ4NPQo8qL1/EPjeVa79AHnDQprxQLLZMO8GjhUojyFUlAbZ01K93DhthqPRaepCpbRHvL/muYhwXXsdr0WnNv2Mo9FpggFhf2txeGzXtdfyWnR603tfHNV0fW279w0BwPXtdZwcmmUxtbkMdr0uF4Ph3AyFGoLPAveKyFngHu0zItIjIl/SLxKRbqAD+Pe8+78uIkeBo0Aj8F8KlMcwru+o5UgBFfVIdJpr22o9m/GZz/XttZwdnSOxuLk1YY4OTrOruapoMj6vb69jfC7J0PTCpu4/OjhDY1U5W2oqDJbMmVzXXsdiOrPpeYIjg1OUBQPs9kNHV6QgQ6CUmlBKvVUptUspdY9SalI7fkgp9Rs51/UrpdqUUpm8++9WSl2rlLpGKfVBpZTx+x5ukuvb65hOLHFhYuORHQtLac6MzHJdkXhrkNVXOqM4fmnjvSh9/Lao9NWRHaI4ssle1NHBKa5rLyJHoyNbNl4b2Jy+jg1Os7e12nPbxRqFn1m8Cte1ZyvqZoY7TmkTxcXUDb1Oq6iHN1FRL00vMDm/WFT62tdaTWlQODywccMZX0zRO1ocE8U6bXWVNITLeG0Tw7VKKY5Ep4tKXxvFNwSrsLuliorSAK9toqJeHr8tnomp5uoKttZWbGpepRj1VV4SZF9rzaZ6BCcuzZBRcF0RNWwiwvUddZvqEVyYiDO7kCoqfW0U3xCsQkkwwDVbazdVUV+9OEVjVRlba4tj/Fbnuva6TeurLBgoiuS7XK5rr+VodJrMBhMXX72Y1bHeCysWrmuvpXdsjrlkakP3vToQ0+4vHkdjo/iG4Cpc31HH0cHpDUcqvNg/yS3d9UUzfqtzfUcd/RPxDa+1/2L/JNe11xbNRLHO9e11zCZTG97h7cX+SbobQjRXF5ejcX1HHUrBkQ32Cl48H6O6oqQoku82i28IrsIt3fUkU5kNeblD0wmisQS3dNebKJkzuXVbds3BF89PrPuexGKao9FpbtlWjPrK/s/Pn59c9z2ZjOKQ5mgUGzd1RggIvLABfQG81D9JT1fEzyi+Cr4huAp6Rd1IwXtRu7YYK+q1bXVUlgZ5/tz69fXqQIxURnFrEeqrsz5Ea20FL5xbv+HsG5sjFl8qyvJVW1nKga21PL8BfU3OL9I7OkdPEeprI/iG4CrUh8vYu6V6QwXvpf5JwmVB9rUWXze0rCRAT3dkY/o6H0MEbuq6YgVzzyMi3La9gefPTa47X+XFfs3RKMIeFMBt2+t5dWCKhaX15au8pOnr1iLV13rxDcEa3La9gUP9sXXPEzzXN0FPdz0lweJU7Ru21XNqeJbYOucJnu0bZ39rDbWV3l5BczXesK2e8bkkfWPrW+Dw2b4JmqvL6W4ozhU037CtgcVUZt1hys/1TVBRGiiqHJXNUJyt1Qa4bXs9iaU0r16MrXntxYk4fWPz3LnH3EXxnMwbdzQA2QZrLWYWljh0IcbP7fb19bPe8TWvTaUz/PjMGHfuaSq6QASdW7bVExD46dm19QXw9OlRbt/R6CeSrYFvCNbgjp2NlAaFp05dbT29LM+cyV5z555ms8VyLNe31xEJlfLUyZE1r/3p2XHSGcVde4tXX10NYbY3hXlyHfp65eIUswupoi5ftZWl9HTXr0tf58fnuTARL2rHbL34hmANqitKuW17A0+eWLvgPXN6jO6GENsawxZI5kxKggHu2tvMj06PkkpffTjtmdOj1FSUcGNHccd337uvhefPTTC7xsY+z5weJRgQ3rSr0SLJnMm9+1o4NTzLwBob+zytOW937i5ew7lefEOwDu7d38K58fmrxnvPJVP8rHe8qL01nXv3tTAVX+LlC6sPp6XSGX50aow3724q2vkUnXv2t7CUVvz4zOrDHUopnjgxQk9XxPM7kq3FPfuz+1+t1et88uQIO5rCdBbpfMpGKO4auE7eui9b8B47MrTqNY8fHyaZyvAL121u/wIv8ebdTZSVBHjs6Or6erZvgvG5JO/09cVNnRHqw2VX1dfJoVnOjs755QvY1hhmZ3MVjx0dXvWakZkFnjs3wc9ft9VCydyLbwjWQVtdJbdtr+c7r0RXDfP758OXaI9UcnMRhkHmU1Vewn0HtvC91y6RTK0c5vfPhweprijxe1BAMCAcvGErT5wYWTXa6nuHBykJiN+wafzijW282D9J//jK0VaPHr6EUvDuG3x9rQffEKyT997cwYWJOM+tEA1zbmyOn5wd45duai/aaI583ntzO1PxJf7t2JVe2/hckn85MsS7rt9adMtKrMZ7b+5gMZ3hu69ErziXWEzzrUMD3L23mfpwmQ3SOY9fuqmdgMAjLw1ccS6dUfzDCxe4qbOO7U3+/gPrwTcE6+Tnr2ulsaqcLzzTe8W5L/30PKXBAB+8rcsGyZzJHTsb2dEU5q+e6btiUbWvPXeBxVSGX7tjm03SOY/9W2u4tbuev/nJuSuSpb7zSpRYfIkPv8nXl86W2gruv2YL//D8Babjr59kf+LEMBcm4nz4Tdttks59FGQIROS9InJcRDIi0nOV6+4XkdMi0isin8g5vk1EXtCOf1NEHOvuVJQG+cjPbednvRM8c/pyKOmp4Rm++dIA7+tpp6m63EYJnUUwIPz23bs4NTzLP746uHz80lSCv/nxOe470MLOZt9by+V33rqLkZkkX/lZ//Kx6fgSn3/iDDd3Rfzs2Dx+++5dzCVT/OWPzi4fW1hK89kfnGJ7Y5j7DrTYKJ27KLRHcAz4X4Afr3aBiASBLwBvB/YDHxCR/drpPwM+p5TaCcSADxcoj6l88LYudjVX8YffOcLAZJzY/CL/8ZHD1FaW8nv37rFbPMfxzuu3ckt3hP/r0eOcGp5hPpnid795GIXi//j5/Ws/oMi4Y2cD9x1o4XNPnOGl/kmSqTR/+N3XiMUX+czBA/6wYx77Wmv4lTd08uWfnefx48OkM4o/efQ4/RNxPnPwmqKPRtsIstk9eV/3EJFnkbmQbgAAB6pJREFUgN9XSh1a4dwbgT9RSt2nff6kduqzwBiwRSmVyr/uavT09KhDh674Kks4OTTDAw8/T2IpTUlAWEpn+NKDtxR1duzVGJiM854vPsvE3CKVZUHmkik+//4bOHhDm92iOZLJ+UXe81fP0j8xT3VFKdOJJT79C/v5dX9YaEXiiyne/9fPc3RwmkiolFh8id+6cwd/eP9eu0VzJCLyslLqitGbEgu+uw3IndGJAm8AGoAppVQq5/iqrYOIPAQ8BNDZ2WmOpOtgX2sN3//Ym/jKs+dJpjL8yhs6ObDVX8dkNTrqQzz6sTfx5Z+dZ2p+iff2tPsrQV6F+nAZ//hbt/Pln57n0vQC77x+q+9kXIVQWQmPPHQbf/dsP31jc9y7r4X7r9lit1iuY01DICJPAitp9lNKqe8ZL9LKKKUeBh6GbI/Aqu9dic6GEH/8zgN2iuAqWmoq+OTb99kthmuoC5Xx8bf5Q43rJVxewkfv2mm3GK5mTUOglLqnwO8YBDpyPrdrxyaAOhEp0XoF+nEfHx8fHwuxYjblJWCXFiFUBjwAPKqykxNPA+/RrnsQsKyH4ePj4+OTpdDw0V8UkSjwRuBfReSH2vGtIvIYgObtfwz4IXAS+JZS6rj2iD8CPi4ivWTnDP62EHl8fHx8fDaOIVFDVmNn1JCPj4+PW1ktasgPtPXx8fEpcnxD4OPj41Pk+IbAx8fHp8jxDYGPj49PkePKyWIRGQMubPL2RmB9O19biy/XxvDl2hi+XBvDq3J1KaWuSFV3pSEoBBE5tNKsud34cm0MX66N4cu1MYpNLn9oyMfHx6fI8Q2Bj4+PT5FTjIbgYbsFWAVfro3hy7UxfLk2RlHJVXRzBD4+Pj4+r6cYewQ+Pj4+Pjn4hsDHx8enyPGUIRCR+0XktIj0isgnVjhfLiLf1M6/ICLdOec+qR0/LSJrbpdpsFwfF5ETInJERJ4Ska6cc2kROay9HrVYrg+JyFjO9/9GzrkHReSs9nrQYrk+lyPTGRGZyjlnir5E5MsiMioix1Y5LyLyl5rMR0TkppxzZupqLbl+RZPnqIg8KyLX55zr144fFhFDV3Fch1x3ish0zm/16ZxzV/39TZbrD3JkOqaVp3rtnJn66hCRp7V24LiI/O8rXGNeGVNKeeIFBIE+YDtQBrwG7M+75reAL2rvHwC+qb3fr11fDmzTnhO0UK67gJD2/jd1ubTPczbq60PAf1/h3nrgnPY3or2PWCVX3vW/DXzZAn29BbgJOLbK+XcAPwAEuA14wWxdrVOu2/XvA96uy6V97gcabdLXncC/FPr7Gy1X3rXvBH5kkb5agZu099XAmRXqo2llzEs9gluBXqXUOaXUIvAIcDDvmoPAV7X33wHeKiKiHX9EKZVUSp0HerXnWSKXUupppVRc+/g82d3azGY9+lqN+4AnlFKTSqkY8ARwv01yfQD4hkHfvSpKqR8Dk1e55CDwNZXlebK777Virq7WlEsp9az2vWBd2VqPvlajkHJptFyWlC0ApdSQUuoV7f0s2b1b8vdwN62MeckQtAEDOZ+jXKnI5WtUdsOcabIb4qznXjPlyuXDZK2+ToWIHBKR50Xk3QbJtBG5fknrhn5HRPQtRx2hL20IbRvwo5zDZulrLVaT20xdbZT8sqWAx0XkZRF5yAZ53igir4nID0RE3wTcEfoSkRDZxvS7OYct0Zdkh6xvBF7IO2VaGVtzz2If6xCRDwI9wM/lHO5SSg2KyHbgRyJyVCnVZ5FI3we+oZRKish/INubutui714PDwDfUUqlc47ZqS/HIiJ3kTUEb8o5/CZNV83AEyJySvOYreAVsr/VnIi8A/hnYJdF370e3gn8TCmV23swXV8iUkXW+PxHpdSMkc++Gl7qEQwCHTmf27VjK14jIiVALTCxznvNlAsRuQf4FPAupVRSP66UGtT+ngOeIespWCKXUmoiR5YvATev914z5crhAfK67ibqay1Wk9tMXa0LEbmO7O93UCk1oR/P0dUo8E8YNxy6JkqpGaXUnPb+MaBURBpxgL40rla2TNGXiJSSNQJfV0r94wqXmFfGzJj4sONFtndzjuxQgT7JdCDvmo/y+snib2nvD/D6yeJzGDdZvB65biQ7QbYr73gEKNfeNwJnMWjibJ1ytea8/0XgeXV5cuq8Jl9Ee19vlVzadXvJTt6JFfrSntnN6pOfP8/rJ/JeNFtX65Srk+yc1+15x8NAdc77Z4H7LZRri/7bkW1QL2q6W9fvb5Zc2vlasvMIYav0pf3vXwM+f5VrTCtjhinXCS+ys+pnyDaqn9KOfYaslw1QAXxbqxgvAttz7v2Udt9p4O0Wy/UkMAIc1l6PasdvB45qleEo8GGL5fqvwHHt+58G9ubc++uaHnuBX7NSLu3znwCfzbvPNH2R9Q6HgCWyY7AfBj4CfEQ7L8AXNJmPAj0W6Wotub4ExHLK1iHt+HZNT69pv/GnLJbrYzll63lyDNVKv79VcmnXfIhs8EjufWbr601k5yCO5PxW77CqjPlLTPj4+PgUOV6aI/Dx8fHx2QS+IfDx8fEpcnxD4OPj41Pk+IbAx8fHp8jxDYGPj49PkeMbAh8fH58ixzcEPj4+PkXO/w8iZDTSRCeaqQAAAABJRU5ErkJggg==\n",
       "text/plain": [
@@ -2506,8 +2489,12 @@
      },
      "metadata": {
       "needs_background": "light"
-     }
+     },
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "series.plot()"
    ]
   },
   {
@@ -2521,6 +2508,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2528,26 +2516,26 @@
     "id": "xtmkmd2l5U4o",
     "outputId": "278f9301-9f68-42b1-d0dd-11657f48e364"
    },
-   "source": [
-    "series.values"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1.22464680e-16, -2.51300954e-02, -5.02443182e-02, ...,\n",
        "        5.02443182e-02,  2.51300954e-02,  1.10218212e-15])"
       ]
      },
+     "execution_count": 72,
      "metadata": {},
-     "execution_count": 72
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "series.values"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2555,22 +2543,21 @@
     "id": "-jvWYyW44JUH",
     "outputId": "7ec67c4d-b14b-4dd3-ceda-5d42655636e4"
    },
-   "source": [
-    "series.to_numpy()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([ 1.22464680e-16, -2.51300954e-02, -5.02443182e-02, ...,\n",
        "        5.02443182e-02,  2.51300954e-02,  1.10218212e-15])"
       ]
      },
+     "execution_count": 73,
      "metadata": {},
-     "execution_count": 73
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "series.to_numpy()"
    ]
   },
   {
@@ -2588,6 +2575,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2596,18 +2584,8 @@
     "id": "Bty17IsDU6B3",
     "outputId": "5434f563-2cdf-4618-ee07-a0056152f58f"
    },
-   "source": [
-    "df = pd.DataFrame({\"Phase 0\": sine_wave_with_numpy(time, amp, f, 00),\n",
-    "                   \"Phase 90\": sine_wave_with_numpy(time, amp, f, 90),\n",
-    "                   \"Phase 180\": sine_wave_with_numpy(time, amp, f, 180),\n",
-    "                   \"Phase 270\": sine_wave_with_numpy(time, amp, f, 270)},\n",
-    "                  index=time)\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -2734,9 +2712,18 @@
        "[1001 rows x 4 columns]"
       ]
      },
+     "execution_count": 74,
      "metadata": {},
-     "execution_count": 74
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = pd.DataFrame({\"Phase 0\": sine_wave_with_numpy(time, amp, f, 00),\n",
+    "                   \"Phase 90\": sine_wave_with_numpy(time, amp, f, 90),\n",
+    "                   \"Phase 180\": sine_wave_with_numpy(time, amp, f, 180),\n",
+    "                   \"Phase 270\": sine_wave_with_numpy(time, amp, f, 270)},\n",
+    "                  index=time)\n",
+    "df"
    ]
   },
   {
@@ -2752,6 +2739,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2760,23 +2748,18 @@
     "id": "ZkC62XnKVd6X",
     "outputId": "6e92b6eb-a66d-4582-9ea7-7fe80c6cf0f2"
    },
-   "source": [
-    "df.plot()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<matplotlib.axes._subplots.AxesSubplot at 0x7f51187bd810>"
       ]
      },
+     "execution_count": 75,
      "metadata": {},
-     "execution_count": 75
+     "output_type": "execute_result"
     },
     {
-     "output_type": "display_data",
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9d5hkV33n/TmVu6qrc85xeqImSRolFBCS0GKCliXI9mNsDNjGGF6v18ZeB2zWL7v77O67tjGvvTixGC8gMgghUEZC0oxmpMkzPdNd3dXd1TlVV47n/ePWrQ6V7r3VFi+P6vs8/Uhz761f3/r275xfOL/zO0JKSQUVVFBBBW9cmH7aL1BBBRVUUMFPFxVDUEEFFVTwBkfFEFRQQQUVvMFRMQQVVFBBBW9wVAxBBRVUUMEbHJaf9gsYQVNTk+zr6/tpv0YFFVRQwc8Uzpw5syylbN55/WfSEPT19XH69Omf9mtUUEEFFfxMQQjhzXe9khqqoIIKKniDo2IIKqigggre4KgYggoqqKCCNzgqhqCCCiqo4A2OiiGooIIKKniDY1cMgRDiH4UQi0KIiwXuCyHEXwkhxoQQ54UQx7bc+4AQ4nrm5wO78T4VVFBBBRVox25FBF8A3lrk/oPAcObnI8DfAAghGoBPASeAm4FPCSHqd+mdKqigggoq0IBd2UcgpfyxEKKvyCPvBL4olZ7XLwsh6oQQ7cDdwBNSylUAIcQTKAbly7vxXjk49xWI+uHQe8DZYFhMKJbkO2dniSdT/NzhDpqq7YZlpUMh/I89hoxEqfk3D2JpajIsK5KM8IOJHxBKhHiw/0GaqozLIhGBi9+A6AYceBfUdBgWFU2kePT8HOvhOP/mUDsddVWGZaXjcTYee4zU2jo1D9yPtcP4eyVSCR6ffJyVyAr39d1HZ3WnYVmkEnDp2xCYg31vh4Z+w6KSqTSPXZxn3h/hvv1t9De5DMuSySSBJ54gMTtL9ZvfjL3f+HulZZonvU8yE5zh7u67GagdMCyLdBquPgqr47DnQWjZW4YoyRNXFvAshbhnbzN722oMy5JSEnzmWWLjY1S/6U049hp/Lyklz/ue59raNW7ruI39jfsNy0JKGHsKvD+B2z8BVXXGZeWB2K3zCDKG4FEp5cE89x4F/ouU8oXMv58CPoliCBxSyj/PXP9jICKl/O95ZHwEJZqgp6fnuNebd19EcfzLe+H6D6G6FT7wPWge0S1i3h/l4b97mYnlEABN1Tb+5UO3MNLm1i0rubyM95c+QNzjAcBcX0/PP/4Djn37dMvyx/z88uO/zNj6GAA1tho+f9/nOdB0QLcsImvwhbfDwgXl345a+IVvQPdN+t8rnOAX/uFlLvo2AHDbLfzTr9zEjX36DXEqGGLqgx8kev48ACank66//RtcN9+sW1Y0GeUjT3yE1xZfA6DKUsVf3vOX3Npxq25ZJCLwpXcrgxTAUgXv+xIMv0X/eyVSfPALr/Di+AoAdouJz/38Md6yv1W3LBmPM/3R3yT0wgsACKuVjv/nf1Bz3326ZSXTSX77md/m2ZlnAbAIC//5zv/MW/uKJQIKIJ2CR35JMQQAJgu862/hhvfoFpVKS37ry6/y2IV5AMwmwX999w38u+NdumXJdJrZ3/skG4+q72Wi7c/+lPr36H8vKSV/8uKf8O2xbwMgEPzhiT/kfXvfp1sWUsL3Pg6vflHh6teeh1ZjRkUIcUZKeePO6z8zi8VSys9LKW+UUt7Y3JyzQ1obfuER+MhzCrGPfACSMV0fT6clv/3VsyxsRPmXD53g+x+/A5MQ/No/nyaaSOmSJaXE9x9+l8TcHN1/93f0f+c7CIeDmd/8GOlwWLesTz7/SSY3JvnrN/8133rHt3Db3HzimU8QiAd0yUJK+M7HYOkqvP//wG+egqoG+OovQGRd93v94bcvcHUuwN/+4jGe/p27aHbb+fUvncEfTuh7L2D+z/6M6MWLdPyP/87gDx/H0t6O77c+TnJlRbesP3/5zzm7eJbP3PEZfvBvf0CXu4vfee53WAgt6JbF43+gGIF3fg4+cR6ahuFrvwx+n25R//Xxq7w4vsJ/+beH+Mnvv5mRNjcf/8pr+NYjumUt/s+/IPTCC7T+yR8z9MzTOPbvZ/Z3f4+4ASfqs699lmdnnuV3b/xdnnrPU9zQfAN/9MIfMb4+rlsWz/1XxQjc92n491eh51b4zkdh4bJuUX/73DiPXZjndx8Y4dQf3sutA438/jfOc2VuQ7es1X/6JzYefZSmj32M4ed/jOv225n/0z8jcuGCbln/fPmf+fbYt/nwoQ/z7Huf5a6uu/jMqc9kHQ9deOXvFSNw+yfgP84ZNgJFIaXclR+gD7hY4N7/Ah7e8u9RoB14GPhfhZ4r9HP8+HFZFkZ/KOWnaqR87r/p+tg3zkzL3k8+Kr980pu99sL1Jdn7yUflXzxxTZcs/2OPycsje+Xql7+cvRY6fVpeHtkrF//yL3XJetr7tDz4hYPyS5e/lL12fvG8PPiFg/IvzvyFLlny2o8Ubl7Y8g6+16T8VK2UP/gDXaJ+fG1R9n7yUflXT25yc8nnl/2//6j8w2+d1yUrdOqUws1ffTZ7LTo2Ji8fOChn/+iPdck6u3hWHvzCQfmXZza/46R/Uh794lH5Ry/8kS5Z0veqwtcP/3Dz2uqElJ9ulvLrv6pL1EXfuuz95KPyT759IXttejUk9/7RD+SvffG0LlnR69fl5b375OynPpW9Fp9fkFePHpNTv/FRXbIm1ifkkf99RP7xC5s8L4WX5K3/51b5G0/8hi5ZcnVCyj9rkPIbH968FlyW8j/3SPmFn5MyndYsamYtLIf+4/flR790RqYzn1sLxeTRT/9Ivvv//Un2mhbEFxbklcNH5PTHPpb9XHJjQ47ecYeceO/7ZDqV0ixrObwsb/7SzfKjT340KysYD8q3fO0t8n3fe59MpbXLkqEVKT/TJeUX3yWljncoBOC0zDOnvl4RwXeBX8pUD90C+KWUc8APgfuFEPWZReL7M9f+dbHnfhi+H176HMRDmj6SSkv++ukx9rXX8L6burPXbx9q4q0H2viHFzyEYklNsqSULP3157Dv2UPdlrDTefw4Nf/mQVa+8L9JbWjzaKSUfPbsZ+mr6eO9I+/NXj/UfIi3DbyNf778z6xGVzXJQkp4+s+hrhdO/Prm9Y4jcPQX4ZW/g+Ci5vf6iyev017r4CN3beaS93fU8PMnevjqK9MsbES1vRew9Jd/haW5mcYPfyh7zT44SP3DD7P+jW+Q8Gn3vj/72mdpdDTyoUObsnprenl478N8Z+w7eDd0eMzPfEaJmO78vc1r9X1w28fgwtdg6Zr293pqDLfdwr+/fzNl2VXv5NfvGuTxS/NcW9Ae3S197nOYnE6aP/GJ7DVrawuNv/ZrBJ9+msjFS5pl/c25v8FqtvLxYx/PXmuqauLDhz7M877nObt4VrMsnvtvSnrjLX+6ec3VCHf/AUz8GLwvan+vZ5U06H982z6EEADUOW38zv17OO1d4yWP9khx5fN/h0wmafm938vKMrvdtPxf/xeRc+cIPf+8Zln/ePEfiaVi/Icb/0NWlsvq4reO/haXVi7xzNQzmmXx4mchFoAHPgOmf73perfKR78MvASMCCFmhBC/KoT4dSGEOps8BniAMeDvgI8CSGWR+D8Br2R+Pp259q+PO/49RFbhnLZ16WeuLuJZDvGxe4ayf1wVv3bXABvRJI+cntYkK/Tii8THx2n81Q8izOZt9xp+9VeR4TDr3/ymJllnFs5wfe06Hzz4Qawm67Z7Hzr4IWKpWDZPWRIzr8DcWbjjt8Fi237v9k9AKg5nvqBJ1PkZP2e8a/z6XYPYLdu/44ffNEAyLfniS5OaZEVHRwmfPk3DBz+IyeHYdq/xV34ZhGDty9r+jh6/h5NzJ/nF/b+I0+rcdu9XDv4KZmHmkdFHNMli1QPXfwS3/AY4dixQnvgNMNvg1Oc1iZpeDfP4pXk+cFsftVXb/46/dGsvDquJv3/eo0lWYmGBwI+eoP7h92Op316EV//zDyOcTta+9CVNspYjy/zI+yPePfzunOKD9428D7fVzZevaqztCK/ChUcUp2Jn8cGxX4Kqejj1vzSJ8kcSfO30DO8+1kXnjuKDdx/rotFl4++fn9AkKx0K4f/mN6n9uZ/D1t297V7t29+OpbmZ1S/9iyZZkWSEb419i/t676O/dvvC/Nv630a7q50vj2rkKxFVxtu+t0OL/nVDPdgVQyClfFhK2S6ltEopu6SU/yCl/Fsp5d9m7ksp5W9KKQellIeklKe3fPYfpZRDmZ9/2o330YTeW6H1EJz9P5oef+T0NE3VNu4/kLtod7SnniPddXz1FW2GYP2Rr2FuaMD94IM596oOHKDq2DHWv/JVNV1W/L2uPYLb5uat/bmLdkP1Q9zYeiNfG/2aJlmc+QLYquHQv8u91zQMg/cqz6TTpd/r9DQOq4mHjuVW4vQ2urh3bytfOz1DKl36vdYf+RrCaqX2Xe/MuWft6MB9772sf/0byETpdYevX/s6FpOFh4YeyrnXVNXEW3rfwrfGvkUspWH96NUvgjArE9tOVDfDwXcrjka89JrP18/MIAQ8fKIn5169y8ZDRzv53rk5TVGn/5vfhFSKuve+N+ee2e2m7l3vVCqvAqUjjO+MfYdkOsl7RnIXTJ1WJ+8YegdPeJ9gLbpWUhbnvqI4E8d/JfeezakYgyuPaoo6v3tullgyzS+c6M2557Ca+fkTPTwzuqgp6vQ/9hjpcJi69+XyJWw26t7/PkLPP098pnTU+cPJHxKIB3jfSO6isNlk5j173sPJuZPaos6rjyrO6o15+Npl/MwsFv+r4PD7wXemZPi+Forz9NVFHjraidWcn7KHjnZydT7A6HzxwZUOhwk+9xw1b30rJpst7zO173wn8clJYleuFJUVTUZ5dvpZHux7kCpL/pLMh4YfYiY4w4XlEgteiahS/njgIbAXqIA6/DBs+GD6ZFFRsWSK756b5cGD7dQ4rHmfeehoJ4uBGC+XCN9lMsnG97+P+7635Hi3Kmrf9U5S6+uEXn65qKy0TPPDiR9yV9ddNFY15n+voYcIxAP8xPeTorKQEs5/DYbvK1xae/j9EA8qUUNRUZJvvjbDHUNNOd6tincd6SSSSPHkldKL2f7vfg/nzTdj68k1KqDol4zHCTz5VElZj08+zuHmwwVLRR8aeohEOsGTU0+WlMX5r0LHUWjLKSxUcPhhkCm4/J2Sor5xZoa9bW4OduYvFX3X0U6l2ObcbElZG9/9HrbBQaqOHMl7v/adigOy8YPHSsp6fOJxuqq7ON56PO/9dw69E4HgBxM/KCmL81+F2h7ov7v0s2XijW0IVM/3SnHFe/rqIsm05O2HC9esv+2GdswmUVLxgs89h4xGcb/1gYLPuO+/DywW/N//flFZP5n9CZFkhLf0Fi5TvLv7biwmCz+cLLH0MvEcJEKw/12Fnxl5UCmNvPj1oqJOelYJRJO8/XB7wWfu3ddCtd3Cd88W5yv86quk1tdxP1C4TNF1xx2Y3G42Hi3O14XlCyxGFovydVP7TdTaa/mRt/jkzdxZ2JiB/blRShZ9bwJXS0m+rswFmF6N8PYbCuvXTX0NdNQ6SvIV83iIT0zgfuD+gs84brgBa1cXGyX0azowzdXVq9zXW7jcdE/9Hnprekvrl39G4ayYfrXsg5b9cKE4XwsbUc5Or/P2wx05aVoVg83VHOqsLTkek2trhM+coeaB+wvKsnV14Th8AxvfL24INuIbnJw7yX299xWU1eJs4WjL0dJ8xQLgeRb2v+NfdW1AxRvbELjboOMYXCv+R3nyygKtNXYOdtQWfKap2s7x3nqeGS0e1m784HHMTU04j+f3GAAs9fW4Tpwg+HTxRaWnvE9Ra6/lxracsuAsamw13NZxG096nyyeHrr6KNjc0P+mws/Yq5Xa+NEfKB5xATx5ZYEqq5nbBgtvaHNYzdy1p5lnRheLvlfwqacQNhvVd9xe8BmTzYb7zfcQfPZZZKpwGe+T3iexmCzc2XVnwWesJiv39tzLs9PPkkgXSTVdeRSECfYUqaM3mZX87thTRUuVn7yygBBwz96WwqJMgvv2t/KT8eWipcqql+9+85sLPiOEwP3A/YROniQdKlws8ZRXkXVvz71FZd3fez+vzL/CerRIefHVzCS69+cKPwOKYZ0+CaHCkeJTV5Qx9pZ9xfdWPHCglXMzfpYChbkPPv0MpNNU31v4OwLUPPBWYlevkpgtbFiem36OpEwWdTQA7u+7n7H1MSb9k4UfGntSSaPtfVtRWbuFN7YhAGUgz5yG4FLe29FEiueuLXHvvlZMpvxWXsU9Iy1cmt0omJeUiQShn/wE95vfnLNIvBPVd76J+MREwbxkMp3k2Zlnubvr7pxF4p24q+suZkOzhfOS6ZQyuQ/fB5YSu6SH7lPSQ0ujeW9LKXny8gJvGm7CYS3+He8eaWYxEONygZpvKSWBJ5/CddttmFzFd9e63nQnKb+f6KXC1TBPTz3NifYT1NiK7zy9s+tOQokQ55fOF37o6veh9/bSO9SH74NEGKYKp62evLLA0e46mt3Fub97bwvRRJqTE4XrKQJPPYnj4EGs7YWjMYDqN90JiQShk6cKPvP09NPsa9hHl7v45qw7u+4kLdOcnC+SMrz6KDSNQNNQUVkM3QdI8BR2gp68skB3QxV7WquLirp7RDGsP76Wf2wDBJ56Ckt7O479xWvzq+9UHKRgZnNePjw99TQtzhYONhVIfWWgOiIvzhapkLr6fXA2QveJorJ2CxVDsOcBQMLYE3lvn5xYJRxP8ZZ9hb01FffsVTa6PTeaX/EiFy6QDoVw3V7Yu1XhepOieKECind55TKBeIA7uu4oKUvdLVtQ8ebOQWhJSf2UwlDGcxrLnxO+Mhdg1h8t6a0B3DWi8PVsAb7iExMkfD6q77mnpCzX7beBEAQLlPn5gj6mAlO8qbNIxJPBzW03Yxbmwnz5Z2DpSvFoQEXfm8BkLcjX4kaU8zN+7tXA160DjdgtJp65mj/qTK6tET13nup77i4py3nsKMLpJPRCfr5UQ3hHZ2n9Oth0ELfVzUuzL+V/IB5SykJHNPDVcUQpxy3AVzSR4oWxZe7d21ow/aLiQEcNzW57wShdxuOEXnoJ9z13l5RlGxzE0t5O6Pn84zGVTnFy/iR3dN6BSRSfVrvd3XS7uwvzlU4r33/4ASWqfB1QMQTth5WWE2P5F85eGl/BYhLcMpB/cXErRlrdtNc6Cipe6MWXQAhct5S28rb+fiwd7QQLDNSTc4r3dXNb6fYKJRVvMvM7+gunTLKo7YLmvQUHqlq7fcdw6T5HLW4HhzprebYAX+GTynfUwpelvh7HwYMFB+qpOcXzPdFWWpbb5uaG5hsK8zWR4WvgrpKysFdDzy2F9SvD153DpXfLO6xmbhtsLMzXK68A4Lq1dJsMYbMp6ccfP583NXdm4QwpmeLm9tL6ZTFZONF+ghdnX8yf5pt6GdIJbfplMsPgPQpfearTXvWuEU+muWtPab6EENy9p5kfX1vKW50WuXgRGYngvOUWTbKq77id0Esv5a1Ou7p6lUA8oGk8AtzWcRun5k+RSOVJPy5eUtq8aOFrl1AxBEIoIb73xbx575c9KxzursNpK92fTwjBbYNNnJxYzTsgQi+9hOPgQcy1hdcatsqqvv0Owi+fzJv3Pjl/kj31e2hwaOvZU1TxJp6Hpj3KmokWDN6r8JXITYG97Fmht9GpubHcbUONnJ1ez5v3Dp08haWtDWuB6pedcN1xO5Hz5/OWRb489zKNjkYG6wY1ybq1/VYuLl/Mn/eefF7xWls09nEaulcZ3HnKIl/2rOK2W9jfoa1R2u1DTUyuhJn353IfPnkKUVVF1cHiqQkVrjtuJzEzQ2I6t+z55bmXsZlsHGnOX0mzE7d23MpcaI6JjTy1+5PPK5vIuktPuICiX6FFWMxtOfGyZwWTgBv7tDUpvn2oiY1oMm/LifDJkyAEzpu09dBy3X4H6WCQyIXcbvsvzympvxPt2lI5t7bfSjgZ5uxSns14qqNRbL1ul1ExBAC9t0FgFtYmt10OxZJc8Pm5ZUB7g7Sb++tZDcUZX9q+CJcOhYicO4dLg/ehwnnzTaSDQWLXr2+7HkvFOLt4VrPSgaKg4WSYK6s7SlJTCZh6SUlhaEXf7ZCKKVUgW5BOS05NrHJLf+noScXNfQ0kUpLXprZPuFJKwqdO4Tpxc8mwXYXrppsgnSZy9lyOrFPzp7i5XbusE+0nkEheXXw19+bE8woHWqs5ejPplTzrBCc9K9zc34C5xPqTipsyzfpemcxdJwifOonz2DFEgbLknVAnwPCrud/x1NwpjrYcxWFx5NzLB1UXzyycyb058Tx0HleiIy3oy6ROp3Ijspc9qxzsrMVdoCx5J27qL8xX6OQp7CMjBcuSd8J5k1KUEXktD1/zpxiqG9Lc8fem9psQiPx8TT4P9f1K9P06oWIIAPoyA9W7vXb8tHeNVFpqSgupKDRQIxcvQTKZVSYtcB5Tzu8Jn9muLBeWLhBLxbipVXs30KMtRwFym17NnlVq3fV4H+oC1o6BenU+gD+S4JZB7Ybzxt4GhMjlK3b9OqnVVZw3azd2jhsOg9mcM1C9G16WI8uaw3aAA00HsJqsuR7b2iT4p6BPR9jefhgsjhxDsLgRxbMc0qVfBzpqcNrMOXwlV1aIXR/DeUI7X/ahIUw1NUTObOdrI77B6Npo0Wq0nehx99DgaMhtNxELwOxr+hyNul5wt+fsV4kmUpydXtfFV2ddFZ11VTl8peNxIq+9huuEdp2wNDZi6+sjvIOvZDrJa4uvcWOrdr5qbDUM1g3m8pVOweRPXtdoACqGQEHTiBLq7+hzcmpCWR843qv9rJz+JhdN1TZe2VHZETmneKlVN9ygWZalowNLa2vOQFU3hx1uOaxZVlNVE13VXZxb2u4tZwdbz22aZeFqgsbhnInt5ISS7z6hIyKodVoZaXXnGs7XlAHivLFwme1OmKtdOEZGcgaqypfWNAeA3Wxnf+P+3IE6namy6dXRrtpiUzziHYZTrf45oSPitJhNHOup59RO/Tqrny9hMlF19EhORHBxSUl9HGnRzpcQgiPNR3L58p1RNonp4UsIxdnYoV+vTa0TT6U50a+vhflNffWcmljblq6NXb6MjMWoKlLGnQ9Vx44RefXVbbLG18eJJCO6+ALFOTu3dI603LIWsjQKMb++8bgLqBgCUEL8nltzFO/ctJ+97W5N6wMqhBDc1NfAqZ0T29mz2Pr7MddpP1BCCIHz+DHCr2334s8vnaerukvz+oCKIy1HeG3xte3rF74zUNsNbp397ntuUYzIlgW9c9PrtNU4dB88c1NfA2e8ayRTm7IiF85jrq3VvD6gour4cSLnzm1b0Du3dA6X1ZXT+6UUjjQf4dLyJeKp+OZF3xmwOqFZZ++Xnltg/vy2JofnptexW0zsa9d3kMpNfQ2MLgS2tfKOnL8AZnPJMsidcB47Tnx8nOTaZouIc8vnEAgONmpba1BxpOUIU4EpliPLmxd9mWi241j+DxVCz63gn4b1zfWLczNK+vBoj75DDG/qb2A5GGNyZbPVR+S84hxUHdbuTAE4jx8jtb5OfGJzLUR1rm5o0u7kgcJXMBHMniECbPLVpT262A1UDIGKzmPKaUmZnvvptOTczDo3dOk/CehYTz0zaxGWg8pGFiklkXPndCsdQNWx4yTn5rZtZDm/fJ5DzYd0yzracpTlyDK+4Ja9Cb4zynfXi55blcqG5c32HOdm/NzQVXohfCeO99YTjqe4vhjMXouev4Djhhs05/RVOI8fQ0ajRK9ezV67sHyBg40HMessxTvacpR4Os7llS2Llr4z0H4EzDoP9+u5FdLJzYGOMrEd6Kgp2LakEI731isdLnyb6yrRC+exj+zJacpXCs7jyt9ejcBAST0O1A5QbdOY089ATT9uizp9r0LDoP4TAXsya2lb0kPnptfpbqiiwaVtDUSFGtGfnd40dpELF7C0tGBt1ecAVeVJ115YvkC9vb7kfoudONqs8LUtivKdAXutwtnriIohUNGh/FGYU5R4ciVEIJrksIGJ7VDmMxd8fgASPh+plRWqjhgwBIcUryyS2Sg1H5pnMbzI4Wb9stTPZAdqaBnWvdBpwPtQjUdmwdgfTjCxHOJwt37DuZOvdChEbGxMVxpNheOgYiCjF5X0RjQZ5drqNW5o1i9LTb1l+UrGYe48dOlLJwCbHvGswlcyleaib8OQo3GocztfMp0mcv6CMb727weTKbsRT0rJheULhvja37gfi8myyZeUymZNI95t6wEw25X1hQzOz/g5bICvoeZqHFYTF2Y2K4ci589RdVj/d7T19WFyu7dtXLywdIFDzYd0Oy1dbiWq3244Tytj63VoK7EVFUOgQjUEs0q+9PyMMsiMTGwHOmoQAi5kZKjeVqGmVsVgHxkBszmreGq++1CT/ohgsG4Qu9nOlZVM5ZDqnXYamNia9igpkszEpnqnRgZqf6OLartlk69LlyCdpuoG/d/R2tmBubY2azivrF4hKZOG+GqqaqLF2cLV1Ux0sXBRqZYywperUUnBZQzn9cUgkUSKIwb0q9ZppbfRmeUrPjlJOhik6pD+ic3kdGIb6M/q13RgmvXYuqGI02a2MVw3zNWVDF8bsxCcN8aX2aoYg4xjthSI4VuPGNIvi9nEgY5aLmR0NLW+TsI7hcMAX0IIHPv3E72kRImBeACP32NIv4QQ7G/cv1nJFw8rp7QZ4atMVAyBCmeDcqBIxgM5O71OldXMULO+8BjA7bAy0OTKGpPI+fOIqirsQyW21+eByeHAPjSUVbwLSxewmqzsbdB/qLbFZGFP/Z5NxfOdUfrltOuPLjCZoe1QdmJTv+shAxGUySQ40FGT9XCjmaMBHYeMDS7HgQNZvtQ2EUYmNoD9Dft3x3CCwrNqODP5biOpNICDnbXb9AswZDhBaX2uGoLzy4osvfluFerEJqUsn6+OI4ohSKezfBlxzECJoi76NkilZXYfgFG+HAcOEBsdRSYSXFy+iDk2/lwAACAASURBVEQa5mtfwz486x6iyaiyhiRTFUPwU0fHUfAphuD8zDqHOmux6MzfqlAUTxmosStXcOzdi7DozCtn4MgMVCklF1cuMlI/gs2sL0+qYl/DPq6sZAbqzGml26PW+u6daD+ipErSKc5NrzPQ5Mo5VEUrbuiq5fLcBolUmsi581i7u7E06D/gHjID9fp10vE4l5Yv0e5q11zfvRP7GvcxsTFBOBFWJjZXi+LZG0HHEWUdKurn3IyfGoeFvsbiPZQK4YbOWnzrEVZDcaLnz2NyubAN5G8VXQqOAwdILi2RWFzk0vIlqixVmjfe7cS+hn2sx9aZD80raQ6TVXEYjKD9CMQ2YG2CczN+TIKCbadL4VBnLZFECs9SkMj5cyAEDo0b73bCcWA/Mh4nNjbGpRXFgB5o0ri5cAf2N+4nJVNcX7uujEf42TUEQoi3CiFGhRBjQojfz3P/fwohzmZ+rgkh1rfcS225993deB/D6DgG/ikSG4tcmt0w7K0BHOqqY34jysJGhOjVqzj26ffgVTj27ye1ukpibo7R1VH2NhqXta9xH4FEgJlApi1wh/50VRbth5XW1StjmYV143wd7KwlnkxzfSFI9PJlHAeNDSxQJjaSSWKj1xhdG2WkYaT0hwpgX8M+0jLNtbVrinfacVQpbzSC9gzXc+c5N60UIpRqZFgIW9cJopcu49i/v2Qjw0JQK42ily4xujbKcN0wFpMxp2Vfo1JNdXn1ssJX64HSjQwLQdXNubOcm15nT6u+Cr6tUHXz/Iyf6OUrSgVftTEHaBtfq6N0VndSazem+ypfV1avKHzVdOqv4NsFlG0IhBBm4HPAg8B+4GEhxLYaNinlb0spj0gpjwCfBbaewxhR70kp31Hu+5SFzDrBwujLxJJpDhj0PmBT8a6+Nko6GMS+twxDcEChc/7VF9mIbzBSX8bEpire7EsQXlFOaTOKzEANTLzCwkaMA0XadJeCumh6acxHYmYGx0gZfGWMSODCWSY3Jg2l0VRk+Vq6oFRIFTpURQsyhiDle41rCwEOaGwrkQ8HMobg4vQa0evXy9OvfftACKKXLnF19Sp7GvYYlrWnfg9mYVbSafMXy+OreZ9y3OfsWS7PbWhuw5EPA83VOG1mLvj8xK5exbHX+Biy9fZicrmIZAznnnrjfHW4Oqix1SiVaQsXobUMvsrAbkQENwNjUkqPlDIOfAUocloHDwMaD+18nZFRWv+kksfd22Zc8fa3KwvGvtPKYpdjn/EzRx1794LJxOJryoakcjzc4bphLMLCFV9mc1Orcc+bphGwVBHwKLlgvfXwW9Hb4MRttzD7qpK/tY8YH1zWzk5MtbUsnT1JWqbLMpytzlYaHA1cmTuplH+Ww1d1M9R0EvKeIZGSZfFVW2Wlr9GJ9+J1ZDiMowy+TC4Xtv5+1s+/RiAeKIsvh8VBf20/VxbPQni5vInNYoPWA8RnXmMpEGN/GXyZM+tQ1zxzJHw+7HuMf0dhMuHYv5/IpUt4N7xljUchBPsa93Fl5bLiaJSjX2VgNwxBJ7C1a9VM5loOhBC9QD/w9JbLDiHEaSHEy0KIgscXCSE+knnu9NJS4f7iZaGqXgnNFi5hMQkGDSwUq3DZLfQ2OElcHQWTCfvwsGFZpqoq7IMDRDNHV5bjgdjMNobqh7iiVsKUo3hmi/L5BWWBcW97gSMuNcBkEoy0uYmPKvsSHGV4uEplx77sUZ/lTGxCiMy6ispXmR5b+2HEfPl8geKoJK4pfNnLiKBASXdk+SpjYoPMgrG6wL4rfF0AZFmOGSh8xa8pfbvsZUQEoPAVvXoVmUqVpV+gFCRcX7tOIp0sL4IqA6/3YvH7ga9LKbe2muyVUt4I/DzwF0KIvKtUUsrPSylvlFLe2NxcugWtYbTsp8Z/jcHmamyW8ugZaXPjmBrH1t+ve6PPTtiH92DzztNV3YXLamyBMfte9SNcjSwoRk/vRp+daN1P7cZ1mlw2mqoN5oLV92pzY5/yYKqpwdKmsRNqATj27MHqncdlrqLTndcv0f5eDSOMRRdJWBzlb/Rp2Y8r4MVlTjLQZNzRAIUvl28i42jor0jbCvuePZiX1qiKyrIcDYC9DXtZSmywYjKV7+G2HMAaX6eZdUbayjOcI21uWpcVn9UxUt7kbd+zBxFP0LpenqMBCl8JmcRjtf5Mp4Z8wNYyiq7MtXx4PzvSQlJKX+a/HuBZ4OguvJNxtB6gLTHFvlZ9bRLyYaSthrbFKaxlhKEq7HuGca9EOOgsf8fhcP0wKzLBekt5XiSgTGwpPydaCx+fqBV729x0rfoQQ8O6N+fshH14GEs8xU2yr+RBIaUwVDdEEslUy7D+HcU70bIPEynubFgv29HY2+am3z+H7OreBUdDMSTHQ81lOxpDdYqs8br28h2NFiWlerNzvuQJbqUw0uamf2OOdLW7bEfDvkeJ8IdWbWU7GkP1Gb6qnK/7jmIVu2EIXgGGhRD9QggbymSfU/0jhNgL1AMvbblWL4SwZ/6/CbgdyG1C/joi3DCClSQnagqfmaoV+1zQElkn0NlX/ov1Kz13Doe0N3QrhEG3ImusvvBh6VqRalKMyW3uhbJl7Wl20bcxx0Z7b9mybJk9G0cC+vrS5MNQrTI4d4MvWpSF/9vcxc+21oI9bW76/bNstPeVLcs+rEQBR4Ll65dqCK7XFz8uUxMyhmBX9KvVzYBf0a+yHY1BRSeOBBvKdjT6avowA2O1reU7GgZRtiGQUiaBjwE/BK4Aj0gpLwkhPi2E2FoF9H7gK3L7iS37gNNCiHPAM8B/kVL+VA3BhFAmoRushYIa7RiMKGsZM7swgcy2KgoyuFK+ogyllUEwVlWe5wcwZekD4KCl8KHeWjGU3KAqFcfXUH4f9tV25bsN7AJf/ZZqTFLuCl9+Zy8JaeagpXz96rZL2sOrTDeU55ECJJpridhgYLV8vpqsbmpTacYd5aW+AFJVjSzJWg7sAl81djP9gbld4UtUVbFYb6J/pfyjJG1mG73JNGOO8vXLKHbF/EgpHwMe23HtT3b8+0/zfO5FoIz6xd3H2Wgre6SZnuRk2bIal2ZYBK7YGnmgTFnjVQH6rNA0Fyn7vVrX56hOpxkT5adzLvlt1Eg33bvAl3VqHIDLjuaiZWda4EnMIWt3hy/H8nW6k0nGSZYt6+pSlDrZTnfKW7as5JjStfKyo/w1s8mgl+km6JkLl364BMTKdQYTccZEntPw9L7XSoi5dBf7k+XzlZiZwZGMc9lR+vzxUlgML+JtkhzaBf0iuMhgLMpoVfn6ZRSVncU7cGUxwqTooHp9tGxZyYkJ4hYrr8bLy98CTAS8+JpM2LxzZcsSy9cYiicZi5ZffTW6EGRUdlMXHCv9cAnEPR4ATkrj+xFUTPgnmGoWOKbKTymwfI2heILrsfLThaMLAYWvwG7wpRjOU9JY24Wt8Kx7mG4WOKbKT1mxNMpwPMFYbCX/GcY6MDofYFT2UBcaz3uGsR7ExhW+zoh6EqnyZHn8HqaawT67SjoeL/2BYlgaZTgeZzqxQSS5C4bFACqGYAdG5wMsOAYQi1dKP1wCsfFx/M1djC4ESz9cAh6/h/VON7Gx8icQlq8xZKpizD9e9kAdXwoyb+/HtHQ175nPehAb9xCua+LyenLb2QRG4PF7WGqvIjk5hdyFgTqUNjMV8hFLxcoSNb4YZNLUi2VjCmLl6UVs3EPKauOKdLEWKu87TvgnmGk2wZqf5EqZBi/jaASSYRbD5RmW8cUgo7ILUzKidMotA6qjMeFsYnI5VOLp4vD4FcMpUiniE5NlyWJ5lKF4AonE4/eUJ8sgKoZgC6SUXFsIEq0dUg7FiJcXJsfGx0l397KwEcMfKS9M9vg9JPs6SC0tbztExBCWrzFU1Yo/5mclWt6gH1sMEqwZVo67XJ8qS1bc4yHd1UM8mca7Wh73nnUPib52pdXE5GRZsli+zlBVC2mZZtJfnqyxpSCB2syekqWrxR8ugbjHQ7qzm7QwcW0hUJYsj99DrFdpbRC7dq3E0yWwfI1Bu1IttO3QFQMYWwqy5sqUxuY5zF4PYh4Psr6BoM3JtTKdswn/BKsdyhpI2XwtXWMQpUfX+Pp4ebIMomIItmAlFMcfSWBu2QNIpUGYQaSCIZJzczgy1SueJeOKF01GmQnM4MhsSouXExWkErDqYahekXV97bphUclUmsnlcLaygyXj6TSZThObmMAxpFRjeJaMe2xSSsb94ziGMnyNlzm4lkezJX7X143zBTC+GEKoZbtlGoKYx0NVpnrFU6aHO74+jj3DV2ysTL6WrmUrh8o1BONLQWjOlF+XazjHPVv0qzxDML4+TlX/IJjNxMbLjNKXR+mpG8BqsjK2tgsRvwFUDMEWqJNPdWemVdKycUsfn1BCvMYDe7bJNgLvhheJpHFEaRcd23JMnm6seiCdZLBV2a5RTig6sxYhnkpT053ha6UMozI/jwyHadyvDPpyBupKdIVAPEDTHqU1cFl8hVchtERvy2HMwoxn3ThfwViS+Y0odR1DSlfOZeN8paNREjMz1O4dxm4xlcVXIpVgOjBNe89eTNXV245h1P9iKVgZo75lPw2OhrL0K52WjC+G6GprUQ6zXzY+SUopM4ZzgI5aR9mG0+P30Nc4hK2raxdSQ9exNO2lr7avkhr6/wPGM4OpfeAAIMoaqOrCVMfh/VhMIivbCFTl6Bk+hrDby1O8jNfe2H6Uamt1WakO9Tt1d3Yr7TnK4kv5jrV7h2mqtpfHV2ay7m8dwdLRXh5fGWfA2rKfLncXkxvGZamT9WBrHTQMwIrxiS0+OQlS4hgapL/JxXgZjsZUYIqUTDFQN4itv5/4ZBmGYG1SObynaYS+mr6y9Gt+I0okkVJavTQOleVopJaXSW9sYB8YZLCluiz98sf8rEZXGVT5KsdwxgKw4YPmPQpfZehXOagYgi3wLAWxW0x0NDVAXU95EcH4OFitOPt66Wl0lhURePweTMJEf90Att7e8hQv851EU/mKN5Y5Y3iouRoah8ub2DIRlH1ggIFmV9l8AQzUDmDvK3OgqjrQNLxrfA02V0PTcFmGU134tA0MMNhcXVZEkOWrbgBbfx+xsgxn5js17aG/tn/3+TJYkBDzKDpgGxxgoEnRL6OFEipf/bX9iiHwepEpg6XYWf1SxuNMYIZEqvyyW72oGIItGF8K0d/kUnrEN+0pyxDExsax9/UiLBYGm8vzQDzrHrqqu7CZbdj6+4lNlBE+Ll+Dmi6wV9Nb24t3w3glxvhSkKZqO7VOa2aglsHXuAdTbS3mxsby+fJ7cFldtDpblYHq8RivjloaVc7Oreult6aXqY0p0tJYRdP4UhCLSdDb6FQ83FUPpIzVjsfGPWAyYevrY7DZxdRqmFjS2GSUjaBq+rH395OcmyMdNrhYv5xZJ2reQ29NL6vRVfwxvyFRqg4MtWQcjei6cs62AailtvZBJSIIxpIsBoxVgKl8DdQqhlPGYiTmDJZ1L6mGYIS+2j5SMsVMcMaYrDJQMQRb4FkKMtiS2Q3ZtEfJSRqsXY55xrENKAtTg83VeFfChksiPX4PA7XK6VO2gX4SMz7jJZFLo9CsrFv01fQxF5ozXLs8vhRisDmzG7JpGIILEN0o/qECiI+PYx8YQAjBYLOLtXCCVYMlkR6/h/6afoQQ2Ab6SYfDJBcN7plYvqZ8N5OZvto+YqmYcvqWAYwvhuhpdGI1mxT9SicMl0TGPONYu7ow2e0MtlSTljC1Ymzy9vg9tLvacVqd2PoVPYsbrbRauqac4lZVT19NH4BhZ2N8KUiNw0JTtU3hCwynh2LjHkxOJ5bW1mxXYaPOhsfvwWF20FHdgT1zKpzhqHN5FEwWaOjP8lVuZZoRVAxBBrFkiqnVMINNWya2ZAQ29FtnGY+TmJ7BNtAPwECzi3gqzcya/gk3mU7i3fDSX6fIsvf3QypFfHq6xCfzIJ1WwusmZUG2r7YPgKkN/WWfUkrGFrcYzsZMSaTRgerxYBtUBpU6UI2mOzzrHgbqFFn2foU3wwN1aTQ7CZU7UMeWgptnYDdl+DKYHoqPe7KTkNrFtJyJLetoZPgyvMC+PJqt8lH1y2h6SNUvIQQ0ZUpIjfLlGceWcTQGMs6L0XWVcf84fbVKM0Nbufq1fF1pNGe2ls1XOagYggy8K2HSku0RARhKd8RnfJBOY+tV+haV44HMBedIpBP01ygKV5biBWaVoyUzk5Aqc2JDvyy11DZ3YtO/TpBaXye1uoq9f7shMMJXKBFiKbJEf+0OvowsgCYiyt6IjC6oMo3wlUil8a6EthjOzMRmwHDKVIr45GT2jOJyJjYppeJoqHz19oAQxhbYpdyMoIAudxcWYTFsOMeXQpv6VdutpOgMOxoT2DOORluNA6fNzPiiMcPp9XuzY8fc0ICppsa44VwazfJVY6uhwdFQMQQ/TajeZ7ZHfNYQ6J/Y4t5JgC2GwJX5HfoH6lRA8dZ7axRZZXls6mJuRvF6apQupEYGqjqIshNbfT8Is6GBqqYh1O/WWV+FzWIyxNd0QImUejIdVi2trYiqKmOGc3UCkFm+Gh2NhiutplfDJFJy87AjZwM4Gw15uIm5eWQ8jq2/D1AOQWqrcRgynMuRZSLJSFYXTA4H1o4OY3yFVyDqz0aHVpPVcKWVP5JgKRDb1C+TGRoHDY3HdDhMcn4eW18fQDYqMFJCmkglmA3NZvkSQmDr7zNmOFNJWJvYdKKg7Eoro6gYggxUb0r1rnA1gaNuc/FLB+JeJSeqKl6d00ajy2ZooKr5VVXxzNXVmJubiHuMTGyZReZMz/MqSxVtrjZDOdyJzCAaUFNpFhvU9xqLoKYUY2frU4yd2STob3TtCl8is6AaK4svxZMUQtBbY2yBXeWrv2lLh8lGY5VDiamMfvVutusebDFWQprlK2M4AeMFCSpfjZs99Xtreg0Zgsm8fA0Z069pJb27ja/makMRgS/oIy3TWf0ClMo0jwG+/NPK8adbziDoq/3plJBWDEEG40tB2mocuOyZhqxCZGqX9e+yjHu9mGpqMNdtNgMbaDY2sU0FpnBanDQ6NvvEGy6JXPWAxaFszsnAqAcyuRLGahZ01G05wKdx2GAENQVCYO3abD+t8GUggsqsd2yd2Oz9fcb5Amjoz14yOlAnMwu52ya2JmO18VnDuWViG2hSSkj1VkepEefWiU3ZS+DVX2m1w3CCol9GKq0mV/IYgqZhZZ9CUl8RQTxjOK092/ma9UeIxPVVWmX52mE4k4uLpII69bUAX6vRVTbixooujKJiCDKYWA5tVzpQ/kCrBvLBXi+2np5th18MNFUzsay/qmNqY4qemu2yDG9iWZ1QUjimzT+7Whuvd9B7V0J0Nzgxm7Yc8NE0rLTl0FlpFZ+awtrejslmy14baHYxvaq/0moqMEVTVRNOqzN7zdbXT8LnIx3TWS646oGqBmWzXAZGK628KyHcDgv1TuvmxcZhCC1BZF2XrLh3CuFwYNlyZOtAs4tANMmKzkqrqY0pLMJCu2vTObD19yHDYZILOju3rnpAmJQ9OBmolVZzIX3lld6M4exp2Pw70jgMMqUYAx1IqIazZ/MgxYFmF1KCd1Xf5J11NHYYTjBQaVXAEMDrXzlUMQQZTK2E6Wtybr/YMKCEb0l9E0h80rvNWwPoaXSyHIwRiumrG58KTG3zPkBRvJTfT2pd3wTCqmeb0oEyUIOJoO7mc96VML0NO/hqHIJkVNkpqQPxKS/W3u3fsbfBRTItmV2P6pI1tZGfL6QkobfSqgBf6u/Rg8mVML2Nzu0nY6m5YZ09reJTU9i6uxFbDHpvo/K38OosIZ0KTCmLuqbNo0mylVaTOlNgqx6o7QLL5pGSRie2yZUQbTUOHNYtB78Y5cs7hbm+HnNNTfaaUb68G17cVjf19k3nQF2rUdcGNWN1AixV4N48NvOnVTm0K4ZACPFWIcSoEGJMCPH7ee7/shBiSQhxNvPzoS33PiCEuJ75+cBuvI9eBKIJVkJxehp2RgT9gIQ17QMindlcstMQ9DUqsvUoXjKdxBfwZReKVaieja4S0nRaUbwtaQ7AUK23lBLvSojexnx8oSyA6UDCO4WtZ/t3VAeqmiLQCu+GtzBfU3oNwUSuITBYGz+Vj6/6/s3fowOJfIYzq1/6+drq3QJYu5V/x6d1lhUXMZz6+QpndSALg3zFp6aw9eQ6GqCfr6lAngi9W9Evw47GFlld7i7MwlzWRk8jKNsQCCHMwOeAB4H9wMNCiP15Hv2qlPJI5ufvM59tAD4FnABuBj4lhCj/kFmdUCfnvp2Kpyq1joktMTMDUmYXPlWoSj2lIxSdC86RlEm63d3brlszihf36hiogTllX8SOgarKVqtttGA5GCcUT+XylR2o2hfO1MgmZ6CqE5uOdtShRIiV6EruxJaRreaKNSERVaLBXeArkdlDkstXn/JfHRObTKeJT03nGM6u+iqE0OdoSCmZDkznRFDW9jawWrMpFc1YGc/hq9HRSJWlShdfoERQfTsNp7MB7DW69AuUNbudhrPWaaXeadUfQeWJOE1VVViam/WNR8gYgu2OmdVkpc3VppuvcrEbEcHNwJiU0iOljANfAc0nDT4APCGlXJVSrgFPAG/dhXfShanMZNNTyBDoULxsxVCe1BBsLhpqgTegyMrxcLMeiA7Fy1PRAdBe3Y5ZmHUpnupF9e5cU6ntUrpq6pjYdlYMqWhx23FYTXh1lPjlWygGMNfVYXK7SeiJCNa9gMzhy2V10eBo0MXX7HqEZFrmRgQ2p7Jwr8PRSC4sIGOxHP2yW8x01Fbp8nCXIkvbSkdVCLMZW2envggqvKq0gGjYzpcQgi53FzMB7Rszg7Eky8EYvTtTtUIoE6cOvtLRKMk8ETpAT6NLlyHYWTq6FdbeHn0RVDqlfI8d+gWKs6GHr93AbhiCTmCrxsxkru3Eu4UQ54UQXxdCqC6u1s8ihPiIEOK0EOL00lL5RyxuhZp+yBmozkbdHoiaV92peDUOK40umy7F21kKqcJUVYWlpUWfB5JnYQq2eCAb2gf9ZDaC2sGXyayUkOoynOpC3o7vaBL0Nrh2xXAKIbB1d+tLpRXgC5TwXY8hKMgXKFGUEb56cyejvianPr4y+tXrzp0krT3dWSOtCarxz8NXd3W3IUejMF86I3TIiaAU+U5dqceZ4Axpmc7RLwBbdw8JPeNxYxZS8fx8ubuz1UmvF16vxeLvAX1SyhtQvP7/rVeAlPLzUsobpZQ3Nm+pltgNTK2Eaaq2UW23bL+heiA6IwJzbe220lEVPY1OXR7bdGA6p3RUhbXHwMRmtkFNrp3tdusbqFMrIcwmQefW0lEV9fo8tmxpX3d3zr2eRqeuVJpqzHam0kBJD+lKDRUxBHr52pzYnLk3G/RNbOp32Gk4AXoaXNnoVgvU79Bdk8uXrbuHxNSU9moyDXxpLSFVnaWcNQJQ+Fr3am7Wt1lqm8tXb6OL2fUI8aS298rylUe/bD3dJJeWSEc0VpOV4Msf87+uJaS7YQh8wFZmujLXspBSrkgp1dKbvweOa/3s6wHvSnh7mdpWNAzoNgTWvlyPARQPR29E0FvTu73SJANbT6++HO6qR8lJm8w5t7rd3UwH9Xm4nXXK7t8cNAzA6qTmdsEJ7xSWtjZMDkfOvb5Gp9L6I61NlnfDS3NV87bSURW2nh4SvllkUmPV1qoHHLXbSkdVdLu7mQ/NE09pK9WcXA5TZTXT7Lbn3mzoh+A8xLUZvMTUFMJmw9LWlnOvr9HJaqb1hxZ4N7xYTNtLR1XYentIh0KktB6LuuoBxOa6xxZ0u7uJp+Oazy8uGKGDol/ppOYeYIUiToDeBidpCTNr2sZkNoLKExFk16G0OmclDAHoW4cqF7thCF4BhoUQ/UIIG/B+4LtbHxBCbNW0dwDqyfA/BO4XQtRnFonvz1x7XZG3AkZFfb/Sb0Zjj/C4N7d0VEVPg5NZf0Rzu+DpwHRe7wO2eCBa2wXnqYDJvpe7R5cHovBVyHD2QzyguV1wvoqO7Hs1uogl0ywEtJWQluKLZJLEvMbOoXkqOrLv5e5BIvEFtfksKl/5DHp2gV1jbXzcO4V1R+moimxBgkZnYzowTVf19tJRFZsFCRqjqFWPEm1acw26GnFondi8y2Gaqu25ETrorhyKT3mV9uZ5InS1XFyrcza1MYXb6qbOnitL1WHNztmqR+md5O7IufUzaQiklEngYygT+BXgESnlJSHEp4UQ78g89nEhxCUhxDng48AvZz67CvwnFGPyCvDpzLXXDdFEirmNaJGJLeOB+Ev/UdKxmLIwlScfCYriSQnTq6XDx0KloypsWQ9Eg2ckZd7SPhV6FW8yX2mfCp2VVvGpqbxhO2ymUrQO1HyloyqyHpueiW3X+CpmONWCBB18FTCcm5VW2qKLfKWjKlRnRnNJZJ4KGBUqX1oXQLXxpS1KV0qTS/ClMV2br3RURXY8al1gV/nKY9D18rUb2JU1AinlY1LKPVLKQSnl/5259idSyu9m/v8PpJQHpJSHpZT3SCmvbvnsP0ophzI//7Qb76MHM2thpCyQjwRdAzXhUzzErTsYt0Ldp6Al7z0bnM1bOqpCrfXWVDkUXFS6jhaY2LrcSmsHLRPbelhJPeRdyANdHlsqGCS1spKdpHdCT613odJRFVmPTcvElowrUeAu8JVKS6ZXI4X50rH3QkpZPIJq0G44C5WOqrB2dSldSHVNbPn5ane1YxEWzYZzarWIo+FuVzxpPY5GAb4aXTZcNrPmBXbvhrcgX+baWky1tdorh4rw5bQq64I/UxHBzzo2F6YKDVTtHohqCKydeQufsh7upIZWE+opRUVTHWjcS5CnZ85WZD1cDZVDJfmq7wWENr6yW//ze/EddQ4sJqFpYlO9J3WS3glLSwvCZtM2sfmnQaYLDlQ9tfHzG1HiqXRhXDOjXQAAIABJREFUvqrqleaGGvhKLi0hI5GcmngVLruFZrddk+Fcia4QSUYK8mXKrENoWmCP+iG8XJAvi8lCe3W7Jr6iiRRz/mhhw2kyKesQGhwNGY+TmJ0tGHEKIeht1LbAnkwnmQ/NF+QLlLJuTZVD2c2d+fmCTOWQgXNCjKJiCNSJrdBisbtN2QauIyIoZAgaXDbcdosmxZsNzgLQWZ1flrm2FrNWD0Tdkr8LHshksQoYUNoL1HZp8tg291zkH6gWs4nuBqcmQ5Dly5WfL2EyZUoiNUxsK8X5EkJorhxS90EU5Ev9PVr0S+WrgOFUf48WD7eUfim/p0fb3osiC58qtPKljo2CEYH6ezTwpZ4LUijiVH+PlhLSxfAiKZkqyZemxeLgfGZzZ37HDPRXppWLiiFYCVFtt9DgsuV/QAjNlUMJnw+sViwtLQVECXo0Kt5scBaLsNDizC8LlLy3psWpVY9yHF5t4QGheWJbCSMEdBcynJDx2ErzVayiQ0VPg0a+QpmJzV1koHbrndhyN/uo0MqXOinnbL7bCo0lyoU2321FT4NLU0SgzRBo3EtQYLPiVmjma7nIHgIVDf3K4nqJyrR4nnbdO9HbqDQ3TJWoTFMLA4rpl7Wnm8TsLDJRorBEo34thheJpYydq6wXFUOwmqcZ2E5o3M0Yn5nB2tGet6JDRV+jS1NVhy/oo83VhjlPuacKW3e3tlTH2mTmhKc8VRgZaJ/YQrTvbAa2Expr4+Mz05ibmjA5CxuVvkYnUyvhkvXsvqCPKkvVtmZgO2Hr6SY+M1O6Nn5tEqwu5UyKAuh2d+ML+ErWxntXQtgsJtprcqtpsqjvB/9Mycq0+PQ0mM1Y85SOquhrdLKwESvZXlmd2Dqqc6tWVFi7e0itrpZur6xWPOUpHVXR7e5mI75R8iB7b7HNdyrq+5U1r2DxctSEeg5Bnj0qKvoanSRSkjl/8QKOUhGn8nt6IJUiMTtbVJYWvrrcXUplWuD1qaavGIJiFTAq6nqVxcMSE0jCN4utQFpIRU+jk+k1bR5IMW8NlG3tidnZ0gfZr3kzufvC6K7R5oFMrYRzW3HsRMOAkjMucZB9YsangS8XgViy5EH2voCPDldHUYNu7elBhsOklkuUtq5n+CoiS2ttvHclTHd9FSZTMUdjQGmvvF7c+07M+LC2tyMshQ26+rcplX70BX3U2etwWQtPuJsL7CWigjUvOJvAVliW1koY72qI2iortVvbde+Exsq0xMwMwuHA3Ji7IVNFj8bKNF/Qh0DQ5ipshNUUZ0nnbM2rtOuuLbzeoBY9vF7poTe0IUilJTNr4dyuoztR3wuJsNI7vggSPl/B9QEV3fWKB7KwUbw2fjY4W9Rbg4wHkk6X9kDWp7b1iM/7Xu5uTR7IzFqE7voShqBeWyWMNr6qsr+3GGZDGvjKlviVmNg08gWlB+rMerh4Gg02c8UloihNfGV+V6lNUpr0S2tBwm7ytRahuyHPjvWtyPJVPJ2WmFX4KuYcqLpcii9f0EeLswWrubCBynZtLbUOtT6l7LkoIuv13kvwhjYEs+sREimpISLIKHmRdtTpSEQphewsbOWBrJJPF/HYYqkYS5GlkgPV2qVMCnFfkck7EYHQouaBWqzHSSyZYiEQpaukIchEH0U8XJlKkZib0zyxTWsYqCX5yvxtEsX4klLXxFaqsmNmLUJXfYmJrU7lq/gEotXRgOL6BRojzi4NfIEmvtRqm1I9dGbWInTVldCv2i5AlIyg4j4f1s7iOtFe68BsEiX39swGZ0vyZWluQthsJHzlO2b19npcVtfr1nPoDW0I1MmlYHsJFRoGquqVax6oRTzcuaBymlMpxbOpA3WmyEBdz3gUdcVTQ+rvKrZbdm49ipRon9iKGM7k4iIkkyX5Un9XsYG6Ed8gEA/QVV3cCKuTQnymSHoiug6xjZIDtc3VhlmYi/IViCZYDydKG053u9K1tYh+peNxkouLJSe2pmobDqupqH5JKZkLzZXUL3NNDaaaGhK+Inyl00q5bQm+qixVNDoas7n2Qu81sxYurV8WO9R0lDwnJOGbLalfFrOJjjpHSUdDiyEQJhPWzs5so7uC0GAIhBB0VncW5Ws38YY2BGq6ofTEpkYEkwUfUf/4pRSvvc6BEMU9Ni0VHQCW1lawWIp7bKrXVELxGh2NOMyOooqnma+qerC5i3pspUptVbgdVuqc1qIDVTWcpSICk92Opbl5V/iymCy0udqKGgLfuka+TCao6y7KV1KjoyGEoKveWVS/VqIrxFKxknypv69oxBlcULpoluALlIobdX9M3vcKxYkm0qX5AuX3FeErFQiQ9vtLrkEBdNUV5yuZTrIQXtDMV1H9SsYhMKuNr+pOzW1MysUb3hAIAe21JRTPXq0shhXx2OIaJza7xUxbTXEPRB0spRRPmM1Y29uLeyDqO5eICIQQdFR3FFU8NY/aVSqCEkJJDxWLoFS+ukoP1O56Z9E1ApWvUoZT+X1dJSIo1RAU5wuUv09Rw7mqGoISfKm/r4iHq+qXGgUWQ3d9VXG+Atr5snV1auOrSAWMik5XcQ9309HQyJeWCF0LXw1VRSOo+dB8yT0EKqxdJSKCDZ+yWVGDfqmGQO954kbwBjcEYdpqHPm7aO5EfW9JD1fYbFiaC5ccqig1sc0GZ7GYLDRXlW63XdIDWZ9S2k9Xt5aUVSoUnVmLYDEJWvN10dyJEh5b1nB2lPayuhuqmNEQQWn22IoaTm0RAZT22LKGcxc8XK0RFCjrKsUcjSxfLg18dSj6VXAy0sOXu5O50BypdP7S1k1HQyNfG76CJbe6+Kp3shSIEU3kfy+9+pXy+0kFg/kf0KlfkWSE9ZjOs8kN4A1uCDRUwKgo4bElfLNYOzqK7iFQ0aVhYmt3tRfdQ6DC2lUidF+fUvYQaHivjuqOoqH7zFqY9joHFrMGtVH5KjCBJHw+LM3NmOyljYpqOAu1o54NzlJlqcrbFXInrF2dJObnC7ejXp9S0lp52k/vREd1B0uRpYIltzNrERxWE42FNituRX2vUnIbyz+BJHyzYLEU3Ky4Fd31TgLRJP5w/klS3XynaWLr6kJGo6RWVvI/oHrltYVr9VV0VHeQTCdZiuSvvlOdo7znXOxEfa/iWfvz66saxWg1nFt//05o2XOhwlZqgV2HIVB/3+uRHipckPwGgG8twon+Bm0P1/fCle8pR8zlmaATMzOalA6UgfqtDR/xZDpvNOILla6AUWHr6iK1vEw6EsFUlWcAaViYUtFV3UUgHmAjvkGNrSbnvqaKDhX1vcqmn/BK3o1ZWhbysu/V4CSeSrMYiPH/sffuUY5c1b3/55RU6pb6/Zrpbql7ZswYv8aewYw9PGwTwGBDEpPgYDBhgYPj/AK55OZlIHFucq+TOCZZuTELHB6Ob2ICAcLjYgIYwjOQEDAmmGCPDW3PTHdL3dMz02+11K1S1fn9UXVKr5JUDw03WcN3rVnTLamPSlt1zt77nO937/GBRmGWYsC0FAU6SGQytujn5BIJr20pZS8fY6nD6YX8AvsGGssF2IyhNmJFhcEqptXuxpbfRs7REMTaBwcuM221wEBqoOH5XD7HcPewZ9+GeqitOyObJT7qke2uzUHPmN12sw3U1kp2M8t4zziGYZDNZtnetqnUB3tL/J9XTJA9/lTbsYhfAtf9A+TWYOmJhqfNZ56P9Vf3MrO0BEtLLYfaF7e474YJNk+e4InlRvumS2nuufgeNuc3eUI0vlc15OQk5XvfzdOFAtoTHq8V58N1H4PFLTjZeqxRa5R7Lr6H0mKJJ063fm09uru7yWQy6HoLPUYVzllHYJgWi+s+qH0Kg3vAMuwWc4ON0Y+Ry9F9ceME9kJmKImUNn11r0fpgYX8Ai/IvMDXWGoxNRYW6HqGh2R9bQ4ueJmvsZTzWcgv0D/s7QiuPr/91hdQcT5rs00cQY7kZZf5GirjagkKno7AD6NDwbVXLtfaEfhAtb08HcGaDwaMgh9H4NdxVnHjD6QbHcFCfsHXthBU7FXK5UgeOtT4ggD2Ut+Rykiy2Sx9fX3s3bsXIQTHz2xRNi3O393XfrDyDpzCzkQ87q/S3BzWzg7d55/fdijDtBCLG6QHk4z0Nmaouc0cW8YWzxx+ZtuxZLnM9pNPoo+PezvO1Vko9Xl+x/UwLZMnV55kd89uRpM+5x02+2p5eZlsNsu+fc3rGVXjnN0aOrm+jSV9HkxBFTe+cXtIdXLyczAFrbnx2+VtzhTP+M4IXG681763Tw2Bgqqj4pWK+tYQKLSgkPrVEChUKLeN9pJS+tIQKLjceC97+dQQKLSj3PrSECi0uL9AOQJ/n7GiJWi+1eE741SOs9mBcQB7TfRMIBCuaHF7e5uRkRE3Y2qWIXsi5my3NekSJ0slRMLHlhwQ1wRCCEqmd7mQklVqKSSrva4YaFrzekPmTuXa2w2lxYhpMd+d8BSEEIyMjLiZlh90xBEIIa4XQvxQCPGUEOLtHs//lhDiqNO8/stCiD1Vz5lCiEedf5+u/9uzhfkgB3nQcmGraAh8TtTh5hM1yP6t/Z4tRGUBGDBQqaPipS72rSFQcDOCxgNQvxoChVZago3SBnkj7z8jGB8HTfPmxvvUECiMJceIa3FPR+BbQ6DQM2ZXufWwl7Wz42gI/H3GgZROX3fc03Fa0gqUQWk9PcSGhrz3vH1qCBQSsQRjqbEaeyknIKXEMC10P+dP9h/aC2ozR2AYaD63RYQQJGJa097FhmmQ0Pwt3kIINF1Hlpo4gnLJtyMA0DUdw/LXHbH+OoIgsiMQQsSAe4GXARcDNwsh6vOe7wGHneb1Hwf+rOq5opTykPPvBn5MCERVA+cwTHhGbEqg5IezDDDeb9fZ95K1+9UQKLhqRq+ILcDBFMBA1wCpeMp1RtUI7Di7++0DVw97BWF0AHTrMXb1dXlyvYMwOgCErhMf3+29sAW0V0yLMdnjTbn1rSFwL0zY7+uhVVGBht/7C+yswMteZ4pnMCzDt71AUW49HGcADYFCM6ZV2ZJYUvrPCMBeUMuNjkCaJtI0ET4cQSwW49ChQ9zwwiP86i2vo1AocOLECQ4cOADYjtOwDP8ZASASCaTh4aCkZW8v1zmCz3/+81xwwQXs37+fu+++u+a5hJYInBGEQScygiuBp6SUx6SUJeAjwCuqXyCl/KqUUt2V38JuUv//FNmVAprAc8/ZE/FEUzWjkpT7XdhimmBy0Ju7HITaB46acXKyycKmNAT+JqoQgnRf2jMjcB1nOw1BNZpQIiuOwP9ilBlKeka4QR0nQGIybdeqr0dARwDNtQSBNAQKTe0V7P6y37f1/RXEXk0pygEzTvW+XvYynG2ZhN+MAJpmBGpbxs/WUDKZ5NFHH+Ur33yEmK7z3ve+t+b5smWzy3QtgCPQdWSp1Ei5VVTXeOW6TNPk137t13jooYc4evQoH/7whzl69Kj7vB6zM4KzrSXohCNIA9WVkbLOY81wK/BQ1e/dQohHhBDfEkL8XLM/EkL8ivO6R06fbl38zQ+yq0X/GgKFJiIWI5dDdHUR8zocaoKp4aRnxJbL59A1nbFUew2BQtOILYCGQCHdkya35eUICv41BApNKLdBNAQKU8Pe2gu3TnyQhS2T6UhGoN7XK8INpCFQaCLCC5pBgbJXY/nuMPZKZNJ2lVurbuskpOM8WTjZsN2htmX0IPMx3mVH2HXXparx+skIFPS4xqErnsPMzAxgL9C33XYbBy89yG2vug3TKet93333ccUVV3Dw4EFuvPFGCgX7e/7Yxz7GgQMHOHjwIC+68UakZWGWStx+++1cccUVXHbZZbxPOZmqjODhhx9m//79nHfeeSQSCV7zmtfw4IMPVq5L05FSUpZN6M4dwo+VNSSEeB1wGKimxOyRUuaEEOcBXxFC/EBK+XT930op3w+8H+Dw4cOR3aOi9gXC0B449s8NDytGR5B9uamhFF96opHWpg7yNOF/QuiZNNuPPdb4RAANgUK6L83DJx9GSlnzebKrRf8aAoWhPTDzT/YhbNVYRta/hkBhaijFZ/5jkbJp1VxDLp+jR+/xpLs2g57JUF5awiqV0KqjxtVZ3xoChXRvmpXtFQpGoYaOGUhDoDC4x277WFyDZEUTYeRyvjUEClNDSbYNizP5EmNVzls5goneCd9j6ZkM0jAonz6NvrsqqFg7Yf/vQ0OgkOnNYEmLpa3ae//uh57ksdw6PV0BliSrDOVt0P/NLuvsQBoGslTiwDMkf/iKS30NpUmLf/3ql/i5n/1pAGZmZvjwhz/Mn73rz7j51TfzmU99hltefwuvfOUrue222wD4/d//fe6//37e8pa3cOedd/KFL3yBdDrN8twcbGzw1/fdx8DAAN/5znfY2dnh+c89wksPP4N9uyo757lcjqmqfgmZTIZvf/vb7u8Jx2kYphEoKwmKTmQEOaD6Tsg4j9VACHEtcAdwg5TSVeBIKXPO/8eArwHP6sA1tUV2teBPwViNwT2wuWhT16oQREOgMDWc4ky+RKFU6+mDUPsU9HQac22tsYFIAEaHwmTPJIVyoaGBSCANgcLgHnui5msnfRAqpMLUcBLTkiyu1zIhVDnlIE5YT6dBSrd+j4sAGgIFlxJZt90RSEOg0OSAPYiGQKEZM20hv8Bw9zDJuP9736Xc1medATQECs1EUqYlg5jdhvqD+m0TFXj4CKaKxSKHDh3iRVc/l/F0hte+/hYA9u3bx6FDhyhZJS4+eDHzs/amx2OPPcbVV1/NpZdeyoc+9CEef/xxAJ7//Odzyy23cN9992E5gdcXv/hFPvCBD3Do0CGOHDnC8vIKM8fnAh8WA6EOjIOgExnBd4DzhRD7sB3Aa4DXVr9ACPEs4H3A9VLKU1WPDwEFKeWOEGIUeD61B8lnBaWyxcmNAFRIhaE9gLTVjFVt+Yxcju7L/EUeCmrLILdarOFN5/I5Xjj1wkBjVdSMWWIXXFB5Ym0OLnh5oLFcCulWjsHuSlSaXS1wzfn+t6uAWqZVX6Whh5HLkTx4MNBQ1eWVq+v757ZyLbtGeSFRVb47sXdv5YkwjlNpCbYW2D+03308kIZAoZpCOlHRWIRznBV7XT5dyXD8lJ+uRw1F+dnPrjwRwl7VjrOfShb35hfu968hUDBLsPS4XZa6p3JvBtEQqDOCsmlxdHHDbukKdDnZqmEa6HEd07S3hm655RY+9alPcfDgQf72b/+Wr33tawC8973v5dvf/jaf/exnueKqq/iXD34QaZq8613v4rrrrrPfbPUElLZqAo10Os18VZ/jbDZLuuq7Vo7gbB8YR84IpJRl4L8BXwCeAP5BSvm4EOJOIYRiAf050At8rI4mehHwiBDi+8BXgbullEc5y6hoCEJkBFDD7DDzecz1dV/FwKqR8eDGF8tFVrZXQkzUikjKRclppNOmM1k9XG581YHxTtlkaWMnuOP0iHBluYxx8qRvzYVCRSRVOSeQUtpUyBZ9ZL2ge3HjlYYgoL1Unf36zluBNAQK1aKyKhi5nK/ifNVQZRrqz1WCUEcV3PLd9ecqa3OBDooBdvfsRhNaQymTQBoCBU0HRMOBsazf8vOBmCbQhHAPrRUMy6gp9bK5ucnExASGYfChD33Iffzpp5/myJEj3HnnnYyNjZFbOsVLrrmG97znPRjO4fWPfvRDtrZrdwCuuOIKZmZmOH78OKVSiY985CPccEOFPKm0BP8VMgKklJ8DPlf32B9U/Xxtk7/7JhAslO4AQh3kgafoJwyjA6ob1FQmqt9yyvXwFEmt++tDUI9qtazCwpq9HRN8YVOO4IT7UEVDEOwzTgx2o4lax7lR2mDL2Aq8lRbfvRt0vdZxFlehtBk4wh3pHqEr1lVjr8AaAgVVvrvqgN3a2aF8+nQg6ihAT1eckZ5EDUXZkhYLWwtcu8dzOjaFW7672nFalt3r4qJgjG9d0xlPjdv2cgh7SkPQ1x1wOVJagjoKqTSMln2wvYcSJOKNWoKSWSImKo7gj/7ojzhy5AhjY2McOXKEzc1NAG6//XZmZmaQUvLiF7+Yg5ddymWXP4v5tTUuv/xypJSMDaT41N/fXzN+PB7n3e9+N9dddx2mafLGN76RSy65pOY1Pw4K6TlZYkJFSb4LzimoBiKr1Y7AXx+Ceoz1dtkNRKqYQ0HKKVcjNjSESKVqF7YQjA6A/kQ/fYm+mogttONMpKBnV02EG4YBA6DHNCYGkh2xl2f57pD28irf7btvQ+NgDVVu/TY88kJmOFUTaJwqnKJslQPbCzyYVvmTNmMnoL2Air0ckl0oDYFCvJZCWtEQ+MsI8lVVQhMxjZJp8cy9e3nsscewpEXZKvOW33wLu1L2Qf2b3vQm3vSmNzWM88lPfrLmd7U9ddddd3HXXXfZGoLF70NfI7Pw5S9/OS9/efMtXD2ms132rxIOg3OyxER2NaCGQEGLNTQQCVLlsBpuA5GqiC0Mx1uNlUhP1nLjA2oIqpHpzdREuKE0BAqD0zWO062rH2Jhq68bH1RMVg09PUkpF90RqPf3dgQh7dWBjBNs5pDX/RXOXukmjjNYxgmNlFujHEJDoFCnJXCpo4ngDBuVESjKrdqO8asqrobQdZu9pA6ylYYgwEGxe11a4qxrCc5RR1BkYiDpX85ejTrRj5HLIZJJYsM+q5hWob6ByEJ+gYSWYCQ5EngsPZ1pzAhiXXZEHhCNC1sIDYFCfYTrXGM8gIZAwS5H3ZmFLZHJ1PaWjeAIMr2ZBntBiIwAHK3KnMuECZtBgX1gvLBWxHTKdwcpp1yPhvLdEeyV7k1zunDaXdhUjZ9AGgKFWMKmkTo9Dlwxmc+MoBqJmIYlpWsvw1m8g6iKFUQiYW+fOYfMrrMK4Qj0mKMlsM6eluCcdATzqwXSYSYpNDqCBbsYWNDaHmBHjNWOIIyGQEFFbG7UsDprZy8BNAQKSv2pxgqlIVAYnLZZVs5ENXILxHftCnyYB7a9ljZ22CnbY+XyOfr0Pga6GitstoOeTrvluwH7O+3qh+72PQ3qMdk76fZNhpAaAoXBaSjlobACOOc+uk58LCBjC9sRGabk1Ka9rRBUtV4NPZ12y3cDVRmnfw2BQrovjURiSvt7LLmq4uBzqL74XJSMQDkidT0qIwjD31diNnU9LuU8ZEYAdvG7s4Vz0hGEYnQoDE7bFT1LdtRXygan9ilkhpKsFw02tu0bTnHiw0DPZLDyeax1h/8fgtqnMNk7yba5zfK23YwklIZAobp8N+GokArqO1OH15Hsla5rIBJCQ6BQryWwG7AH1BAouISEE+71BdUQKNQzrRa2FhhNjtIdD7glShVFWW0Prc3Z2aYefB4pR6Q6lRlli5gmiIUIWog7WapyBIZhBz8h7KW2ptRWlTqgDeUInEDHUo4gSkagtARNurF1AuecI1AagsAHxQqDe+3/HVaOkcuF2u+GykTNVU3UMAd5UEXxy9YtbGGuq6rhCtgL21RQ8Z1CdV8COuMI1NZLkHLK9XCrtlYvbCHtVV+O2u58F9Feq9X2CvcZz4a93KqtUe4vh3KryiaUTBnufAAqC6sTcauqo2GcsB53ymFXZQR6LNxYbkagylGbTtXRMNflbE39JCPoIBbXi8HKKdejihtvbmxgbWx0YGErUjAKrGyvhJ6obsS2kLNFK4UzkTICsBeO0BoCBdXUfG2+oiEIa6+q8t2qD0Fox6k6by0sBO5DUA8vRxDaXuoanECjtBDecSotgWIO5TaDi+8UKuW7nXOVCPZS5bvdraEwGgIFLQ5o7mFskD4E9YhrGjFNUDKdswurFOqgGGxmmojFKuWoA5afroYmNOJa/KxqCc45RxCJ0QE1EW6F2heumGqlzn4hNGNIoRKxLdj8bgjF6IBaLUFoDYHCgGObtbnQGgKF6vLdaztrFMvF0I4zPuqU787lQmsIFAa7BknGkyzkF9jYNlgvGuHt1T1gn1OszWFtb2OePhM64+zWY4z1dZFdLWBaJie3Toa2l0gkiO92yncrDUFIe8W0GOOpcUzLdDUEoTMCIRwKaSUjCFJsTpWhPnDgAK961aswd7Y5duw4Bw4csFXFIQ6K3UurLkdtNncE73znOzlw4ACXXHIJ99xzj/v4ysoKL3nJSzj//PO59cZbObN8JvS1tMM56AgiMDrAruQZ64LVWXe/NGzENtyTIJWIkV0tBm5IUw+tvx+tt9eeqBEYHQA9eg+DXYMs5Beq7BXScca7bP3F2lwkBgxUyndnV4uRHWelfPdCZHsJIdwD9lzUQENdx9ocxoItMAxrL6gw004XT1OW5cAq7GroaafceQQNgUK6N40pTVdDEIoxpOBQSINqCKBSYuKxxx4jkUjwsQ/+jasuLlvlSIXehGpQo/oQxBuv67HHHuO+++7j4Ycf5vvf/z6f+cxneOopu2fz3XffzYtf/GJmZma4+qeu5t3/+92hr6UdzkFHUCSmCSaCaggUNM3VErgLW0D5v4KtJUiSXS2EKg9cP5ZbNz6ChkBhsneS3FYuvDiqGg43Xp1fhI1w1XV0wl5Ax+21sLXQQXtFd5z2ddjMNNdeIbeGwP7eSgu5ii4kZMYJtr1My4ymIVBw1MVRGEMAV199NXMnjmGYFmWzzB/+5h/ygsMv4KUvfSlFh13mpwz1NddcA4AVi/G7f3qXXYb62pt439/+fcN7PvHEExw5coRUKkU8HucFL3iBK0578MEHecMb3gDAza+7mS999ktnTUtwzimLVR+CUFRIBWeils7kEKkUscHglEMFNVEX8gt0xboY6Q6uIVBwRT9rI6E1BArp3jQzqzNkTUdD0B/ScYJtr/mHMfLhNQQKmaEkX/vhaTcjCFJOuR56Os32E09EzgjAZsJ8b+l70TNOsBfYp78SWrVejcxQks/9YJGsUwohbMaprqP8j59BnjmOgMiO0yyZ7Dg8+9RX7oBTj4cbzCyBuYOIJUls76BUz0loAAAgAElEQVQlu23x5/il8LK72/89UC6Xeeihh7jqhddiSXhq5in+5K/+hOv/z/X80i/+Ep/4xCd43ete56sM9draGgB/89GP0t/by8P//CVKp37E83/hTbz0Z15Z01D+wIED3HHHHSwvL5NMJvnc5z7H4cOHAVhaWmJiwr6/05Nplk8v21lKhO2qZjgHM4IQVSHr4UZsCyQC9iGoR3WEG7Sccj1UhCsjaAgU0r1pFrcWmVsuMDmYJKaFvy4Gp2Ejh5GdD60hUMgMpTi1ucPsxjx9ib5AfQjqoafTmCsrWEvHQmsI3Ovqy7BpbHJs+QxJPcZwGA2BwuA0GAWME0+F1hC41zWUomxJfrhsR/FRHSeWhXHiSec6g2sIFFQmt+3UCdKi3F9qzjh0VD/lpxVUGerDhw8zPT3NL/3SGwGY3jvNhZdeSEJL8OxnP5sTJ04A/spQq0qlX/r61/n7f/xHnvWcqzjyM69neWXFbXyjcNFFF/G2t72Nl770pVx//fUcOnSImAf1NRFLIIQ4awfG52RG8Lxn+O8k5onBaSicwcjORYrWwHYEG9tl5jaykaI1sPdwra0trJOzxIbDp+1gR2w75g6zmyfJDAVXTddgcBqsMsbcicBVR+uhnPjxtWykbSGoOmCfO0bX4J5Q1D4F9d0dX5snMzQSyaGrSNuYfRp9MpyGQEHZ69jqPGPJMbpiIdThDlx7zT5Fond3KA2BQro3zerKKjvlEnEtjvayd4Qei9IWnPkRZXMIc7NA10UX+f4u1RmBQtHpRKYnEggEcS1OLBZzt4b8lKF+9rOfzXe/+10k8Be/+7u8/IbriMs1mDjoeV233nort956KwC/93u/R8aZI7t372ZxcZGJiQmWl5YZHh2mZJVIEeH8qQnOqYxgp2w6fQiiZgR7kNKuMxTVESg9w0J+IdL+LVRx43O5SGk71IqkOpJBEU1DoKDq7Eehjioo9pLRAXtVU247aa8o5ylQba/wGhWFmnLnHbKXzdWPuAw5bBzFGIrihBOOlkBKSTwWbxjLbxnq+fl5rrv+eu776EcpFbYgpvOjmRm2tuqaRwGnTtktWubm5vjkJz/Ja19rt3O54YYbeOCBBwD4+w/+PS982QvPmqjsnMoIFte2o2kIFAb3YBkCa6vQgYwgBdoOm8Z65IzA1RIsb5KMOlEd9eeacSoaAwZsx2mBcXqZ/pDUUQX7u5Msb59ksveaSGO5jvPkGRgMVpq5HsqJL+8scdVkVHtNu9fVd/BIpKEmB+2zneXtk1y869ltXt0a+u7dtpbg5DI898pIY40lxxAIypZBKgpjCFwtgTTKiO5oto9pGjENJNJTQ+C7DPXBg1x22WU8/e/f48qX/zxoMDae5lOf+lTDmDfeeCPLy8vous69997LoHPm+Pa3v52bbrqJ+++/nz179vDH7/vjn2wNdQJu+ekwVTSrMTiNsWWn62EZQwqZoSSavgpEY8BAVcS2FetYxKbpq9Ed50CGcjEGlozsOHf1daMnChhyJ7K9XC3BRj6yvQa6BkjGU6xzJrq9uvux9CHMjWJke3XFY+zqj5M3z0S2l0gkiO/ahbF8IrK9VMMVEyMaYwhcLYEsW2gBNARQW4ZaYd/efTz4jU+7h7K/8zu/4z7ntwy1fVmCP3rbW/mj334LXbv6mjY9+sY3vuH5+MjICF/+8pfd359ee/qsOYKObA0JIa4XQvxQCPGUEOLtHs93CSE+6jz/bSHE3qrnftd5/IdCiOs6cT3N0BFGB0DvLkpFe4yoE3UwpZNM2vWBok7UWH8/Wk+34wiinRGk9BS98QGEvho9I4h3UZI2gynqVkdME+wasr/HMMXTqiE0DX3XSEccpxCC0e7xztgLMDT7s0W9vwDGh0tIzMgZJ4A+PkZpS0S2F4AmYoAZTUPgQAq7QmdYVXE19JhAYoZWFVdD6DrSlJ4agqBIxM5eg5rI34AQIgbcC7wMuBi4WQhxcd3LbgVWpZT7gb8E3uH87cXYPY4vAa4H/soZ76xAaQjGo1AhAYTAMG2aZ9SFTQjBYL8dlXRkoo70YWzFOzJRe+O7OpMRgGuvTixsg/3RqZAK+mhfRxwBQF/sP6u9Ond/JTpoLw0NRDl6RgBIZ3MjiKq4GeJxpyx2BDGZgojHkJZAdsCp6Jp+1voSdCIjuBJ4Skp5TEpZAj4CvKLuNa8AHnB+/jjwYmGfwrwC+IiUckdKeRx4yhnvrOBfTn+UwfQ/RdMQODBKvWgJgTYQvARyPVI96wipM9wdkZ0D6ANxjEIcesNrCBQScgRNX42mIXBg7PQCEJ8IT19USKU2gOgZFIA+GO/YwpZgpHOOwLGXHkFzoaDsNZ7qgOMc0CkXY8iI2ZiNGEJYxDsQ+knLntOiA4Npms0c0kT0nXPhlNaWRL8uKWNIKSkand8e6oQjSAPzVb9nncc8X+M0u18HRnz+LQBCiF8RQjwihHjk9OnToS60qM0T630s1N/Ww9iKofeY0WiCDjR9DWkMdeCqQO+xMLbidCJmkMYQWmKNKBRvBaMQJ5400TrghDV9FVlOERfRF1y9x8LciWFZ0aM/aQwhYtvE9ehtBY1CHDRJPNWJ+2sVKQWUw+skFPQeE6TAKHZC1OQs3sKMPJK0bDt1ZD9BOA1gZAccgWbPRHV9USCtOFLGkUS3Vz3+y9BHpZTvl1IellIeHgspsLnugosoaytY0mr/4jYw1k301A7sbEYeqyyWKZeG2ChG70CU6N7CMsB01I1RsF0cAGG4fQmiwFgvo/eUYXOh/YvbjaWtYBlDNU19wkLvss8bVAHBKNgu2tnh4tZi5LGM9TJ6ykRsZNu/uA3KYhlZ7uPURvQFRO+26Y/Gqej3hFocTRn9vpemtCn6nRjLWWgtK/ryKDR7rZFm9NBMyG7kzjgpPXqGXo9OOIIcUC0xzDiPeb5GCBEHBoBln3/bMaR70hiWwZlitCp+UkqM5bwdHVV1KwuLTfMUVmmopr9sWOgxm4FU04YxJNY37e2J6jaMYWGsbHXMXnlzCcsY7Ii9EjG7E1gpF/0zrm/0AZ2xV2lli0SPWdO/OCw2zSUsY4j5lU7eX9E/oyWdjmAdqLMvTQuhSUQHDlMtaSBl3O1LEAUC2zHJDmznGGWJHhcd2YWoRyccwXeA84UQ+4QQCezD30/XvebTwBucn38B+Iq0Tzw+DbzGYRXtA84HHu7ANXmiurxyFJhra1jbpY4sbJulTYrmZmci3J08erwzE3XbMFldtxe2qPaS5TLGmdWO2EtKyfL2ErIT9pISHTt678TCtrRaEQdGhbG0bGdQHXCcyzsnO2MvQDcXQHTIETgZQSdEUtIo25UlAjqC+jLUhUKB4yeO8/NX/6xbEC8KhGUgtKqWlR544xvfyK5duzhw4EDN448++ijPec5z3BIY3/nOwyRiGlJKfv3Xf539+/dz2WWX8e///u+RrzOyI3D2/P8b8AXgCeAfpJSPCyHuFELc4LzsfmBECPEU8FvA252/fRz4B+Ao8Hng16SUnd8Ac1DfQCQsVLSd6MDCphYNe6JGjNjW5+3FlugTdWGtiGXYe8qR7XVyCUyrI45geXuZkrWDMEei26uwQkzbROixyBnUxrbBxpaOLrojOwJrextzeQV9MBHZXmWrzKnCKVLaruiOwDIR+RzxwVTk+8tuxi7RRPSGK1JKuyFNXAvsCOrLUL/3ve+1r0dUGtREglmyG9S0yAhuueUWPv/5zzc8/ta3vpU//MM/5NFHH+XOO+/kHXf+D/SYxkMPPcTMzAwzMzO8//3v99Q1BEVHzgiklJ+TUj5TSvkMKeWfOI/9gZTy087P21LKV0kp90spr5RSHqv62z9x/u4CKeVDnbieZlAFt6JOVLc8cH+8UpI3JNS1JMVo9Im6NkcsIdF6ok/U7GoRZBe9+kDH7JUYG+yY4xzpGu+AvWYRAvRdw5HtZfchEAx3jUd3nKrh0a7hyPZaKixhSpORrt3RHefmIlgGid3DkbfSzuRLSAlxoUffGjJNpGUh9LjdCSwkrr76amZmZjAtE8u0eNt//zUuueSS0GWozbLB7f/rz3j+q27i8HXX8b73vc/zfa+55hqGhxsZg0IINjZsxtfq2hqju3aTiGs8+OCDvP71r0cIwXOe8xzW1tZYXIx2LnVOKYuT8STD3cPRJ6rbkGYy8h6uakgz3jMZfaI6TsltIBIBapGd7JnsnOOcnOiYI5jomeyI47Sv6z+ZvWrur87Ya7InzVNznbPX1hPzbV7cGupe12MJdswt3vHwO3hy5clwg1kWVrGI0GMITEj0AHDh8IW87cq3+RpClaG+9iV2qZHZY8d5x7v/Dzd+8G949atfHaoM9f33vZ+Bvj7+7bP/yNaZVa697TZe+tKX1pShboV77rmH6667jt/5nd/Bsizu/8RD6DGNXC7H1FTlaDWTyZDL5dyS1WHwX4Y11ClkejMd2BrKofX1ERvfG3miZjezJONJpgc7kLqvzUK8G31qTwcWNrsPwXR/Z+yFEOhT+yI7zmzeXiT3DabJRj38VAvb9L6O2Atg72Cmc45zz3n2NUYQEGU3s+51La4X3e5boaDstec8yktLLfe9216Xc693xXTKVhkZgfCsBFb2Iap0/vlDfRnq195iF3yb3rOHZ158KWVLhi5D/U//9E984OOf4fDLfpprbr6Z5eXlhjLUrfCe97yHv/zLv2R+fp4/fcef8z9v//WOiO+8cE5lBGAfGB9dPhppDCOXs8spOw1XomDBqQo5JVJ8+9iKLZMPywpwGoonYmkK//ZvkcbKrhaZHEyS6UvzjdzXI41l5HLEd+9GjO6FJ/8vmGWIhbv1FvILDHYNsnd4hOWtMxRKZVKJkLfx2hx0D6BPnoe5+imsrS20np5QQ2VXiyT1GOcNTrH59CYbpY3QvRKMXA6h68SnLoCjRdg6A73hKNMLWwsIBBeMZrDkk5xc3w5fa0s5gn0X2n0JlpZITIXrSZBdLbI/AV1xuyz2b17+m+7PQVE+cwbj5Em6904gNuZg7ELfJbLry1CvFG0WWVeXTdEsla3wZagtk3f98Vu59qdfS2k+R+K884il/Nv+gQce4J3vfCcAP/1zr+TNb/pVEnFBOp1mfr6SkWWzWdIRFejnXEagWgpG0RIYCzk7bR+chu012F4PPdbC1gKTvZNMDafI75RZK0Q4OHMcgZ5OYxUKkbQEqoGP6ksQRUvglp8enAZpwkb46Fs5TqXezUXJolx72WyyKPveyl6qJ3CUrKCUy6FPTiJUT4kIWdRCfoHdPbvZO2xrHCJRbtdmoXccfXovUNnCCoPsaoGYsDMCINKBsTQMhKZBwuHXl3dCj1WySggh0IRiNNWuE4HKUL/oGt7zgY9T1uxA5YdHj3qWoW6GyclJ/vmf/xmAr3zlq0zvO494TOOGG27gAx/4AFJKvvWtbzEwMBBpWwjOQUeQ7k1TtsqcLoRTJ0spKWWdOvGqLEGE7aFcPsdkz6S7sEXaHqpyBGD3SwiL7GrRXtg6wLSyHcFk5+zVO+kWdoturz1uvago20PKXtV9CcLCyC1UHCdEcgSV+6tT9pp2K+5GtVdME25htygHxrJUQugJhNOXIChzqBqGZRDX4m7/mFIdhVSVoX7+85/PhRde6D5+++23c+mll3LgwAGe97zncfDgQX75F3+Biy/Yz+HnPY/DP//zvPm//wblcqPg7eabb+a5z30uP/zhD8lkMtx///2AfTD927/92xw8eJC7/tcfcOefvxNNCF7+8pdz3nnnsX//fm677Tb+6q/+KvTnVTgnt4bAjsR39+wO/Pfm6iqy6JQHVhU+1+bs/qgBsVHaYLO0WRPhZlcLXJoJUb9oZxOKK/ZEHa1M1OSlB9r8YSO2DZNTmztkhlKke21R2UJ+gYNjBwOPJctljKUl+jvgOKWULG4t8lNTP8VUlb1CDmZfxzNeWNVwJXwUn10tcvn0kNuXIEpGYORydL/oRZVWkBEc50J+gcO7DzM+0I0mOuAI0ofdvgRRM6iYNuQsuiKSlkAaht2wXovbbSoDOIL6MtSGabBv7z4ee+wxji5sUDKt8GWoZZm7/sdbueud57P95JNofX0kPGqTffjDH/a8tquuuorvfve7ADx9Ou8efQghuPfee31/Rj845zKCqBGbe5CXydQ6ghBwGR2diHDXnD3DwWm3UFnYiC23Zl9DZijJRI+dcoa218klME076h6YAkRoe50pnmHH3GGyd5LR3i4ScY35sPYqrICxBYPTxEZHEV1doe21sW2wXjTIDCUZ6BogFU+FdgRWsYi5vGw7p64+SIankBqWwVJhicneSRJxjfH+7vAH7JYJ61kYnEboOvr4eGh7SSnJrhaJx2yVrKqqGXYslREghN2tLEJGULJKJJzMIhEXDRlBIJglt/y00PVI6mKjbJHoQLnuZjj3HEFPNHWx6wjSaUgNg94TWkugFtd0X5qBpE5fdzx8hKsWi4Fpuy9Bf3/oiVrdwCelpxjuHo5ur8lJe1L0h6dEuvbqTaNpgsxgMoK9nO9sYMpejNLp8PZaqdhLCMFk72R4x6k0BKqT2+B0aHud3DqJJS13ey8zlAofaGwuglV2sxTbXuHuidP5HXbKFjGnmqGuRdASKA1BwimCF0uE1hKYlolpmW75aT2mYYQVlVkWWIbbRlMkEqFZVpaUGKYVvaVnC5xzjqA73s1I90j4hU1xvCcn7QgkwkRV16C2E6aiTFS1sDldkKIsbKomjdquisKNd+2lmtZ3wl5qYRv+T2KvuoZH6d50dHulz4a9IjhOFewMduL+sr+zuHIEMT301pCKst0+BBEyApWVVDICjZJphav/r64h1uVenzTC9RIwTAvpXM/ZwjnnCMCeGIqPHhSlXA5tYIBYn12Hh6E9kSZqKp5ioMveN8wMJcOzOlZnIZ6EHptmqKcnMRbCZwR6TLC7z2ZhRIpwc1nQNPTxcfuBKAvblhKT2dtVmaFkeEfgLmz2uUUUEZ6bQTnbe5O94R1nyXWc6cr1hdQSVG89gp0RnNzYDrfd4TrOvfb1pdOhtQTKGamMIKElKFvlUEw+9f5uZ7J4wmamWcGrkCpHoDICVdenbEVxBJWtIaREehwWt70u5/tKxDpfbE7hnHQEUSaqkcvVdiWLsLApBozi56vUPVQEsjZrX4szViKdppRbCDXW/GqB9GASzZmo6d40i1uL4aIZpSFQE3Vw2qaPmsEnRC6fY7h7mJRuL7iZoSQrWyW2dkKUHl6bg+5B6LadsJ5OY66tYeb90/sU5lcK9CRiDKbsBSTdm2bTsLUEQWHkFuzewKOj9gODe6C8DVvBWW65fA5NaC4pIjOUxJJwcj1Ev4S1OUDAgJ2p6Ok0SIlx8mTgoZTjrN4agnDF5zwzAgiVFaj3d7eGnAg8lOM0d2quR93/shT8M6oqqD/JCDoMtbCZVvD6di61T2FwGnbWobgaeKxcPlfTZSszlKRQMlkNoyVYm61pjq2n08iQWoLsarFGdBRFS+BSbRUiaAlym7maPsWRDtjr7OVSSENkUcpeyqFHqXJrZLPo6bTNi4dITKtcPsfu1G53YVNbV6GyztVZ6JsAR/SlR6DcZlcLjPYmXK6+HkFLIEslhBZDxB0CpHIEIc4JlIYg7vD+lYo3lBrbLAECnM+mHJU0QlxXWSIQPzkj6DQmeydtLUExWJQlpayIoxRCTlQppacjgJCUSIfjraD25MNoCbIrhZp2i2phU+UKgqBT9gLHcfZ10l61jlNdb1AoMZmCy0zbDD5Wg72GwovK6u+vKddxduD+imCv+ZUi6aFKoBFFS+BSRxWcPXm/GUF1GepbX3cr5e0ys7OzHDhwwHUEoTKCcsl2So6za5YRzM/P88IXvpCLL76YSy65xFUSA7z61a/m0KFDvPiqK7n+uZfxrGc9y33uT//0T9m/fz8XXHABX/jCF4JfXx3OSUegJkfQiM08cwa5vV05+ITQC9v6zjpbxlbtRB0OGeEWHXVzBxa2QqnM8lbJjbYhvL2sUony0lJH7GVaJgtbC00WtoD2UhoCz4Ut2GdUVMgae/WEF+EZ2WzlfAAcyi3hHOdmrSOYGOgmpomOZFD6+G6IxUJpCbKrBVcHAkTSElilUmXbEUCLBdISVJehjsfjfOyBj1WG0gRxTQvXoMYsVbITQGgaIh5vyAji8Th/8Rd/wdGjR/nWt77Fvffey9Gjdgmcj370ozz66KN8+svf5PqfuYFXvvKVABw9epSPfOQjPP7443z+85/nzW9+s1vfKCzOSUcQVktQqq4KqRBSS5DbqlAhFdIqdQ/K9VbvXT1RQ2oJ1CJRHeGqw1l1WOsX5cVFu/lLtSPozxBGS3C6eJqyVa6x12hvgq64FjzCzZ+y992dg0+A2MhIKC3BWsEgv1OusZerJQhoLzOfx1xfJ1Ftr65eSI0EtlfJLHGqeKrGXvGYoyUI6ghMw97Kqwo0RDyOvnt3YHuZliS3Vus4lZYgaEYgpbQzAr0qI4igJXjWc57F3HHbzqZpctttt/GKFx3h5p//2eBlqM0Spohx++23c8UVV3DZZZfx1x//eIOWYGJigssvvxyAvr4+LrroInJ1Nt0pmzz06f/LzTffDMCDDz7Ia17zGrq6uti3bx/79+/n4Yej1Tw755TFULWwBYxw1TZLzURNDkGiL7CWQG0bVG919HfrDCT14BN1rZYBAxDr60MbGAjhCBQVsjJRlZagI44zpJagWkOgIIQIxxzysFdYLUG15qJ6rDBMqxqNSjVCEBJc6mhf7Vi2vQI6zvUsSKvGXuo6g2ZQpza3MUzJ1HASqFyHvOd+tn50jNm4/368UkqsQgEtkah1BuUiSEnXZZcz/nu/52usndIOX//S13nZ9S8DYGZmhg9/+MP8j7vv4f/7pdcFK0O9sgzbc9z/oY8zMDDAd77zHXZ2dnjeFVdw7XOfy4V793pew4kTJ/je977HkSNH3McsKfn2N/+FsV27Of/88wHI5XI85znPcV+jylBHQaSMQAgxLIT4ohBixvl/yOM1h4QQ/yaEeFwI8R9CiFdXPfe3QojjQohHnX+HolyPX3THuxlNjgaO2DwnakgtgdfCBiEnah3HWyEMJbKysNVWbwyjJfB0nNBhe6WCH342tVdwR1CvIVAIoyVo0FwodNpeKyEd51B0e1UyztoqnDEthiTgFoxisWn1y5jmm26rylBfecWVTKQnuOWNtwCwb98+Dh06hB7XuPDAIY4fPw74LENdsj/jP331G3zgAx/g0KFDHDlyhJW1NWaeftqTfZfP57nxxhu555576O+vVK01yhYPPfgJfuGmmwIYJjiiZgRvB74spbxbCPF25/f6ThAF4PVSyhkhxCTwXSHEF6SUis5yu5Ty4xGvIzDCRWxZYiMjaPWlZENO1P5EP32JvprHM0NJjp0OSGFcm7OzkmStH06k0+w4N7BfzK8U6IprjPXWlgSe7J3kR6s/CjSWkctBPE58d11Np8FpmP1moLFUBqW29RQyQ0m+nw3IjPLICMB2nNv/8R+BhvLKoNR1fnfpu4HKd7fMCH70BXtx8zlWq0BjaXObnbJJVzzmayz33vbICMpLS1ilElr1Pn0LqG3PqaEkO2cqj/ff/hucKpxiauQiNOEvPjXX1ynNz9O1fz9ad1UmkV+CjQVf9b/UGcHGzgbzm/P0dveyxRZdXfb9n4hpaJpGybApyr7KUB95Ht/97ANIBO9617u47rrrACivrGAsLCDL5ZoMxjAMbrzxRn7xF3/RPQdQKOyU+PLnP8Mf/c8/cB/7z1iG+hXAA87PDwA/V/8CKeWPpJQzzs8LwCkgXHH1DiLdkw7M6ijVH+QpKFFZAJ59PaNDIZSWQB3k1S0S+qSdugcZS1XRrF+8VIQbRPRjZLPoExOIWN2C42oJ/B8O5vI5diV3uapPhcxQirWCweZ2gIPGtVlbeJeoXbz1dBpzfR2zrhBZK8yvFOnvjjOQ1GseT/emyRv5QFqCUjaLSKWIDdUl1kpLkD/le6xcPkdcizOWrJ1qmaEkUsLiWgAtweosiJhzvlOB0hKUA7RJdDu5DdZmUC6FNMA9YSkxmV5r+zAUUldMFqsdS3H3TUdU5qsM9egI8wtLXHfd9bznPe/BcM4FZk6cYKtQqBHhSSm59dZbueiii/it3/qthuv64he/xL5nnM++PRUnfMMNN/CRj3yEnZ0djh8/zszMDFdeeaXvz+qFqI5gt5RS3QUngZblPIUQVwIJ4Omqh//E2TL6SyFE084UQohfEUI8IoR45PTpcCWkqzHZO8nJrZOBtARGNkcinWl8YnAaSpuBtAS5fI5MX+NYU0NJiobJylaAw646BoyCnk4ji0XMVf/XNb9aaIhuwbZXySqxXPSvJWigQioMTtt7zgG0BPXUUQW1haUK5flCHXVUIRGCOZRdLXg2egnDtDJyCyTSk40ZRAimlSo/HdNqnXAoZtraHPSnG5oJhWGmza8U2N3fRbdee11hKKSyZCBiscZAI4SorGSV0IRGTNSOpbj7phNM+SpDfcXlHLzkQn75tl/h4osv5vLLL+fAgQO8+Td/k7Jp1hwY/+u//it/93d/x1e+8hUOHTrEoUOH+NznPuc+/4mP/QMv+7lfQK9SFV9yySXcdNNNXHzxxVx//fXce++9xOptEBBtt4aEEF8Cxj2euqP6FymlFEI0DT2FEBPA3wFvkNINK38X24EkgPdjbyvd6fX3Usr3O6/h8OHD4fvaOZjsnaQsbS3BeI/Xx6t7f9PEWFyk/2Uva3yyum58qrEJdcNYUrKQX+Ca9DUNz6lFeH61yEivj45NUtoR274XNDxVXTc+7tEc2wvZ1SKHpgYbHq9mWo2l/CV0pVyO3p9qvK4aplUVc6cVcvkcz9797IbHXVHZSpELx312BFudhfTlDQ+72otcju4LnulrqPnVIs8Ya+xqVi0qu2jkIoyvVEMAACAASURBVF9j2WKyJoEG2PfX1BW+xqqnjiqE0l7UUUcVEs79Vcrl8NvXrZ5qq+CqiwOIyqRRRx1VCKAlUGWoDdNAj+kIIdi7dy+PPfYYYG8NveFX38LufnvryVcZ6pVjUN5BxGLcdddd3HXXXfb1WhbbR4/WZARXXXVVy4z9z9/1PgpGuSE4uOOOO7jjjjua/FVwtM0IpJTXSikPePx7EFhyFni10HvmrkKIfuCzwB1Sym9Vjb0obewAfwNEy28CINNrTzi/5wTlkyehXPbeGgoYsalyyl4RbmY44ERV5ZQ9JmrQiG1z22CtYHhO1KARrrW9jXnmTONBMQS2lyqn3Gph831gXFVOuR5B7WVrCAqunqEaQRv6uGJFL3uF0BI0y6DG+20tQaAD9iYZVHy3rSUIlBHUaQjcsUJoCdzy0/UIqCUAp/y01jiWpgniMc2t9+ML5VoNgUJFS+D/M5ZM66z1Ka5G1Hf4NPAG5+c3AA/Wv0AIkQD+L/CB+kPhKicisM8XHot4Pb4RtAxAqRkDBgJrCZod5AGkBwN2Kls74VxD9IWtvnhaNYJqCZoefIK9zSA03/Y6ma8tp1yNkZ4E3brm316bi3Z5YI+FLTY8jOju9m2vM/kS24bVwBgC6E/006P3+LaXtb6Olc972yuglqBgFFjdWfW0VzymMTEQQEtgbNs287i/RDzu9CXw9xnLpsXi+rZnoBFUS+BqCBJ645NKS+DzjEBK6WYEXkjEAorKTG9HAMH7EpTOch8ChajvcDfwEiHEDHCt8ztCiMNCiL92XnMTcA1wiwdN9ENCiB8APwBGgT+OeD2+MdEbrOFKU2ofQHIQugZ8awnUe6qspBp93TqDKd1/RtCECgkQ6+0lFkBLUF9+uhpBtQQN5ZSrEU9An38tgZf4TsHWEqRC2MtjYQuoJVDv6XVGEFRLoAINz4wT7O+3A4EGBKzauu6wUzwyTghGIV1c38a0ZAM12R1L81+OWpbLIGXjQbFCAFGZKU0saXlmBBDQEVhlu5ZWvIkjCNCXwLIkZevHkxFEoo9KKZeBF3s8/gjwy87PHwQ+2OTvXxTl/aOgK9bFWHLMd0Zg5LIgRKWccj0CUEjVRK2nQioE6kvQhNqnoKfTvssAeKmKqxGEG19qlRFAMHt5iO+qMRVkYXNV2Hs9nw6ivZhvwolXSPf4t5d6z0Qrey097musdo5gaijF12d8Ei6aUG0V9HSarW/6owJ7aQiq6bWJWILN0qavsRrKT9cjnoCSPxp2fdXReiTigvVt6Y8KrLKQVhnBxoavsaJUHQ1aKficLDGhEKQcdSmbJT4+3vzGC+gIRpOjdDdRUWaGkv7LTKzN2vqBbu+D0iAR2/xqgVQixnCP92cMYi8jm7PLKY+Ner8goL1iIsbulDcpLVDnrbVZqssp1yOQvVpkUFCxl59J2TLjBNte6/O+KMrtM4IUSxs77JR9MOZaZJzgaAlOnXKpnK2gziXU1mN3dzfLy8uufXRN992XwC0/3Ww+xvz3JVDbUfXUZAXd6Uvgq1tZXUOaeohEwndfAlXsLmjVUSkly8vLdHf7V2mfkyUmFCZ7J/nB6R/4eq1RX065HkN74NjXfIl+cpu5ptkA2AvLV5485S8CaUIdVdDTafL/8i++xmqmIVCY7J3kq3NfxZJWW9GPkcuhT05WyinXY3AafvAPtpagyd6se135LOM942554HpkhpKsFw02tg36u1uPxdpcTTnleiSqtASx3t7W17VaZLgnQU+X93VN9k66WgLVfKgZjFwOra+PWH8T5tPgdEVL0NeSpU12M0synmS425spphxXbrXIeWOtPyNrc6Dp0OedCVdrCRJ7vJ2Fe12rRTQBE4P2ApXJZMhmsyg6eLFcZHV7FWvJavpdK5ibm1ibm8Q1zft+NQqwdQZWHm8anSvkS47eowfP+3rbMDmTL2GtdtHVLjrfcWjkqwkPxbNDolhZIWaabUV4+Z0yawUDbb3b7d3gF93d3WSaBRUeOKcdQbo3zRdPfBHTMhv41vUwsll6nve85i8YnLbZO4UV6BlpOVY2n+WyscuaPp8ZSrFTtjiTLzHW14ZCujoLu5rTE6u1BO0opPMr3gwYhXRP2tUStKOQ2lU0W9yI1VqCNhTSZuI7hWoK6cWTbRzBqjcVUqG6CmmsDYW0vopmPaqZVu0cQSnXzl5VhIQ2jkBpCJo59AqF1I8jmLX7FDeZH6qOlJHLtXcEKwUmBpJuhKvrOvv27XOf/96p7/EbD/0G77n2PVyVvqrlWAt33MHW17/B+d/4epMXfA8+eRO8+kNw0c+0HOvOf7uTL85+kW+85huezx87nefn/+Kf+d83HeSVl7ZZXD/3Vnj07+F35z0Dwp1jxzl282uZ/PM/Y+Bnf7blUHd97gn+9ptZnrzzerdJ1NnCOb81VJZlThVaKzatUonyqVPtFzaosHiaoGyVWdpa8jwoVvDN9bYsh4vvZ2Frvd0hpSTnZATNEKRqa0M55XoEoJAu5BfaOIIAlFvVya0JgjCtmnHiFYIw04xszuXle6JaS9AGC/mFpucpYPd6Bp/MtNXZpttCUDnT8HMOlV0tuhV2vaCaDvm1V9PzJwjE5Gt3f00GYfI1Ufkr6JM2ScXf/VUgU9Up8GzinHYEfuvGu1TIDixspwqnKMtyyxvPt/pz65TdEq/FRPW7sK0XDTZ3yp4MGAW/WgJVTrn1RPVnr+3yNmeKZzpjL49yyvXway/LchxnEwYM+NcSuBqCyVb28qcl8Gp4VI/x/m7imvDpOFtvPQbREsw30VwojKXGiGtxf4FGM82FQnIIEr2+HEE7e3XrMXb3d3XEXlp3N7GxUX/2Wim6Tvts45x2BH4j3KZVNKvhc2FzD/JaRGy+tQRtDvKgKnXPtu4upipStsoIFOW2HTfeZcC0spfSErSh3DYrp1yNoZROKhFrby9VTrlFBuVqCdrYa2lzm5JptcwI/GoJzOXlxoZH9Uj0QGq0bUawUdogb+RbLmwxTTA56INptZOHwpmW9nK1BG064e2UTU5ubLe8vzSh+apyK8tljMXF1oGZWxW4tb0saTUV31XDFyFBqfxbzEeAxGTaLdHeCvN1ne/OJs5pR5DuTaMJjfnN+ZavM3JtGB1gN0HvHmzrCFS7R5WNeKGnK85wT6K9+rMNtQ8qWoJ2qfvsik21mx5uXixAHUC2d5xKQ9BicvnUEmTz9litttJUX4JO2MvVErTpXTy7bL/XnhYRm18tgS97gS+mlR97AT7tpajJrRc2P0wru5Ai7BlpHeH6YaYZJ5fANDtir9OF0xiW0XI+gk97FZbtc8IW9xf46+OwXrRV/q3ur07inHYEekxnomeivSPIZhG6TnzXrtYDDk63jXBz+Rya0BjvbV3fyJfoZ8UpMd0iYgN/E1UtbNNtJmq6t33V1tKcbU99aqrl6/xM1HaaCwVfEZtrr30tX6anJ9s6zjnlCNrZqyfd1hGUnJLCiekO2KtJue56+Lq/Vv3aq/395dtevWnXmTWDMW/bIDHVesF17dWCcusnQwfbXotr25RbCcvU/TXsw16Li8gW7SX92qtTOKcdAUCmL9PWEZSybaiQCj4jtomeiabiFfe6/DSoWT1uR9V66/RRT6fbpu5zywVGexP0NqFCutfV295exvycTYUcbCxeVwMfqXt2M0t3rLuhnHLDdfm1V8zpkNYCfuw1u7LlbrG0vK6+DNnNbEstQWnOvmdaZpzg2GveJgk0gVpEp/paO5XMUIrTmztsGy20BAEWtvKpU1g7O01fM7vcPuME214r2ytsGc3FYCrQ8OU4dzZaVgUOYq+yJVnabP4ZgzhODIPyqeYkFT8ZeidxzjuC6b7p9gvb3Fz76BZsGmSbCGR+Y77tTQe26CbXri/BynEYPq/tWPr0FEY2i2yxgMyubDHtIw2d6p9icWuxZZXI0tw8ienp9hqI4X12AxGjeW38uc05Mn2ZtmNNDaXY3C6zXmxRomDluP0dtaEKJ6amsTY2MNeaN7yZXS6QHky2FftM9U1RLBdZ3m5evtuYmyc+Pl7bXMULw/tscsBm8/r/cxtzDHcP05toTQv1Vb579bi95ZlsaDxYA7Ugt8oKZldsseJob2vuvJobagvVC8b8nC1WbKbyV1AL8uqJpi+Z25gjJmIuY6npdbkU5RbBxspxQLSlQyt7leabrzt+M/RO4Zx3BFN9U6ztrDVtICKlpDRvL2xtMTht90vdOtP0JXObc74cQWYoyU7Z4nS+RQSycgyG97YdKzG9B1kqUV5aan5dywX2jrSPPqb7pjGlyWK++WJUmptDbxetgePEZMuswK/j9EUhXTneNloDSDhNQFpN1LmVgq+0fbrfHmtuo3mmWJqbI+En0FBOf+VY05fMb8579rmoh6u9aLU9tHLMtlcbJ6zmRmm2+fc4t1xgejjV1qFP9zn22mxhr9k59EymfYbuw15zm3OM94w3LTinUK29aIqVY3a2qbd26Pq0vZVrzDX/jHaG3tU2Q+8UfuIInEWmWVZgrq1hbW66i0NLtOF6b5Q2WNtZc2/2VnD7EjTrL7uTt+mjQRa2We8bb9swWdzY9hV9uAtbk4kqy2WMhYX2+7fQdqJa0iKbz3bGXlLaEW6bbQ6oXtiaT9TZZZ+OwM/CNj8fwHHS1hH4s5dTvrtdhOvDXvqe9gvbrE/HqeZjS8c5P+/PcarIXG1xeSC76e/+mhjsRog25c5X/QUa+sQ46Hrr+2tl68d2PgA/cQRtHYHhRDm634wAmjoC9R6+toaG20xUle762BpyF7Y57+vKrhZ8MTqg/UQ1FhehXPbnONssbKcKp9gxd1zn0/K62tlr6wyU8v4mqrPINLPXWqHEetFgj4/924neCWIi1tRe1taW3bdhuvWBP+B0CUs0tVfJLHFy66SvhW1XXzeJmNbcXqZh1zbycX/FBgfR+vqaLmyWJZ0Mqr29ehO9DHcPN52PUkp7q9bPfEyk7DO0NhmBn/urKx5jvL+buQ44ThGLkchk3LMhL8wuF35sjCH4iSOoOIIN7xtPfVnt5PNAhWbXZE/SdQT9frY6UggBJ5abHJqpm9vHjaeK5TWL2Nz9SB8L20j3CMl4sulEVYuBrzOV5JC9B91koqr38LPVMZhKMJDUfdir/cKmdXcTHx/HaLKwBdm/1TWdyd7J5vbyyxgC+2xjaG9Te2XzWSTSl71immBqONncXuvzdsE2H45TCEFierrpwnZyY5tS2fId4U73TTfNoMzlZaxCwd9WLdjfdxN7re+ss76z7iswAztQUt99A3Y27Qzdx3wEWtpr27A1Fz+u8wH4iSMgpacYTY62XtiEaM/oALuBSM+u5gub42zacbzBVjNODiQ5cabJRPXJUAC7M5I+NdU0YpsNQFUTQrScqC61z4/jFKLlRFXfiZ8IF2DvaE/zhW3VHwNGodVEnV0JRu1rZS+XMRRoYfPe6lD3l58IF2DfaA8nzjRZ2FzGUHvHCfb2Y1N7uZoLfwyY6f7pphmUb8aQwvC+5o5z0x9jSMG2V7P764Tzfv7spe+Zxpid9SSDBMnQO4VIjkAIMSyE+KIQYsb535NeIIQwq5rSfLrq8X1CiG8LIZ4SQnzU6Wb2Y8dU31RzRzA3R3xivG2lQBcjz4Bl7xtvbnOOseQYKd3fF7x3NMWJZhHIynFIDttNcXyg1cI2t1KgJxFjpEn56Xq0m6iiq4v4mL++xq0cwdzGHHER99VTGmDvSKrNwibain0UWi1scy4V0t/3mOnLML8x7znpDTcjCBjheoylnI3/CLeH2ZUtLMuDmRbQcerT0xi5nGf3rTmHCul3Ycv0ZVgqLLFdbmSTqUBD93MGBba9tk7ZEXv9dYWw1/JWiY1tD2aaT42KQmJ6D1ahgLncyCYLkqF3ClEzgrcDX5ZSng982fndC0Up5SHn3w1Vj78D+Esp5X5gFbg14vWEwlTfVPMId27O3/6twvAzYOVpz6fmN/0xYBT2jrSIcFeO+Z6kUHEEXovR7PIWe0Z62tM9HUz1TZHL5zCtRg56aW4OfcoHo0Nh+DybcuvRVnB+c550X7ptSWKFvSM9LKwXvbnxK8fs3r9Nyk/XQ5+exlxexnSam1djdrnArr4uUgl/1zXdN82mscn6znrDc6XZOWKDg8T6+nyNxfB5tno138hBn9+cp1fvZairNd1TYe9oD9uGxdKmB3135TjEu6GN8FEhMb0HTBNjoVExO7tcIK4JJgb81cdXGaCXEK80Owea1rq8RDXcc6jGLEoFM3620gCXVTfrFWwE2KqFKgKHR7ChHMHe/yoZAfAK4AHn5wew+w77gtOn+EWA6mMc6O87iam+KU4VTnlGIKW5Of/RGsDIeZBf8oxA/FIhFfaN9rBWMFgreDT9WPWnIVDQ90wji0XKpxo7U/lldChM9027DeXrEdxxnmfX//EQ4gV1nPtGe5CyyYHx6nFfVFsF9Rm8KJGB7dWCaVWan0P3c7CuoBYaj2BDUZP9OvR9zsJ23Gu7Q1FtfTr0CjPN216ZoSRxnw1WXKaVR9ZZmp9HHw+QobuOoNFe85vz7ErtIhn3V89n36hjL6/gbPW43Ve6u3W5cQWXwHGi0V5zKwV6nTIzPy5EdQS7pZSKUH4SaFYovVsI8YgQ4ltCCLXYjwBrUkrVqicLNHXzQohfccZ4RDWy6BTUYlMfgZgbG5irq/4YMArDz7D/r9vuKJaLnCqe8r1/C7gsi4btoXLJLqDmMw2Fyp69UceEMS1JdqUY6GDKZQ7VLWyu5sLPQbFCE3tJKQM7ArU4e26nKU68TyT2NqdE2px4/2l7KwqpMTvnj2qr0MReYO95h7GX5wFo0Ixzj3KcTezlgzGk0NJxzs36P0+Blsy0oPeX2gqc9XScwe4vfXISYjFPZtrs8pYvzUUn0dYRCCG+JIR4zOPfK6pfJ+09h2Yy2D1SysPAa4F7hBDPCHqhUsr3SykPSykPj/ndf/aJZhGIWzMnUEbgfLTl2ggk6MEUwL5RZ2Grv/HW5uwoOsxErVvYTm7YVTT9HuRBc5FU+dRpu4qm34M8aDpRV3dWyRt53wfFUInYGuy1vWEXBAuQQSlnVr+wKUZHkIwg3ZdGIBqYabJUwjh50v/BJ9jbW1q8wV5lq0xuMxco0JgcTJKIaY32ktI+/AywsMVGRtBSqYb7S0rJieWtQFTIga4B+hP9nud2xpxPcadCVy/07vZ0BHObc4Hur2QixsRAt3dGsHIi0HwUum6XMvHaGgqYcXYCbTc5pZTXNntOCLEkhJiQUi4KISYAz+IZUsqc8/8xIcTXgGcBnwAGhRBxJyvIAP6axXYYzbQEKnoOvNUBDamoim6C3HhTw00opKvBGB0A+ri3iEVFN0FuvF2pXSS0RKO9FGMoiL16RiHR1zBRlZMJ4jgHUwkGUx4U0oAHnwBaKkV8bKxhYZsLyBgC6Ip1Md4z3hDhlnI5sKxggUYsbtOU6+y1uLVIWZYD2SumCaZHUo322jxpK+SDLGxCoO/Z0xDhrhUMNrfLgRe26b5GQoK5uWln6EEcJ3gyrQpGgTPFM4HsBfY5QUMGVd6BjSwM3xxorMT0dMN8VBn6Sy5u3YWu04i6NfRp4A3Oz28AHqx/gRBiSAjR5fw8CjwfOOpkEF8FfqHV3/84MNA1QJ/e1zhRlYZgyn/vTxI99gFbHXNIZQR+D6bAFrF4UkjVIhAgYhPxOIl0umFhU9HN3lH/GYEmNPuAvT6DmlWOIMDkEsKT4hdEc1GNPV4H7CHsBfa5Sv3CpvbT/ZTjqIYXhVRFg4EiXPBkWgURK1bDk2kV8OBTITE93aC9cO+vgPaa6m8kcLhU2yBbadDaXgHvr72jqeYZesD7y4vAsbBWpGRa7vnNjwtRHcHdwEuEEDPAtc7vCCEOCyH+2nnNRcAjQojvYy/8d0spjzrPvQ34LSHEU9hnBvdHvJ5QEEIw1T/VUOiqNDdPfGwMLRUwTRtpZA7Nbcwx0DXQtndtPfaN9nC8PgJZftruvtTbpix2HbwWtmOnt+jWNSb6/TE6FDwn6uwsxOP2/mcQNJmoAuFLc1GNfV4Lm9qmC5BBgZ3Z1C9sx07bi8C+seALW/3WkDpY9aW5qIaKcKsWEFdDECDjhAozrYZCqu7d4WA7uInpaUq5HLJcdh9T9jovoL2m+6bt4oZmhaqpVP7q/MY3hvfZhfpKlQU8qEZFYa8XhVTdXyMB7bVnGmtzs6a44dOnbZZa217SHUYkRyClXJZSvlhKeb6U8lop5Yrz+CNSyl92fv6mlPJSKeVB5//7q/7+mJTySinlfinlq6SULSqsnV1M900zu1G7SJbmZoMxOhSGz2s4I5jdnA1804FSM9ZFIMszMLK/bTGweqiFrToCOXY6z96RnsB9Uaf6phrKK5eOHycxNYXQ2zSQr8fweXZZDrOygMxuzDLRM0EiFow5sceLQrr8lF1qoCvY5EpMT1M+fRqrUHEsx07nGe3tor872Gec6ptidWeVzVKFTbZz/Dhafz+x4eFAYzF8nl1euVDhoM9uztrlulPBzs/2jPawU66jkJ6ZgViXb82FQmLPNBgGxsmT7mPHTueJa6JlC1QvTPVNud3DFHaOHwchwjlOqFH8q7keNIPa40UhXZ6x/x/ZH2gstSVoVDGt3EAjQIbeCZzzymKFfQP7yOVz7JgVX1Q6MRv8pgM7Miicge0Kb/z4/9/ee0c3dtx5vp8CCBCMYM45djfZ7BwkK1ptW5YsS86yLTnM7MieGXvGb8/bGXt8Zkdndues953z7Nl9Httjy0kOsr1OkizLyi21pO6WOneTbOacI0AQRK73RwFgBAHcy6Y8bnzP4QF478WPhS+r6herytZHtTU+1xEilJBOd0FefdyyzBUVam+b2dnldk0vUqvB+qjIqMDldzG1tFzB5e7rxVwd/3ckp0ZtZ2Bbtpj18LWuhHS6E/LiG6Sw8S6kfdOLcVu3sGx5rsyreHr7MFdXxV8dskGCvc/WR5W1CoOIb0hvWEI63aX+RpTtutfCtMEupH3TqgIm2nbdaxFKeq/ly1RcHH277rWIwFd+Sj4Z5hjXbwSxYQnpdKcqHU2NT6FvVMDRN71IhiUp6nbdW42EIgii2lqNRIYtBb/Nhn96muSa+MIJwLoSv0XvIpPOSU0TW9XagepxqgkzV4MiWFPr7fEFGJpb0jaxBQdqv60fAOn3q1LI6qq4Za1NsEsp6bf3a+Mrbw1fUsJ0tya+TBvUevdOL1K7BXyB8qCSqzQqTljldfbZ+qjO1MJXqDJtjYWrSXGuX3vRO6VPcfbb+8PXPH192gyNUOx+JV92bYZGuER5leLU2L/KykCINf3LQU1++raWjkJCEYRRlVkFLA9UT5+qMjBXa1AEa0pIQ5059DfialfemlrvUPxWi0cQGqh9qj2Ds4v4A1LTQK2xKl76bIqn0PYCmhTnGr4mnBMs+Za08bW2Nn5xCtw2yGuIW5a5Uv19T38/oHYdnV30UJMXvwdVmVmJQRjosyu+/I5FfJOTmLXwlVWhSkhnugFw+92MOkapslbFLarYqkpIw+FHv1eFUDTwlZSfj0hJCfPlD0j6ZhY1xbtzLDlkmjPD/UtKiae/XxtfKVmQmhfmS0pJv61fU/+ymFQJ6aqChBltHrrBbMZUUhLmC5TirN3msBAkFEEYlZlqkgx1PHevek2u0WGBBD2CkEwtFkh5TioGoWKtgHLbQVPHM5WVIcxm3L1qwu0JJfI0TGyFqYWkJKWEJ7ZlxamBr/RCSLbCVAegj6+sVDPZqSZ6p9fyFb+Fa0xPI6mwEM9avjQozmRjMqXppeHvFhr8mjyoJLPqY9OKrwH7ABKpiS+jQVCZmxr+bsz1qzCdBgtXGAwkV1fj6VH9fnR+CY8vQI2GiU0IQY21JsyXb3JS7TpaXRW3LADyG1UIB5h1zWL32DXxBSo8FIrlszSvjA0N4xHAXFuDu1fx5fT4GLO5NPUvvUgogiBSTakUpRWFrXdPXy+YTLHtOroW5lTILAtPQv22/nDJZbxITjJSmZtGd0gRBK2aeCs6ILgPelVVeKBqrYABNVCrrdXLilOPIhAC8hvCAzXsQWmwcAHqCtLpngzxFUrkaRuoybU1uMN86avoWMlXSHEma+EL1MQ2FeQr6MVqsXBB8dWzBYYGgLm2Njyx6a2A2VK+8hqUoREMO4K+/tUz6VCFEqHxqLV/1dTi6etD+v0rKqy2t2IIEopgFaozq1d5BObKCkSSxqPi8hvDFlufrY+y9LK4K2BCqM1fMbFNd6nVpWZtKw/NNTW4+4KeyrS2CpgQqq3V9NqULE9fP0arlaTs2DY8W4e8ZUXQZ+sjzZQW9cD6SKgrSKcrNFCnu9Tmadb4lTCo0KCntxcpJX3TiyQZRPh0r3hRnVnNgH0Af8CvJjaDIXy6V9zIq1cep98b7rMhrzZe1BWkMzCziNvn11wBE0JyTTW+sTECi4vhPI3WCphqazUzrhlsbps+jxNU/3LNw+K0Lo8TFF8Lbh+TC+4tUJw1SLcb79iYbr70IKEIVqDKWkW/vV/FI3t7SdaSHwghZLEFAvTb+zVbH6A6Xt/0Ij5/QE2WGgcpQHJNDd6hYQJut+ZEXgg11hrGF8dxep14ejVWDIWQ16A261uaD8dvtSbMavPTmXd6mVn0BCtgamPePG0tzLU1BJxOfBMT9E4tUpEbfwVMCDVZNSqevziKu68XU2lp7JunrUVeIwRUPL/f3k9RWlHM25uvRV1BOgEZTLBPd0Jafszbm6+FuUZ5qu6+fnqn9FXArMxDuXv7EKmpJBVqXHGbH8x5THfQb+sn2ZhMcVqxJlF1QYu9a8Kh+DIkRT2wPhJCOTVPTw+9U4sIkVAEbzmqrdWqwsc+pjZP05KYCiG/EXxLBOb7GbAPaKroCKGuIB2vX6qE3ky3ZusD1MRGIICnf0BzBUwIIYuq396PaPP6yAAAIABJREFUu19jRUcI+Y3qdbpTc0VHCHUFaqB2Tzo0V8CEkBya2Hp6VEWHhnxKCKHv1Gfrw9PXrz3eDcsT21SH5oqhEELlw92TDs0VMCEk1wYntt4e3RUwq/nqw1xVqb2aJm91/wol77VguX8tqP6VXQVGbV51aI5x9/TSO+2gxJqCxRRf2e5WIKEIViAUYx26+gb4fNoSxSHk7wBgbPgN3H63Lo+gPtjxhgZ71bm7Gio6QkiuVRPbXHuH5gqYEEKTT99YG/6pacx6+Ap+J+fEZcYXxzXHuwHqC1VteO/4HMwN6ORLDVRXdw/9M059ijPE11wvnv5+fR5n8DvJqau6Pc7a/HSEWKk4dRgaFRVgNKqJTWcFTEl6CSaDKawIdPGVWQqmNJjq1FwxFEJ+RjKZliSVt5vu1tW/krKzMebk4O7t0e2h60FCEaxAyAKZar8AoM8jCHaOvvGzq2RrQW1QEcwPBnfm0BEaMldVgRBMtnYEZWvveBWZFRiFkemrii/NiTxQG6kZzQxMKFl6+CqxWkg1G5kd6gDp12XhGvPyMGRkMNvehccX0LT4LoQsSxY5lhwm+luRLpc+Dyo5AzJKmJpqZdG7qIuvFLORsuwURsdG1WplHYpAmM2Yy8txdnczZnOF+64WJBmSqMysZHC6G+/oqD6+DAbIq8MzdZVhx7AuvoQQKmE8YVN5Gh3jEVR4yNPbR8+UQ1f/0oOEIliBUEnkYq9KAOnqeKk5kFZA/7ySpccCSU9OothqwT9xVV3QYYEYLBZMpaU4OlW1Q0NhfCsrV8JsNFOWUYazSyV5dSlOYxLk1tE/F+RLh4UrhKA2Px3/ZLu6kK+dLyEEyTU1LHYF+SrSzheofrDMl47+BZDfQP9sZ1iuHtTlp+OfCPKlo3+Bqhxa7FIlt3r6FyiDwNnTBVKGvTPNyGtkaK6bgAzo6l+gwkOuyV7wu7eEr6XuHpxuH406+5dWJBTBCgghqLXWIvuHScrPx5iuUzvnN9K9OEpWsrIE9aCuIJ1UW6c6ASkzzk3d1sBcW4MYHCDNbKQ0S1sFTAjVmdUY+kaUJRjvLpprkddA1+IoRmHUP7EVpJM63wmIcJhOK8y1tYihfmA5TKcV1dZqjH1q/xxLg74JhLxGupxqX5/arPjLiVeiriCdNFuwAqZgly5ZyTU1iJEhjAE/jVugCEwD6uyrZL185TfQ5VH7M9Va9fNVsBTcsqJQJ1+1NWC3YfU4aChMeAR/FKjPridjeJbken3uHgD5jXT5FqjPqte9ZLw2X3U8WbAr7s3m1iK5ppb0yREa8mM/pzgSqrOqsQ7Pq8lSa6ltCPmNdAecVGZUaC61DaGuIJ0STx+B7Gow6VN2ybU1JNvnaUiVpCXr+4411hryxp0Y8vMwZmmrzAkjv4Fugx+rKUNzqW0IdQXp1MpBAuYMsGpYO7MC5toahN9PtXtOc6ltCDXWGsomA2BK2gJDo5FukwmjMFCTpc+7qCtIp0EMIbfC0AjmPioWJsP5re1GQhGsQX1mLcWTPgLV2urOVyKQ10h3koH6NH0WPEBdfhp1DLKYpdMqQoUkTH4v+5M3OLQ8TtRn1VM6FcBbpa0UbxXyGugyJVGfqv9Qjtr8dBrFMPZM7fHuEEID9YjBrltWXXYd5VMST1Vsh8JvirwGusxm6lMKdSv0uoJ0Gg3D2DPqt8DQUHwdMtji3tV2Xbuy6iifAk9Zfvy72q5FXgNdZhMV5mySjcn62pWfQaNhGEdqmTqDRAdCIa9m36zmNT16kVAEa7BjKQuzD2ZK9btooxm5OA0G6g36rCKApnQHVuFkxKwzrgy4ypWMJteGB8rFhXpjCXkLMFOs/2g9Z04NwyYT9egbpAANuUlUifEt4ctYp7zDLeErs5byaZgp1l8dIvN30W02USf071RZl59OoxhixFylW1ZyXR0BBM0u/WeL11hrqJiSW8IXubV0m83UCf39qyw7hR2GIUZM+vtXUnExS+aULeFLKxKKYA1KJ9Se+H15Ad2yuoILj+o8nihPRkeDUIfmtPtKdcvqyygkgKBiflS3rOJJdUBHf65+vrqDUZc695JuWZVyhCQR2BK+hs1WFpMsW8JX5pQTs29r+BrFzaLBQL1b/zEeVv8s2cJBu19fWAjAThKjablbwpdhyU2+Hfq3YDw6A16GkpKod+v3hA0BD9VijPaA/v4VkNCbWUylTT9fWqFLEQghcoQQzwkhuoKv6/YXEELcLoS4sOLHJYS4L3jvB0KIvhX39uppz1bA1DdKQMDl9PnoD0dBt3sagPr58ShPRkeaTVWHnHLEdyrZRuiy+RlNyyVrrF+3rECvknEp07b5gzGgO7gHTMP8hG5ZxilVYXXSoT8E0zW5SJ+1mKzxgegPR4G7W1UfXc7YAr7mlKyt6F9MqtLkrehfnRMO+qwlZI1tAV9dKoF9OVN/WK7X1osUUL8F/YvpLowEOO0oXHU4kxYMzCzSk1FE1tggMqBf4WmBXo/gi8ALUsp64IXg76sgpXxJSrlXSrkXeDvgBJ5d8ch/Cd2XUl7Q2R7dcHd1Mp+fwlVnb/SHo6BrrotSkkibaIv+cDRMtjNvzOXspP59yjsmFhjOKYOebt2y3J1deCxJnEP/oO+a6yIFA6WTnbplMdmGT5h4eTpd90DtmFigz1qMoa9H90ANTWynLCP4A/4oT2+OrmBpct1kj9o+Wg+CpbYvz+evPt1NAzomFujLLCZpfITA4mL0D2yCEF8XM+awe/Qpg65gaXK9fQocOsMwQb7OuYqZsOvzyDonFuizlmB0OfGOvjVegV5FcC/ww+D7HwL3RXn+g8DTUkpnlOfeMrg6OnFVFtIz37MlA7UuOQ+mroJPZ3hoshVbei2904u6B2r7mB1nWRXeoSH9A7WzE1d5PmPO8S0ZqLXJuRgcE1swUNuwp1UxvSQZt+sLBbSP2VkoqUIuLuoeqO7OLjyF2diN7lWnb2lB51wnxSYrGX5PeMM+zZhow52cw1QgQ+2howNto3Ym8lWxhatTX7vcnV1ISzLT1uWJXCu65ruwGEyU+XwwcUWXLCZbCYgk+mQx7WP6+n3bqJ0Bqyq2cF+9qq9dGqFXERRKKceC78eBaOUe9wOPrbn2L0KIS0KIrwkROYsjhHhICHFGCHFmauraJFUCTifeoSHMDXW4/e51h7PHA4/fQ7+tn/qsOtA7UH0emGzHX9CMPyB1DVSfP0D7mJ3kHTtAyrDFpQUyEMB19SqmRlWZEwpVaJIlJV3zXdSH6uH1DtSxSwQKmwF0D9TWERuWHapEUO9AdbW3hfkKWfRa0TXXRV2oDHKiVZcsxi8SKNgivkZtWHaovX3cHfoUgau9naTGOqQQdM7pk9U110WNtRoj6Odr7BIyrxEvSbTp5OvKqB1jrTqD3NXRoa9dGhFVEQghnhdCXNng596Vz0nlf0f0wYUQxcBu4JkVl78E7AAOATnA30f6vJTy21LKg1LKg/n5+mqmI8Hd2QlSktu8H9BngXTNdeGTPnaWHFEX9ExsU+3g95BefRCAtjHt8WXlUQQo2tcEgOuq9o7nHRwk4HCQu/cwgK6BOuGcYNY1y87iw8ELOvhaGAfHOOlViq/2sYUoH4iMGYebUZuLopZdugeqf2EB78AgOXsOYRAGXXwt+ZbotfWys/AAGM0wflmzLLwumGzHUnGAVLNR18Tm9Qe4OrZA+Y4aDOnpuDq0K07p9+Nqbydz914yzZm6xqOUkraZNnbm7Yb0In39S0oYu4CxdB9l2Sn6FcGIjYbKAswVFbh1jEc9iKoIpJTHpJTNG/w8DkwEJ/jQRL9Zfd2Hgd9IKcPBTCnlmFRwA98HDuv7OvqwdEVZCZWH7yBJJHF1Vnsnbp1Rspqq3g5JKfoG6qhKneTVHyHVbNQ1sV0ZUUqkoaVB90BdalXfsWDfUbKSs2ifbdcsK8xXyRE1UMd1DNQgX5aKA5Tn6BuoraPqsztrCzFVlOsaqK5WlStKb9lDVWYV7TPa+eqY7SAgAzTl71Y7t+qZ2CZbIeBDlOylsShDF19dEw48/gBNZVkkNzbq4svT3490OrE0NdOY06iLr2HHMHaPnaa8Jihs0te/bMNqT6aSvewsztTlQU3aXUwuuGkqtZLc2PjH6xFEwRPAJ4PvPwk8vsmzH2VNWGiFEhGo/ILOeIA+uK5cwZiXR2pJOXXZdVyZ1t6ctpk2spKzKMkoV0vQxy9pb9jYRUjOxJBbowbqqPaOd2XEjsVkoLYgA8vOneHJSQtcbW0IkwlLfT1NuU26+GqdbsUojDRkN0DxHhjTUTcwdgEQULSbnUWZtOvha1QpzqYSK5Zdu3C1ag8puNoU15amJprzmrkyfUVzIjusOHObFF+jF5SlqgVjF9XriolNa7tCfDWXZCq+rl5F+nyaZIW4tjTtojm3mY65Djx+bbm2thnFfZivqXbwaixTDvFVrPjqn17E6dH2HUOGRogv7+Agfpv+irJ4oVcRfAV4hxCiCzgW/B0hxEEhxCOhh4QQVUA58PKaz/9ECHEZuAzkAf9dZ3t0YenKZVKamhBCqIE6o2+g7srdpVZ8Fu2GsUs6BuoF1XkNBlpKrVwZteEPaB+ou4ozMRoElpbduNvbCWhc5+BqbSO5sRFhNtOc10zPfA9Or7Y6gLaZNuqy6rAkWaD0gDpW0KVxAh+9oHbQTE6npcxK7/QitiVtVTWtI3YqclKxpphI2d2Cd3QU3/S0Jlmu1laSiotJysmhOa+ZGdcME05tpYxtM23kWnIpSC1QfC3NqvOGtWD0AliyIKuSllIrCy5f+LSseNE6YiPNbKQqN42Ult3IpSXcPT2aZLlaWxEWC8k1NTTnNeMNeDWH01pnWjEZTNRn1Su+Aj7tXvrYBRBGKGqmpdRKQCoDSwtCHvqukkxSWnYDsHRl++1hXYpASjkjpbxDSlkfDCHNBq+fkVL+pxXP9UspS6WUgTWff7uUcncw1PSAlFJfuYIOBBYX8fT0Ytmt/hnNuc0seBY0JYzdfjfdc93K+gDV8VzzMKNhQPi9yo0t3gPA3oosnB4/nRPxh4cCAUnbqJ3mUisAKbtbkF4vbg3uqJQSV1sblib1HZvzmvFLv6ZwWih+uys3uHlX6QFAavcKxi5AsVqSsrdcLW25NKxtXciVURvNpZkAywP1srYJxNXaiqVJfcfmXJWYvTytTVbbTBtNecpoUXwBI2c1yWLsApTsBSHYW6H2P7owpJUvO00lVgwGQUpwLC1d0uYNL7W2YmlsRCQl0Zyn+NLqdbZNt9GQ3YDJaNLP1+gFtb+QKWUFX3OaRF0ZtVGdl0aGxYSlWX1Hl8b+pQeJlcVBuNraQEoszcsTG2jreJ2znfikb3liKwumPobfiL9hUx1qq9vgxLYvOLGdH4x/oPbPLOJw+2guCSqCPS0ALF2Mf6B6h4cJ2O1YdgUnNh18jS2OMeeeW6E4VbKe4TNxy2JhAhbG1MQGtJRbEUIbX7YlLwMzTpqCfFl27QKjUdPE5nc48PT3h/lqzGkkyZCkiS+n10mvrXe5fxXsUnkoLRObzwMTbWFDo74ggzSzURNfPn+AtlE7u0qU4jRVVmKwWnFp4EsGArjb2sOGRnFaMTmWHE2Kc52hkVmsDqrR0r+CieIQX3npyZTnpGjiC5Qn0RTky5iZibmmRtN41IuEIggilChOCWrl2qxaLEaLpoG6Kn4Lar/y5EwYfjP+ho2eU6/Bia0yN5XsVJMmC+RcsLOGrJikoiKM+Xm4Lsff8UJWS2ig5qXkUZRWxJWZ+PkKxW/DAzU1B3JqtE1so+fVa3CgZlpM1OWna7Jwzw8qjveWK74Mqakk19fjuhT/ZBTKxaQE+TIbzTRmN9I6HX/OoWMumCgO9S+jSX1fLXxNXFFnHwcNDaNB0FKWpYmvq+MLLHn97Av2LyGUV7CkgS9PXx8BpzPsQYXCtVr4GloYYsG7sMwXKGNDC1/2EVicCo9HUF6nFr4m7C5G5pfC/QtQfF2+rHsRZLxIKIIgXJcvq/htXh6gTkfambtTkyK4OHWRHEsORWnB7Q0MBuWOalEEg6chJSd8CpIQgj3l2gbq2YFZMi1J4cO31UBt0TRQnefOI1JTw/XioMIdWvkyGUw05KzYWbX0AIyci1sWQ6fUYeIl+8OX9gb5indwnR2Yw2gQWzJQl86r75Kyd3kCac5rpnWmlYCMb7XyxcmL4c+HUXpAJTHjXWE8dFq9lh8JX9pbkUX7mD3uhYtnB5TiPFC5vNNMSstu3F1dBJzx5Y6c54J87Vv+PzbnNtNr62XRG1/+4uJUBL7m+sA5G5csBk+p15V8lWcxZnMxbotv4eKZfsXXwarls0osLbvxT0/jGxuL9LFrgoQiQLmOzrNnSdmzZ9X15rxm2mfb8cY5uM5PnudA4YHVWwOXH1aLWNxxpkEGT0LFDau2Bt5Xnk3XpIMFV3ztOjswx/7K7FVbA6e0tODp68Nvjy/Z5Tx3lpQ9LavOIGjOa2ZoYYhZV3yD69zEOZrzmldvDVx6EBZGwR7nSt7BU8q6NS/vhrqvIpvZRQ+Ds/FNRmcH5thZnLHqDIKUPS0E7Ha8A/FtqeE8e47k+nqMVmv4WnNeMw6vg975+LYzOTt5loqMCvJS8pYvlh0Anyu8Z1DMGDwJWRVgXd48bV95Fr6ADCcyY27XwByFmcmrDjuytLRAIBCumIoVS2fPYczOxlxdFb7WnNeMRMYdHjo7cZYMUwZ1WSvOGClVa0ziNjYGT4E5HQqXlco+jXmCswNzJCcZ2FWcGb6W0qLmIC3GmR4kFAHgHRnBNzFB6qGDq64fKDiA2++OK9wxvjjOiGOE/QX7V98oOwQysBy6iAWOSZjtgYojqy7vrchCSrg4FPtAtTm9dE44OFi5el/AlL3Bjnc+9nb5HQ7cVztI3bf6Ox4oVEm4cxOxDy6n10nbTNvGfMGyBRYLvC7l7lccXXU5ZNHHE8f1+QNcGJrnQMUavoLGgvNs7N9R+v0snT9Pyv41fBUovs5OxB6iCMgA5yfPs79wC/iSUj1fvoavivj5AjWxHazMWWUAaeELlEeQcmD/Kll7C/ZiEIa4+AI4N3mOvQV7MRqMyxdL9qnKn8GTccli8BSUHVRHqwaxqzgTk1Fo4GuWPeVZmJOWp2FLYwPCYsF5TmMiWyMSigBwvqFCNqmHDq26HprY3hyPPaQTmgTXDdRQpUI8AzX0bMUNqy7vr8jCaBCc6p2JvV1Ba2X/OkWwF2EysXg69kT20oWLEAiQcmD1d2zKbSIlKSUuvi5PX8Ynfev5Kt4D5gzoPxGzLMYuqO081vDVWJRBpiUpLr6uji/g9Pg5sMJtBzDX1WHMycH5xumYZbm7ugg4HKSu4asso4zC1ELenIidr975Xmxu23rFmVWhfvpeiVkWc33gmFinOAsyLFTlpsbF15htiZH5pXX9Kyk7m+T6epynY+fLNzWFd3CQ1P0HVl3PMGewI2dHXP1r1jVLn61vff9KTlfKIJ7+5bKpnMqa/mUxGdlTlhUXX0seP62j9lVhNABhNpOyby/OOMbjViChCADnmTMYrVaS61YfT5llyaI+uz4+RTB5jjRTGo3ZjatvpOZAUQv0rV1KsQkGT4IxOZz4DCHDYqKlzMrrPbHXs5/smcFsNKyKd4M6zD5l716cp2JXUM6zZ8BgIGXP6l3DTUYTe/P3xjWxnZs4h0Cwr2Df6hvGJKi8EfriGKgDr6vX8tUelNEgOFqTy2tx8gVweI0iEEKQeuQwi6dOx5wncJ5R1t1aj0AIwaGiQ7w5/mbMss5NKkMjZKSsQvUt0P8qxLpD6kDQGl6jCABurMvjdN8sPn9sskKT4Fq+AFKPHsV5/jwyxvUqzrOKr9T9+9bdO1R4iMtTl3H7Y9vx8/yE8nQj8jVyNvZw7dAbgFzXv0DxdXnEFvN6lTMDs/gCckO+0o4cxd3RgW9OW0mqFiQUAeB8801SDh1EGNbTcajwEBcmL8ScJzg9dnq9GxpCzW3KyvfEmOzqeVFNhknr9+J7W20eF4dtMecJXumc4mBVNqnm9Wfuph45gqu9PeYVjYuvvU5KSwvG9PWnRh0qOkTXXBdzrtg68enx0+zI2UGGeYOzWqtvhpkusMeYOOt5UcVu09fvRXVjbS5Ds0sMxZgneKVriobCdIqslnX30o4cwTcxEXOeYPG11zCVl2MqXX+IyaGiQ2GrNRacHjtNfko+5RkbHKVadYtarzIRY3y550VIK4D8netu3Vibi8Pt41KMeYITndPkpJnDpZArkXbkMHJpKeb1F4uvvYYhIyNcV78Sh4oO4Ql4uDQVW6Xb6fHTWIyW1RVDIVTfrBaWxeql97wISZaNFWdtLgEJp2P0Ck50TWM2GjhSs4HiPKLKzUORiu3Ada8I3H19eIeGSDt6w4b3DxUdwuV3cWEq+uKmoYUh+u393Fx688YP1NymSvUGYohLzg+p7avrjm14+8a6XPwByZv90ROzk3YXV8cXuLl+48360o4cBilxvhm94/nm5nBdvkzazTdteP9QkQqvnR6PHgqwe+xcmLzATaUby6IqyGMs7rt7QQ3oujs2vP22OpVYjcWLcnn9vNE3G5Gv1MPKIlw8Ff07BjweFk+fJv3mmzY8V/hQoeLr5Fj0PuEL+Dg5epKbSjeWRXWQr1jCQwG/mtjq7lBVbWtwQ02ualdP9IlNSskrXdPcVJe34RnFqYcOgRAsxuB1SilxnHiVtBtuWFWIEMK+wn0YhZGTo9H5klJyYvgEh4sPYzZucJxn+VEwmGL30rufh8q3gWn90bP7KrKwmAy8HgNfsLlhltLcjEhNxXk6jjCyTlz3isBxXHWC9Ntu2/D+DSU3YDKYeHkoemd5deRVgMiKoOIGtVNk70vRG9bzgnqNoAj2V2RjMRl4pTP6xPZqt3rm5vq8De+n7NmDIS0Nx8vRv+Pia6+DlKTfvPF33J23m6zkrJj4OjV6Cr/0R1YERbshNQ86n9n4/kr0nVBKNgJfdQXpFGQkx8TXm/2zuH0BborAl7m6iqSS4pj4Wjp3Dul0knbTxnyVZ5ZTba2Oia+LUxdZ8C5wc1mE/pVZola8xsLX6AW1LUUEvnLTk9lZnMnLndG3fL86vsC0wx2RL6PVimX3bhwvR1dQnu5ufOPjEQ2NTHMm+wr28fJwdL4G7AMMO4Yjj0dzqrLuu57d+P5KzA+qreQj8JWcZORQVQ6vdEXnK2SYReJLmEykHTmC4/jL27aeIKEIjh8nub4ec9nGZ4+mmdI4XHSY48PHo8o6MXyCysxKKjIrNn7AnKqs3KtPRd93qPt5tfoxv3HD2xaTkVvq83mmdZxAlH2HXuqYIjfNvKpMbSWE2Uz6rbew8OJLSP/mteOLJ05gzMoKLyRbC6PByC1lt/DK8Cv4AptvxHVi5AQZ5gxa8ls2fsBghMZ3q4Ea7WCf7ufBlLauAiYEIQTHdhXyUsdk1Pr4l65OKbe9er3bHpKVcccxFl97LerBPo4TJ8BkUl5XBNxWfhtvTryJw7N5rPrE8AmSRBJHizf+jgDsuFvlSqLVx3c/DwiouT3iI+/YVciZ/lmmHZvH41/qUJsORzI0ADLuuAPXpUt4JzbfW8lxQhlT6TdFMA5QfHXOdTLiGNlUVsgwi2hoAOx4j/K8p6OcpdH9vHqN4HECvHNXIb1Ti3RF2f7leFC53hLB4wTIOHYH3tHRbTuo5rpWBH67HefZsxG9gRBuLb+VAfvApnHcRe8ib4y/Edn6CGHXvapaY7PdSD2L0P0CNLxr1fqBtbizuYgxm4uLm+yj4/L6ebF9gnc2FW7otoeQfscd+GdmWLoQOQQmPR4Wjh8n/dZbEMYNciBB3FZ+WzjsEwm+gI9Xhl/hbSVvI8mw3j0OY8d7wG2H/k2syYBfKdfa2yFpgxBAEHc2FeH0+DnRFdkrCAQkf7gyxi0NeRu67SFkHDuG9HhwvPpaxGeklCw8+xxphw5hSFufTwnhtrLb8AV8vDa6uazjQ8fZV7hv43xKCDvuBumP7hW0P6HWtqTlRnzkzqYiAhKebd188n768jh7yrMotq4PmYSQcUxNoAsvvLCprIXnniO5sRFTcXHEZ24rvw2A40PHN5V1fOg4NdYayjLKIj+04271evV3m8qi7QnIrlK7BETAO5vUAtKnr2x+hvTTl8cozUrZMJ8SQvrtt4PBwMJzz2/eri3Cda0IFp59Fnw+Mt6xsbsXwu3lymp6tj+yC/nC4Au4/W7eVfWuzf/ojveo+uXW30Z+puNp8Dqh+QObirpjZyFJBsEfNul4xzumWPT4uWt35IEFkH7LLWAysfDscxGfcbz2GgGbjcy77tpU1o0lN2I2mHl2IDJfp8dOM+uajc5Xza3K0m9/MvIzA6+DYzwqXzfU5mJNMfH0lcjJ5/ND84zaXFH5Sj2wH6PVysJzkflyXbmCd2iIzLs352tP/h5yLDk80x958u6Y66DH1sO7KqPwVbwPMko252vyqiqDjMLXzuIMKnNTN+VrcMbJ5REbd+8u2lSWuaYGc1XVpnx5R0ZYOn8+av+qzKykxlqz6XicWJzgjfE3ovevrHJVlbcZX44plUdo/sCmhllhpoUDldmbKgKb08ur3dPc3VK8cZ4niKScHFL272Phuee2JTx0XSsC228fx1xdHd5xNBKK0oo4XHSY33b/NuJ2AE/1PkVpeil78vdseD+MtFw1uV35VeQyv0u/gIzidfXKa2FNMXFTfR6PXxiNWOb363PD5KaZw8m/SDBmZJB+6y3YnnwyYpmf/cknMVqtpN2webvSTGncUXkHT/U+FbHM76nep8gwZ0SOd4dgSlFW25VfgydCxc+lnytl0bD5oDcZDbxzVyHPtk7gcG8ctvr1uWGSkwwc27X5qasiKYmMO+9k4fnnI67Ktj3xJJhMZBzb3NAwGozcVX0XLw29FLHa6qnep0gSSbyz6p2bysLXDSFKAAAR20lEQVRggOb3Q9czakHiRrj8CxAG2LX5EeNCCO7aXczrPTMRt0/41blhhCCq4hRCkHnXXThPncYzvHFIx/a7pwDIvOvdm8oCuKf2Hs5NnmPAvnHl1tN9TyOR3F1zd1RZNH8ARs4oBbkRrvxKLQZten9UUXftVmcYRzqs5olLo3j9kve0bM4XgPXuu3F3deG6ovNYzRhw3SoCd3c3zjNnsN5776aaOYT76u5j2DHMG+PrF3r02fo4OXqS99a+NyZZ7HsQ5gegewPraLZXxcT3PaBi5FHwscMVjNtdPN++ftCPzi/xfPsEHz5UTpIx+r86+8Mfxj87y8KLL667552YxP7sc1jvuw9hjhx+CeG+uvuwe+w8P7DetZ1ZmuGZ/md4d9W7V28rEQkHPqXCQ62/Xn/POQuXfwm7PwjmyOGXED56pAKH28dvz6+fjBZcXn5zfoT37ikh02KKKivrwx9Culxqwl8Dv2MR229+Q+Y737lqW4lIuK/uPnwBH0/0PLHu3pJvid92/5Zbym4h25K9wafX4MCnVFnk+R+vv+d1wdkfQsOdkBHtiHG4/1A5/oDkZ2+u347d6w/w2BuD3NqQT1l26gafXo2sDyoPZP6X/2fdPenzMfezn5F69Cjm8g1KY9fgvbXvxSAM/KrrV+vu+QN+ft7xc/bk76EyszKqLPZ8TFUPnfvh+nuBALz5HbUgtGh9OetavH9fKclJBn58ar2CklLy45MDNJdmsrs0ep/IfM97ECkpzP/i59G/g05ct4pg5juPIFJSyPrIh2N6/h2V7yAvJY9HLj2y7t6jbY9iMpj4SONHYvvjO+9R7vtr/3t90vjUN5UCOPhnMYl6+44CSqwWvv1KzzoX8ruvqpzGxw5HSF6vQdrb3oapvJyZb39nnay5H/8Y/H6yP/6xmGQdLT5KjbWGRy4/ss6LeuzqY3gCHh7Y9UBMsqi8UdW6v/a/VD5gJd78LviW4MhnYhK1rzyLppJMvvdqH941XtSPTw3i9Ph54GgMkwdqJ1HLnhZmv//9dV6U7Ve/JOBwkPNgbN+xMaeRA4UHeLT10XVe1OPdjzPvnucTTZ+ISRZ59VB9K5z+1nov6tLPwTkdM1+VuWnc2pDPj08NrPOiHr8wyuSCmwdj5MtUUkL67bcz99jP1nlR9j88g29sLGa+ClILOFZxjF90/AKbe/VahxeHXmTYMcwndsXIV3o+NN0H5x6FxTX5o65nYKYbjnw2JlHZaWbu2VPCr8+NMLmw2ot6uXOKjokFHjxaGZPBaMzIwHrPPdgefwLv+OZ5B73QpQiEEB8SQrQKIQJCiIObPHenEKJDCNEthPjiiuvVQojTwes/F0JENzW3AEtXWrH97ndkf/hDJGXHYGEBliQLn276NKfHT3NieLmuvWO2g990/Yb31b+P3JTNwy9hGE1w0xdg4FWV5AxhqhPOfE95A5klMYlKMhr4mzvqOTc4vyo2OTjj5EcnB/jQgXLKc6JbawDCaCTvr/8KV1sb9t8tt8szPMLsD39I5t13Y66ITakYhIGHWh6ie76bx7uXTzAddYzyaNujHKs4RrW1OiZZCAG3f0mV7517dPn6wji89q/QeJc6hzYmUYL/61gDvdOLPPbGspU743DzjePdvH1HAXvWrL7eDPmf+zzekRFmf/rT8DX//DzT3/gmqTccxbInSqhwBT6757NMLk3yo7Yfha/Z3Da+efGb7CvYt35bic1w25fU9hEnv758zb0AL/2L2nCt+taYRX3hWD3TDg///vLywUpLHj9ffbaDPWVWbm8siFlW/uf+moDNxsy3vx2+FnC5mPrqV0lubIxauLESn9nzGRa9i3zr4rfC11w+F187+zWqMqu4oyJyhc863PJ3Ki93/CvL13weePYfIac2ahhtJT53ex1ef4CvPbd8mprPH+ArT1+lIieV9+3bJHm9BnmfeQgpJVP/+r9i/owmSCk1/wA7gUbgOHAwwjNGoAeoAczARWBX8N4vgPuD778F/GUsf/fAgQNSK7zT07L7rrtl5823SJ/NFtdnXT6XvO+398nbfn6bHLQPytmlWfm+x98nb37sZjnvmo+vIT6PlF8/IuX/UyfldLeUizNSfvMmKf9HuZQLk3GJ8vr88t3/+opsefgZ2Tlul/NOj3zv/3dCNv3XP8ix+aW4ZAV8Ptn7oQ/LqwcPyaWODumz22XfR+6X7Xv3Sc/YWFyyfH6f/MTvPyGP/OSIvDpzVTo8DvnJpz8pD/34kBxZGIlLlgwEpPz+3VL+9yIpR85J6XZI+YP3SPnP+Yq/uEQF5Me/c0o2fPn38uzArFzy+OQDj5yS9f/we9kxbo9b1uBDn5Htzbvl4tmz0r+0JAcf+oxs29Ukl652xC3rCy9+Qe59dK98c+xN6fa55edf+Lxs+WGLvDpzNS5ZUkopf/FJKR/OlrL7RSm9bil/9oCU/2SVcuhM3KL+9rFzsuZLT8kXr05Ij88vP//Tc7Lqi7+Tp3tn4pY18g//INt27JT2F16UAa9Xjvzd38m2xh3ScfJU3LL+28n/Jpt/0Cyf739eev1e+Y+v/qNs/kGzPDl6Mm5Z8vd/J+U/ZUp5+ZdS+n1SPvkF9XvHH+Jv15OtsvLvfyd/dXZI+v0B+U+PX5GVf/87+fTl0bhlTfy/X5VtjTvk3C9/Gfdn1wI4IzeYU4Xcgoy0EOI48H9LKdcd+SOEuAF4WEr5ruDvXwre+gowBRRJKX1rn9sMBw8elGfOxH+60Ng/PYztySfB76f83/+dtKPr9wyJhs65Tj79h0+z5FsiyZCEL+Dj63d8nRtLboxbFpNX4ft3qr1OjGa1IOojP4GGKAnBDTA06+S+f3sNu8uL2WjA4w/wjY8f4B1Rkp4bwTM8Qv/99+Ofn8eQnEzA5aL0q18l813xt2vUMcqDTz/IzNIMliQLS74lvnLzV3h3dfSE4DrYx+CRY+oEMnMaeBxw3zdhz/1xi5p2uLnv315jdH6JNHMSDo+P//n+Fj58KHp8ei18c3P0f+R+vMPDGNLSCCwsUPTww2TfH2OocAXmXfM8+PSDDNgHSDens+BZ4IuHv8jHd348blm4bPDIO5QnZclUv7/zX+DGz8UtatHt44PfOkn7mB1rignbkpe/v3MHf3lbbdyyAk4n/Q88gLutHYPVSsBmI+9vPk/+X/1V3LKWfEv82R/+jCszV8g0Z2L32PmL3X/B3+z/m7hl4XPDD96jThJMyYalOXjb38I7/jluUR5fgAe/e5rTfbNkpZqYd3r585uq+cf37IpblvR6GfyLh3CeOoW5upqyb/wbydUxetNrIIQ4K6VcF73ZDkXwQeBOGTzDWAjxIHAEeBg4JaWsC14vB56WUm6YkRFCPAQ8BFBRUXFgIM794AGmv/0dvGOjZH/0o1gaItcDR8PwwjA/vfpTPH4PH2r4EI05Gy/6ignzg3D635VbeuBT6zaYiwdjtiW+92ofDrefjx4up6Us9hDHWngnJpj70Y/w2xfI+sD7153VEA+mnFP8pP0nzLvnua/uPvYW7I3+oUhwTMGpb6g4956PQeXmFUybYXbRw3df7WV6wcP79pdyNEpl1Wbwzc0x96Mf4Z2YwHrPPaQd3WTRVxTY3DZ+0v4TxhfHubP6Tm1GRggum8o7zQ9B0/ugfvMKps3gcPv43qt9DM46eXdzEXfsjN/ICCGwuMjsj36MZ2CAjHccI+Ptb9csy+l18tOrP6Xf1s/t5bdzR2UcIaG18C6p8TjVoarQdt27acnoZnD7/Dz6+gDt43Zuayzgniglo5sh4PEw99OfsnT2LEUPP0xSrra+qlkRCCGeBzYqEv6ylPLx4DPHucaKYCW0egQJJJBAAtczIimCTZZ0KkgptZsQCiPASn+7LHhtBsgSQiRJKX0rrieQQAIJJLCN2I7y0TeB+mCFkBm4H3gimLh4Cfhg8LlPAo9HkJFAAgkkkMA1gt7y0fcJIYaBG4CnhBDPBK+XCCF+DxC09j8HPAO0A7+QUoaWyv098J+FEN1ALvBdPe1JIIEEEkggfmxJsni7kcgRJJBAAgnEj0g5gut2ZXECCSSQQAIKCUWQQAIJJHCdI6EIEkgggQSucyQUQQIJJJDAdY7/kMliIcQUEP/SYoU8IPrBtduPRLviQ6Jd8SHRrvjwp9quSinlujMy/0MqAj0QQpzZKGv+ViPRrviQaFd8SLQrPlxv7UqEhhJIIIEErnMkFEECCSSQwHWO61ERfDv6I28JEu2KD4l2xYdEu+LDddWu6y5HkEACCSSQwGpcjx5BAgkkkEACK5BQBAkkkEAC1zn+pBSBEOJOIUSHEKJbCPHFDe4nCyF+Hrx/WghRteLel4LXO4QQUY/L3OJ2/WchRJsQ4pIQ4gUhROWKe34hxIXgzxPb3K5PCSGmVvz9/7Ti3ieFEF3Bn09uc7u+tqJNnUKI+RX3rglfQojvCSEmhRBXItwXQoj/HWzzJSHE/hX3riVX0dr18WB7LgshXhdC7Flxrz94/YIQYkt3cYyhXbcJIWwr/lf/dcW9Tf//17hd/2VFm64E+1NO8N615KtcCPFScB5oFUL87QbPXLs+ttFBxv8RfwAj0APUAGbgIrBrzTN/BXwr+P5+4OfB97uCzycD1UE5xm1s1+1AavD9X4baFfzd8Rby9Sng6xt8NgfoDb5mB99nb1e71jz/eeB728DXLcB+4EqE+3cBTwMCOAqcvtZcxdiuG0N/D3h3qF3B3/uBvLeIr9uA3+n9/291u9Y8ew/w4jbxVQzsD77PADo3GI/XrI/9KXkEh4FuKWWvlNID/Ay4d80z9wI/DL7/JXCHEEIEr/9MSumWUvYB3UF529IuKeVLUkpn8NdTqNParjVi4SsS3gU8J6WclVLOAc8Bd75F7foo8NgW/e2IkFK+Asxu8si9wKNS4RTq9L1iri1XUdslpXw9+Hdh+/pWLHxFgp5+udXt2pa+BSClHJNSngu+X0Cd3VK65rFr1sf+lBRBKTC04vdh1hMZfkaqA3NsqANxYvnstWzXSvw5SuuHYBFCnBFCnBJC3LdFbYqnXR8IuqG/FOpc6Xg+ey3bRTCEVg28uOLyteIrGiK1+1pyFS/W9i0JPCuEOCuEeOgtaM8NQoiLQoinhRBNwWt/FHwJIVJRk+mvVlzeFr6EClnvA06vuXXN+ljUM4sT2D4IIR4ADgK3rrhcKaUcEULUAC8KIS5LKXu2qUlPAo9JKd1CiM+gvKm3b9PfjgX3A7+UUvpXXHsr+fqjhRDidpQiuGnF5ZuCXBUAzwkhrgYt5u3AOdT/yiGEuAv4LVC/TX87FtwDvCalXOk9XHO+hBDpKOXzBSmlfStlb4Y/JY9gBChf8XtZ8NqGzwghkgArMBPjZ69luxBCHAO+DLxXSukOXZdSjgRfe4HjKEthW9olpZxZ0ZZHgAOxfvZatmsF7meN634N+YqGSO2+llzFBCFEC+r/d6+UciZ0fQVXk8Bv2LpwaFRIKe1SSkfw/e8BkxAijz8CvoLYrG9dE76EECaUEviJlPLXGzxy7frYtUh8vBU/KO+mFxUqCCWZmtY889esThb/Ivi+idXJ4l62LlkcS7v2oRJk9WuuZwPJwfd5QBdblDiLsV3FK96/Dzgll5NTfcH2ZQff52xXu4LP7UAl78R28BWUWUXk5OfdrE7kvXGtuYqxXRWonNeNa66nARkr3r8O3LmN7SoK/e9QE+pgkLuY/v/Xql3B+1ZUHiFtu/gKfvdHgX/d5Jlr1se2jNw/hh9UVr0TNal+OXjtn1FWNoAF+D/BgfEGULPis18Ofq4DePc2t+t5YAK4EPx5Inj9RuBycDBcBv58m9v1P4DW4N9/Cdix4rN/FuSxG/j0drYr+PvDwFfWfO6a8YWyDscALyoG++fAZ4HPBu8L4N+Cbb4MHNwmrqK16xFgbkXfOhO8XhPk6WLwf/zlbW7X51b0rVOsUFQb/f+3q13BZz6FKh5Z+blrzddNqBzEpRX/q7u2q48ltphIIIEEErjO8aeUI0gggQQSSEADEooggQQSSOA6R0IRJJBAAglc50goggQSSCCB6xwJRZBAAgkkcJ0joQgSSCCBBK5zJBRBAgkkkMB1jv8furgMtJITn34AAAAASUVORK5CYII=\n",
       "text/plain": [
@@ -2785,29 +2768,27 @@
      },
      "metadata": {
       "needs_background": "light"
-     }
+     },
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df.plot()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "goaaXKMXVjUq",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 423
     },
+    "id": "goaaXKMXVjUq",
     "outputId": "e3c5e802-dd8e-4fb3-8598-0dd8be598f66"
    },
-   "source": [
-    "df['Max'] = df.max(axis=1)\n",
-    "df['Min'] = df.min(axis=1)\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -2958,9 +2939,15 @@
        "[1001 rows x 6 columns]"
       ]
      },
+     "execution_count": 76,
      "metadata": {},
-     "execution_count": 76
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df['Max'] = df.max(axis=1)\n",
+    "df['Min'] = df.min(axis=1)\n",
+    "df"
    ]
   },
   {
@@ -2976,18 +2963,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "Ilzy8VvZDgt0"
    },
+   "outputs": [],
    "source": [
     "!pip install --upgrade -q plotly\n",
     "import plotly.express as px"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2996,13 +2984,8 @@
     "id": "7XF4YcNIE1Hn",
     "outputId": "6c694dac-a715-472b-a2cb-37b29b113858"
    },
-   "source": [
-    "px.line(df).show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -3038,8 +3021,12 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "px.line(df).show()"
    ]
   },
   {
@@ -3053,6 +3040,7 @@
     "This dataset was discussed in a blog on [vibration metrics and used bearing data as an example](https://blog.endaq.com/top-vibration-metrics-to-monitor-how-to-calculate-them).\n",
     "\n",
     "Note you don't *have* to use a CSV. They have a lot of other file formats natively supported ([see full list](https://pandas.pydata.org/docs/user_guide/io.html)):\n",
+    "\n",
     "* hdf\n",
     "* feather\n",
     "* pickle\n",
@@ -3062,22 +3050,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "8Yiph7IODh4E",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 455
     },
+    "id": "8Yiph7IODh4E",
     "outputId": "c87e5403-aeb5-4a33-a402-8971ecb52c85"
    },
-   "source": [
-    "df = pd.read_csv('https://info.endaq.com/hubfs/Plots/bearing_data.csv', index_col=0)\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -3212,9 +3195,14 @@
        "[120000 rows x 4 columns]"
       ]
      },
+     "execution_count": 79,
      "metadata": {},
-     "execution_count": 79
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = pd.read_csv('https://info.endaq.com/hubfs/Plots/bearing_data.csv', index_col=0)\n",
+    "df"
    ]
   },
   {
@@ -3230,14 +3218,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "rB5uIDRt6CJe"
    },
+   "outputs": [],
    "source": [
     "df.to_csv('bearing-data.csv')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -3250,6 +3238,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3258,13 +3247,8 @@
     "id": "TVD8WFpvHqs-",
     "outputId": "17bbd709-f79a-4d6e-f0e1-bb42f01d3242"
    },
-   "source": [
-    "df.describe()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -3364,13 +3348,18 @@
        "max         0.917908       1.124376       0.594025       0.251382"
       ]
      },
+     "execution_count": 81,
      "metadata": {},
-     "execution_count": 81
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.describe()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -3378,13 +3367,8 @@
     "id": "6fiVPnBNJb32",
     "outputId": "df0b8b39-f9df-44bf-c236-7695d375cae4"
    },
-   "source": [
-    "df.std()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Fault_021    0.198383\n",
@@ -3394,13 +3378,18 @@
        "dtype: float64"
       ]
      },
+     "execution_count": 82,
      "metadata": {},
-     "execution_count": 82
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.std()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -3408,13 +3397,8 @@
     "id": "oQgXuQ9VJhTd",
     "outputId": "537e189f-46b5-4945-808d-705f1932e4f0"
    },
-   "source": [
-    "df.max()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Fault_021    0.917908\n",
@@ -3424,9 +3408,13 @@
        "dtype: float64"
       ]
      },
+     "execution_count": 83,
      "metadata": {},
-     "execution_count": 83
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.max()"
    ]
   },
   {
@@ -3440,6 +3428,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -3447,13 +3436,8 @@
     "id": "TUsz_I4ptfo3",
     "outputId": "bd9f9729-ecf7-4899-8113-ca5a5cc4ffe0"
    },
-   "source": [
-    "np.max(df)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Fault_021    0.917908\n",
@@ -3463,13 +3447,18 @@
        "dtype: float64"
       ]
      },
+     "execution_count": 84,
      "metadata": {},
-     "execution_count": 84
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "np.max(df)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -3477,13 +3466,8 @@
     "id": "cEG3SeRAJkyW",
     "outputId": "33ef1359-42c7-41f7-d908-5a753168ac5f"
    },
-   "source": [
-    "df.quantile(0.25)"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Fault_021   -0.107020\n",
@@ -3493,13 +3477,18 @@
        "Name: 0.25, dtype: float64"
       ]
      },
+     "execution_count": 85,
      "metadata": {},
-     "execution_count": 85
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.quantile(0.25)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3508,14 +3497,8 @@
     "id": "Shx-sdauJllV",
     "outputId": "8f8d4f7b-5071-4df5-c5d2-4c7ef7ae0a49"
    },
-   "source": [
-    "df['abs(max)'] = df.abs().max(axis=1)\n",
-    "df "
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -3663,9 +3646,14 @@
        "[120000 rows x 5 columns]"
       ]
      },
+     "execution_count": 86,
      "metadata": {},
-     "execution_count": 86
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df['abs(max)'] = df.abs().max(axis=1)\n",
+    "df "
    ]
   },
   {
@@ -3680,6 +3668,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3688,13 +3677,8 @@
     "id": "-u2YH6_WMxdX",
     "outputId": "6b4dd652-7842-4961-ee70-2c8bb4970ca9"
    },
-   "source": [
-    "df[0: 0.05]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -3842,9 +3826,13 @@
        "[600 rows x 5 columns]"
       ]
      },
+     "execution_count": 87,
      "metadata": {},
-     "execution_count": 87
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df[0: 0.05]"
    ]
   },
   {
@@ -3858,6 +3846,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3866,13 +3855,8 @@
     "id": "aH5m-nHdM6MV",
     "outputId": "97f1fc33-f5aa-42ca-83f5-d1e8b2919da6"
    },
-   "source": [
-    "df[0: 0.05: 100]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -3972,9 +3956,13 @@
        "0.041667  -0.289975  -0.227409   0.088202  0.016898  0.289975"
       ]
      },
+     "execution_count": 88,
      "metadata": {},
-     "execution_count": 88
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df[0: 0.05: 100]"
    ]
   },
   {
@@ -3988,6 +3976,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -3996,13 +3985,8 @@
     "id": "VgZB15g6LQTY",
     "outputId": "23123f3d-7038-4e4c-86b7-b8bba57e093e"
    },
-   "source": [
-    "df.iloc[0:10]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -4138,9 +4122,13 @@
        "0.000750   0.021487   0.092426   0.027452  0.044018  0.092426"
       ]
      },
+     "execution_count": 89,
      "metadata": {},
-     "execution_count": 89
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.iloc[0:10]"
    ]
   },
   {
@@ -4155,6 +4143,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -4163,14 +4152,8 @@
     "id": "QeIgZF4WNo7K",
     "outputId": "59361aae-3320-48b6-8716-e68971845511"
    },
-   "source": [
-    "n = int(df.shape[0] / 100)\n",
-    "df.rolling(n).max()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -4318,13 +4301,19 @@
        "[120000 rows x 5 columns]"
       ]
      },
+     "execution_count": 90,
      "metadata": {},
-     "execution_count": 90
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "n = int(df.shape[0] / 100)\n",
+    "df.rolling(n).max()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -4333,13 +4322,8 @@
     "id": "eke1fPqkN_NS",
     "outputId": "e238d753-2fcb-4119-90b4-b8e34c98b900"
    },
-   "source": [
-    "df.rolling(n).max()[::n]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -4487,13 +4471,18 @@
        "[100 rows x 5 columns]"
       ]
      },
+     "execution_count": 91,
      "metadata": {},
-     "execution_count": 91
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.rolling(n).max()[::n]"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -4502,13 +4491,8 @@
     "id": "ZX7LWaYlL-eH",
     "outputId": "dcf2ba3c-08ed-46a2-e1b6-8ab978787f0a"
    },
-   "source": [
-    "px.line(df.rolling(n).max()[::n]).show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -4544,8 +4528,12 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "px.line(df.rolling(n).max()[::n]).show()"
    ]
   },
   {
@@ -4561,31 +4549,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "jSQFF4_PMFyX",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "jSQFF4_PMFyX",
     "outputId": "e290bbf0-00e8-46ab-b733-d8652f8a0c3f"
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[K     |████████████████████████████████| 6.3 MB 56.8 MB/s \n",
+      "\u001b[?25h  Building wheel for yfinance (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install -q yfinance\n",
     "import yfinance as yf"
-   ],
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\u001B[K     |████████████████████████████████| 6.3 MB 56.8 MB/s \n",
-      "\u001B[?25h  Building wheel for yfinance (setup.py) ... \u001B[?25l\u001B[?25hdone\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -4594,23 +4583,15 @@
     "id": "NBd9jY74MOs_",
     "outputId": "34453976-3b01-4b41-ce61-3b936aa5ba08"
    },
-   "source": [
-    "df =  yf.download([\"SPY\", \"AAPL\", \"MSFT\", \"AMZN\", \"GOOGL\"],\n",
-    "                  start='2019-01-01',\n",
-    "                  end='2021-09-24') \n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[*********************100%***********************]  5 of 5 completed\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -5097,9 +5078,16 @@
        "[688 rows x 30 columns]"
       ]
      },
+     "execution_count": 94,
      "metadata": {},
-     "execution_count": 94
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df =  yf.download([\"SPY\", \"AAPL\", \"MSFT\", \"AMZN\", \"GOOGL\"],\n",
+    "                  start='2019-01-01',\n",
+    "                  end='2021-09-24') \n",
+    "df"
    ]
   },
   {
@@ -5113,6 +5101,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5121,15 +5110,8 @@
     "id": "KA6yCs-IPqpD",
     "outputId": "5309f784-3917-4125-f1a9-f39b56fb3372"
    },
-   "source": [
-    "df = df['Adj Close']\n",
-    "df = df / df.iloc[0]\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -5277,13 +5259,20 @@
        "[688 rows x 5 columns]"
       ]
      },
+     "execution_count": 95,
      "metadata": {},
-     "execution_count": 95
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = df['Adj Close']\n",
+    "df = df / df.iloc[0]\n",
+    "df"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5292,13 +5281,8 @@
     "id": "GwRWHNPUQj1I",
     "outputId": "4bf45621-d8e6-4720-d389-3f17ebcd1383"
    },
-   "source": [
-    "px.line(df).show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -5334,8 +5318,12 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "px.line(df).show()"
    ]
   },
   {
@@ -5349,6 +5337,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5357,13 +5346,8 @@
     "id": "FL9eZOutQzso",
     "outputId": "36661409-e636-4055-e6b7-7bd68c046329"
    },
-   "source": [
-    "px.line(df.rolling('40d').mean()).show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -5399,8 +5383,12 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "px.line(df.rolling('40d').mean()).show()"
    ]
   },
   {
@@ -5414,19 +5402,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "ZQpQ7EJIRAJP"
    },
+   "outputs": [],
    "source": [
     "from datetime import date\n",
     "start = date(2021, 4, 1)\n",
     "end = date(2021, 4, 30)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5435,13 +5424,8 @@
     "id": "1YU6TiEcRzPa",
     "outputId": "96ee05aa-e1a9-4e69-cf17-2d62f5e1c9b9"
    },
-   "source": [
-    "df[start:end]"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -5676,13 +5660,18 @@
        "2021-04-30  3.414100  2.252844  2.231482  2.563443  1.736994"
       ]
      },
+     "execution_count": 99,
      "metadata": {},
-     "execution_count": 99
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df[start:end]"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -5690,13 +5679,8 @@
     "id": "aJWvXHmlcGtV",
     "outputId": "7564cf85-46c9-482b-e30c-895d888a17c3"
    },
-   "source": [
-    "pd.date_range(start='1/1/2019', end='08/31/2021', freq='M')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "DatetimeIndex(['2019-01-31', '2019-02-28', '2019-03-31', '2019-04-30',\n",
@@ -5710,13 +5694,18 @@
        "              dtype='datetime64[ns]', freq='M')"
       ]
      },
+     "execution_count": 100,
      "metadata": {},
-     "execution_count": 100
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "pd.date_range(start='1/1/2019', end='08/31/2021', freq='M')"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5725,13 +5714,8 @@
     "id": "Q1KZmgV4cVGe",
     "outputId": "6c89eb55-ca9f-4df1-ffce-dfb308d16ff4"
    },
-   "source": [
-    "df.resample(rule='Q').max()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -5876,9 +5860,13 @@
        "2021-09-30  4.082358  2.424363  2.753736  3.115720  1.892556"
       ]
      },
+     "execution_count": 101,
      "metadata": {},
-     "execution_count": 101
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.resample(rule='Q').max()"
    ]
   },
   {
@@ -5893,6 +5881,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -5901,14 +5890,8 @@
     "id": "PI9EYy7JSgeo",
     "outputId": "6936608c-279b-44e3-e0ad-f6faeff55be9"
    },
-   "source": [
-    "df = pd.read_csv('https://info.endaq.com/hubfs/data/endaq-cloud-table.csv')\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -6730,13 +6713,19 @@
        "[23 rows x 29 columns]"
       ]
      },
+     "execution_count": 102,
      "metadata": {},
-     "execution_count": 102
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = pd.read_csv('https://info.endaq.com/hubfs/data/endaq-cloud-table.csv')\n",
+    "df"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -6744,13 +6733,8 @@
     "id": "TrjLYbATgLDi",
     "outputId": "7154d956-2df0-4a0b-a04c-b70ac0be95fb"
    },
-   "source": [
-    "df.columns"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Index(['Unnamed: 0', 'tags', 'id', 'serial_number_id', 'file_name',\n",
@@ -6765,9 +6749,13 @@
        "      dtype='object')"
       ]
      },
+     "execution_count": 103,
      "metadata": {},
-     "execution_count": 103
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df.columns"
    ]
   },
   {
@@ -6781,6 +6769,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -6789,19 +6778,8 @@
     "id": "6BUQuL9kgQ6z",
     "outputId": "72f73913-1a57-4804-f69d-c92882d80b0b"
    },
-   "source": [
-    "df = df[['serial_number_id', 'file_name', 'file_size', 'recording_length', 'recording_ts',\n",
-    "         'accelerationPeakFull', 'psuedoVelocityPeakFull', 'accelerationRMSFull',\n",
-    "         'velocityRMSFull', 'displacementRMSFull', 'pressureMeanFull', 'temperatureMeanFull']].copy()\n",
-    "\n",
-    "df['recording_ts'] = pd.to_datetime(df['recording_ts'], unit='s')         \n",
-    "df = df.sort_values(by=['recording_ts'], ascending=False)      \n",
-    "df   "
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -7215,9 +7193,19 @@
        "[23 rows x 12 columns]"
       ]
      },
+     "execution_count": 104,
      "metadata": {},
-     "execution_count": 104
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = df[['serial_number_id', 'file_name', 'file_size', 'recording_length', 'recording_ts',\n",
+    "         'accelerationPeakFull', 'psuedoVelocityPeakFull', 'accelerationRMSFull',\n",
+    "         'velocityRMSFull', 'displacementRMSFull', 'pressureMeanFull', 'temperatureMeanFull']].copy()\n",
+    "\n",
+    "df['recording_ts'] = pd.to_datetime(df['recording_ts'], unit='s')         \n",
+    "df = df.sort_values(by=['recording_ts'], ascending=False)      \n",
+    "df   "
    ]
   },
   {
@@ -7231,6 +7219,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -7239,14 +7228,8 @@
     "id": "3oe0EgX0gyfz",
     "outputId": "7008ef1a-9396-4183-c7c8-23f08a4b050f"
    },
-   "source": [
-    "mask = df.recording_ts > pd.to_datetime('2021-01-01')\n",
-    "df[mask].sort_values(by=['serial_number_id'], ascending=False)      "
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -7500,13 +7483,19 @@
        "[13 rows x 12 columns]"
       ]
      },
+     "execution_count": 105,
      "metadata": {},
-     "execution_count": 105
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "mask = df.recording_ts > pd.to_datetime('2021-01-01')\n",
+    "df[mask].sort_values(by=['serial_number_id'], ascending=False)      "
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -7515,14 +7504,8 @@
     "id": "ug9gKCKQhW7K",
     "outputId": "f8b91607-0276-4304-a49c-add75954c180"
    },
-   "source": [
-    "mask = (df.recording_ts > pd.to_datetime('2021-01-01')) & (df.accelerationPeakFull > 100)\n",
-    "df[mask].sort_values(by=['accelerationPeakFull'], ascending=False)    "
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -7664,9 +7647,14 @@
        "[6 rows x 12 columns]"
       ]
      },
+     "execution_count": 106,
      "metadata": {},
-     "execution_count": 106
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "mask = (df.recording_ts > pd.to_datetime('2021-01-01')) & (df.accelerationPeakFull > 100)\n",
+    "df[mask].sort_values(by=['accelerationPeakFull'], ascending=False)    "
    ]
   },
   {
@@ -7680,28 +7668,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "thTJcMe0kDWT",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 542
     },
+    "id": "thTJcMe0kDWT",
     "outputId": "4458ed52-eda1-4d5b-a27d-84d38c0b77b6"
    },
-   "source": [
-    "px.scatter(df, \n",
-    "           x=\"recording_ts\", \n",
-    "           y=\"accelerationRMSFull\",\n",
-    "           size=\"recording_length\", \n",
-    "           color=\"serial_number_id\",\n",
-    "           hover_name=\"file_name\", \n",
-    "           log_y=True, \n",
-    "           size_max=60).show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -7737,8 +7714,19 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "px.scatter(df, \n",
+    "           x=\"recording_ts\", \n",
+    "           y=\"accelerationRMSFull\",\n",
+    "           size=\"recording_length\", \n",
+    "           color=\"serial_number_id\",\n",
+    "           hover_name=\"file_name\", \n",
+    "           log_y=True, \n",
+    "           size_max=60).show()"
    ]
   },
   {
@@ -7752,6 +7740,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -7760,22 +7749,8 @@
     "id": "HmeGuksDd8PK",
     "outputId": "b895aea4-a574-4f33-e8fd-4ddd0056b7b7"
    },
-   "source": [
-    "df['device'] = df[\"serial_number_id\"].astype(str)\n",
-    "\n",
-    "px.scatter(df, \n",
-    "           x=\"recording_ts\", \n",
-    "           y=\"accelerationRMSFull\",\n",
-    "           size=\"recording_length\", \n",
-    "           color=\"device\",\n",
-    "           hover_name=\"file_name\", \n",
-    "           log_y=True, \n",
-    "           size_max=60).show()\n"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -7811,8 +7786,21 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df['device'] = df[\"serial_number_id\"].astype(str)\n",
+    "\n",
+    "px.scatter(df, \n",
+    "           x=\"recording_ts\", \n",
+    "           y=\"accelerationRMSFull\",\n",
+    "           size=\"recording_length\", \n",
+    "           color=\"device\",\n",
+    "           hover_name=\"file_name\", \n",
+    "           log_y=True, \n",
+    "           size_max=60).show()\n"
    ]
   },
   {
@@ -7839,42 +7827,42 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "qVKyNUT9cvKA",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "qVKyNUT9cvKA",
     "outputId": "887fddf9-bab4-4953-adb9-1974705ca840"
    },
-   "source": [
-    "!pip install -q endaq"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  Installing build dependencies ... \u001B[?25l\u001B[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001B[?25l\u001B[?25hdone\n",
-      "    Preparing wheel metadata ... \u001B[?25l\u001B[?25hdone\n",
-      "  Installing build dependencies ... \u001B[?25l\u001B[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001B[?25l\u001B[?25hdone\n",
-      "    Preparing wheel metadata ... \u001B[?25l\u001B[?25hdone\n",
-      "  Installing build dependencies ... \u001B[?25l\u001B[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001B[?25l\u001B[?25hdone\n",
-      "    Preparing wheel metadata ... \u001B[?25l\u001B[?25hdone\n",
-      "  Installing build dependencies ... \u001B[?25l\u001B[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001B[?25l\u001B[?25hdone\n",
-      "    Preparing wheel metadata ... \u001B[?25l\u001B[?25hdone\n",
-      "\u001B[K     |████████████████████████████████| 92 kB 1.1 MB/s \n",
-      "\u001B[K     |████████████████████████████████| 81 kB 11.1 MB/s \n",
-      "\u001B[?25h  Building wheel for endaq (PEP 517) ... \u001B[?25l\u001B[?25hdone\n",
-      "  Building wheel for endaq-calc (PEP 517) ... \u001B[?25l\u001B[?25hdone\n",
-      "  Building wheel for endaq-cloud (PEP 517) ... \u001B[?25l\u001B[?25hdone\n",
-      "  Building wheel for endaq-ide (PEP 517) ... \u001B[?25l\u001B[?25hdone\n"
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[K     |████████████████████████████████| 92 kB 1.1 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 81 kB 11.1 MB/s \n",
+      "\u001b[?25h  Building wheel for endaq (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Building wheel for endaq-calc (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Building wheel for endaq-cloud (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
+      "  Building wheel for endaq-ide (PEP 517) ... \u001b[?25l\u001b[?25hdone\n"
      ]
     }
+   ],
+   "source": [
+    "!pip install -q endaq"
    ]
   },
   {
@@ -7888,41 +7876,43 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "l-GXnXDQun1O",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "l-GXnXDQun1O",
     "outputId": "19f6b56c-2e65-4ce6-ac10-dd353834be5e"
    },
-   "source": [
-    "! python -m pip install -U -q numpy scipy plotly pandas\n",
-    "exit()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "\u001B[K     |████████████████████████████████| 15.7 MB 417 kB/s \n",
-      "\u001B[K     |████████████████████████████████| 28.5 MB 1.3 MB/s \n",
-      "\u001B[K     |████████████████████████████████| 11.3 MB 28.8 MB/s \n",
-      "\u001B[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "\u001b[K     |████████████████████████████████| 15.7 MB 417 kB/s \n",
+      "\u001b[K     |████████████████████████████████| 28.5 MB 1.3 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 11.3 MB 28.8 MB/s \n",
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
       "tensorflow 2.6.0 requires numpy~=1.19.2, but you have numpy 1.21.2 which is incompatible.\n",
       "google-colab 1.0.0 requires pandas~=1.1.0; python_version >= \"3.0\", but you have pandas 1.3.3 which is incompatible.\n",
       "datascience 0.10.6 requires folium==0.2.1, but you have folium 0.8.3 which is incompatible.\n",
-      "albumentations 0.1.12 requires imgaug<0.2.7,>=0.2.5, but you have imgaug 0.2.9 which is incompatible.\u001B[0m\n",
-      "\u001B[?25h"
+      "albumentations 0.1.12 requires imgaug<0.2.7,>=0.2.5, but you have imgaug 0.2.9 which is incompatible.\u001b[0m\n",
+      "\u001b[?25h"
      ]
     }
+   ],
+   "source": [
+    "! python -m pip install -U -q numpy scipy plotly pandas\n",
+    "exit()"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "xjTc9n3Ju5W1"
    },
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -7932,9 +7922,7 @@
     "import plotly.graph_objects as go\n",
     "\n",
     "import endaq\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -7947,9 +7935,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "2VB-DQoGv6dF"
    },
+   "outputs": [],
    "source": [
     "def get_doc_and_table(file_location, display_table=True, display_recorder_info=True):\n",
     "  \"\"\"Given an IDE file location, return the object and table summary\"\"\"\n",
@@ -7962,12 +7952,11 @@
     "    display(table)\n",
     "\n",
     "  return dataset, table.data"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -7976,13 +7965,8 @@
     "id": "fUxT9tPOwgSc",
     "outputId": "3376b560-7e5d-47fd-ba09-a6b9daf637b3"
    },
-   "source": [
-    "[doc,table] = get_doc_and_table('https://info.endaq.com/hubfs/data/Bolted.ide')"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "CalibrationDate                         1583263964\n",
@@ -8002,10 +7986,10 @@
        "dtype: object"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
@@ -8177,15 +8161,21 @@
        "<pandas.io.formats.style.Styler at 0x7feec8874750>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "[doc,table] = get_doc_and_table('https://info.endaq.com/hubfs/data/Bolted.ide')"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "0FOIW0ri3Sqd"
    },
+   "outputs": [],
    "source": [
     "def get_primary_accel(dataset, table, preferred_ch=None, time_mode='seconds'):\n",
     "  \"\"\"Given an IDE object and summary table, return a dataframe of the accelerometer with the most samples unless a channel number is explicitely defined.\"\"\"\n",
@@ -8197,12 +8187,11 @@
     "    df = endaq.ide.to_pandas(channel,time_mode=time_mode)\n",
     "\n",
     "  return df.drop([\"Mic\"], axis=1, errors=\"ignore\")  "
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8211,14 +8200,8 @@
     "id": "XuU2PbWuwjlH",
     "outputId": "280b68bf-bcaf-449e-d5db-f0f9e86c0f99"
    },
-   "source": [
-    "df = get_primary_accel(doc, table)\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -8340,9 +8323,14 @@
        "[585728 rows x 3 columns]"
       ]
      },
+     "execution_count": 17,
      "metadata": {},
-     "execution_count": 17
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "df = get_primary_accel(doc, table)\n",
+    "df"
    ]
   },
   {
@@ -8357,6 +8345,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8365,32 +8354,8 @@
     "id": "v8WTbmq5xGpC",
     "outputId": "6f29f012-a331-48c3-8eb7-2555506d89cb"
    },
-   "source": [
-    "df_psd = endaq.calc.psd.welch(df, bin_width=10)\n",
-    "\n",
-    "fig = px.line(df_psd)\n",
-    "\n",
-    "fig.update_layout(\n",
-    "    title='Power Spectral Density',\n",
-    "    xaxis_title=\"Frequency (Hz)\",\n",
-    "    yaxis_title=\"Acceleration (g^2/Hz)\",\n",
-    "    xaxis_type=\"log\",\n",
-    "    yaxis_type=\"log\",\n",
-    "    legend=dict(\n",
-    "        orientation=\"h\",\n",
-    "        yanchor=\"top\",\n",
-    "        y=-.2,\n",
-    "        xanchor=\"right\",\n",
-    "        x=1\n",
-    "    )\n",
-    "  )\n",
-    "\n",
-    "fig.show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -8426,36 +8391,17 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "thYYU5yLAXfI"
-   },
+   ],
    "source": [
-    "We also provide a function to convert a linear spaced PSD to an octave spaced one."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 542
-    },
-    "id": "97aXuVQPxiqZ",
-    "outputId": "240ada0e-881a-4b80-8667-eb7c04d1ad06"
-   },
-   "source": [
-    "df_psd_oct = endaq.calc.psd.to_octave(df_psd, fstart=4, octave_bins=3)\n",
+    "df_psd = endaq.calc.psd.welch(df, bin_width=10)\n",
     "\n",
-    "fig = px.line(df_psd_oct)\n",
+    "fig = px.line(df_psd)\n",
     "\n",
     "fig.update_layout(\n",
-    "    title='Octave Spaced Power Spectral Density',\n",
+    "    title='Power Spectral Density',\n",
     "    xaxis_title=\"Frequency (Hz)\",\n",
     "    yaxis_title=\"Acceleration (g^2/Hz)\",\n",
     "    xaxis_type=\"log\",\n",
@@ -8470,11 +8416,30 @@
     "  )\n",
     "\n",
     "fig.show()"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "thYYU5yLAXfI"
+   },
+   "source": [
+    "We also provide a function to convert a linear spaced PSD to an octave spaced one."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 542
+    },
+    "id": "97aXuVQPxiqZ",
+    "outputId": "240ada0e-881a-4b80-8667-eb7c04d1ad06"
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -8510,8 +8475,31 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_psd_oct = endaq.calc.psd.to_octave(df_psd, fstart=4, octave_bins=3)\n",
+    "\n",
+    "fig = px.line(df_psd_oct)\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title='Octave Spaced Power Spectral Density',\n",
+    "    xaxis_title=\"Frequency (Hz)\",\n",
+    "    yaxis_title=\"Acceleration (g^2/Hz)\",\n",
+    "    xaxis_type=\"log\",\n",
+    "    yaxis_type=\"log\",\n",
+    "    legend=dict(\n",
+    "        orientation=\"h\",\n",
+    "        yanchor=\"top\",\n",
+    "        y=-.2,\n",
+    "        xanchor=\"right\",\n",
+    "        x=1\n",
+    "    )\n",
+    "  )\n",
+    "\n",
+    "fig.show()"
    ]
   },
   {
@@ -8527,6 +8515,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8535,17 +8524,8 @@
     "id": "0z3-ayAh4ytz",
     "outputId": "514155ec-8fe9-41d6-c996-c2f08cad9ab4"
    },
-   "source": [
-    "[doc,table] = get_doc_and_table('https://info.endaq.com/hubfs/data/Motorcycle-Car-Crash.ide',\n",
-    "                                display_recorder_info=False,\n",
-    "                                display_table=False)\n",
-    "df = get_primary_accel(doc, table)\n",
-    "df"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -8667,9 +8647,17 @@
        "[1280087 rows x 3 columns]"
       ]
      },
+     "execution_count": 8,
      "metadata": {},
-     "execution_count": 8
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "[doc,table] = get_doc_and_table('https://info.endaq.com/hubfs/data/Motorcycle-Car-Crash.ide',\n",
+    "                                display_recorder_info=False,\n",
+    "                                display_table=False)\n",
+    "df = get_primary_accel(doc, table)\n",
+    "df"
    ]
   },
   {
@@ -8683,9 +8671,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "nKt1eQtW5hyI"
    },
+   "outputs": [],
    "source": [
     "def get_peak_time(df,num):\n",
     "  \"\"\"Get a subset of a dataframe around the peak value\"\"\"\n",
@@ -8697,12 +8687,11 @@
     "  df_peak = df[peak_time - num / fs : peak_time + num / fs ] #segment the dataframe to be around that peak value\n",
     "  \n",
     "  return df_peak"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8711,29 +8700,8 @@
     "id": "DryEV6a96bCI",
     "outputId": "264ce923-11d8-4003-d074-2a3806e1320b"
    },
-   "source": [
-    "df_peak = get_peak_time(df,5000)\n",
-    "\n",
-    "fig = px.line(df_peak)\n",
-    "fig.update_layout(\n",
-    "    title=\"Time History around Peak\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    "    template=\"plotly_white\",\n",
-    "    legend=dict(\n",
-    "        orientation=\"h\",\n",
-    "        yanchor=\"top\",\n",
-    "        y=-.2,\n",
-    "        xanchor=\"right\",\n",
-    "        x=1\n",
-    "    )\n",
-    ")\n",
-    "fig.show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -8769,8 +8737,28 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_peak = get_peak_time(df,5000)\n",
+    "\n",
+    "fig = px.line(df_peak)\n",
+    "fig.update_layout(\n",
+    "    title=\"Time History around Peak\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    "    template=\"plotly_white\",\n",
+    "    legend=dict(\n",
+    "        orientation=\"h\",\n",
+    "        yanchor=\"top\",\n",
+    "        y=-.2,\n",
+    "        xanchor=\"right\",\n",
+    "        x=1\n",
+    "    )\n",
+    ")\n",
+    "fig.show()"
    ]
   },
   {
@@ -8784,6 +8772,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8792,31 +8781,8 @@
     "id": "TtSWPMFX6ihW",
     "outputId": "e7a56508-5a1f-4af4-de12-27798d030491"
    },
-   "source": [
-    "df_filtered = df - df.median() #For shock events it's sometimes best to avoid high pass filters because they can introduce weird artifacts\n",
-    "df_filtered = endaq.calc.filters.butterworth(df_filtered, low_cutoff=None, high_cutoff=150, half_order=3)\n",
-    "df_peak_filtered = get_peak_time(df_filtered,5000)\n",
-    "\n",
-    "fig = px.line(df_peak_filtered)\n",
-    "fig.update_layout(\n",
-    "    title=\"Filtered Time History around Peak\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Acceleration (g)\",\n",
-    "    template=\"plotly_white\",\n",
-    "    legend=dict(\n",
-    "        orientation=\"h\",\n",
-    "        yanchor=\"top\",\n",
-    "        y=-.2,\n",
-    "        xanchor=\"right\",\n",
-    "        x=1\n",
-    "    )\n",
-    ")\n",
-    "fig.show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -8852,8 +8818,30 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "df_filtered = df - df.median() #For shock events it's sometimes best to avoid high pass filters because they can introduce weird artifacts\n",
+    "df_filtered = endaq.calc.filters.butterworth(df_filtered, low_cutoff=None, high_cutoff=150, half_order=3)\n",
+    "df_peak_filtered = get_peak_time(df_filtered,5000)\n",
+    "\n",
+    "fig = px.line(df_peak_filtered)\n",
+    "fig.update_layout(\n",
+    "    title=\"Filtered Time History around Peak\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Acceleration (g)\",\n",
+    "    template=\"plotly_white\",\n",
+    "    legend=dict(\n",
+    "        orientation=\"h\",\n",
+    "        yanchor=\"top\",\n",
+    "        y=-.2,\n",
+    "        xanchor=\"right\",\n",
+    "        x=1\n",
+    "    )\n",
+    ")\n",
+    "fig.show()"
    ]
   },
   {
@@ -8867,20 +8855,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "tAVITAR07FJy"
    },
+   "outputs": [],
    "source": [
     "[df_accel, df_vel, df_disp] = endaq.calc.integrate.integrals(df_peak_filtered, n=2, highpass_cutoff=None, tukey_percent=0)\n",
     "\n",
     "df_vel = df_vel-df_vel.iloc[0] #forced the starting velocity to 0\n",
     "df_vel = df_vel*9.81*39.37 #convert to in/s"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8889,27 +8878,8 @@
     "id": "6NQrZXmJ87TE",
     "outputId": "630f45ed-723c-446a-fdf9-ce949e54766e"
    },
-   "source": [
-    "fig = px.line(df_vel)\n",
-    "fig.update_layout(\n",
-    "    title=\"Integrated Velocity Time History\",\n",
-    "    xaxis_title=\"Time (s)\",\n",
-    "    yaxis_title=\"Velocity (in/s)\",\n",
-    "    template=\"plotly_dark\",\n",
-    "    legend=dict(\n",
-    "        orientation=\"h\",\n",
-    "        yanchor=\"top\",\n",
-    "        y=-.2,\n",
-    "        xanchor=\"right\",\n",
-    "        x=1\n",
-    "    )\n",
-    ")\n",
-    "fig.show()"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -8945,8 +8915,26 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "fig = px.line(df_vel)\n",
+    "fig.update_layout(\n",
+    "    title=\"Integrated Velocity Time History\",\n",
+    "    xaxis_title=\"Time (s)\",\n",
+    "    yaxis_title=\"Velocity (in/s)\",\n",
+    "    template=\"plotly_dark\",\n",
+    "    legend=dict(\n",
+    "        orientation=\"h\",\n",
+    "        yanchor=\"top\",\n",
+    "        y=-.2,\n",
+    "        xanchor=\"right\",\n",
+    "        x=1\n",
+    "    )\n",
+    ")\n",
+    "fig.show()"
    ]
   },
   {
@@ -8960,20 +8948,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "TaZLW-jS9bsg"
    },
+   "outputs": [],
    "source": [
     "freqs=2 ** np.arange(0, 12, 1/12)\n",
     "\n",
     "pvss = endaq.calc.shock.pseudo_velocity(df_peak-df_peak.median(), freqs=freqs, damp=0.05)\n",
     "pvss = pvss*9.81*39.37 #convert to in/s"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -8982,28 +8971,8 @@
     "id": "N_Ggrhq_nKFc",
     "outputId": "c2623b81-0edb-4576-9ca5-65645109cc3a"
    },
-   "source": [
-    "fig = px.line(pvss)\n",
-    "fig.update_layout(\n",
-    "    title='Psuedo Velocity Shock Spectrum (PVSS)',\n",
-    "    xaxis_title=\"Natural Frequency (Hz)\",\n",
-    "    yaxis_title=\"Psuedo Velocity (in/s)\",\n",
-    "    template=\"plotly_dark\",\n",
-    "    xaxis_type=\"log\",\n",
-    "    yaxis_type=\"log\",\n",
-    "    legend=dict(\n",
-    "        orientation=\"h\",\n",
-    "        yanchor=\"top\",\n",
-    "        y=-.2,\n",
-    "        xanchor=\"right\",\n",
-    "        x=1\n",
-    "    )\n",
-    "  )"
-   ],
-   "execution_count": null,
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<html>\n",
@@ -9039,9 +9008,55 @@
        "</html>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
+   ],
+   "source": [
+    "fig = px.line(pvss)\n",
+    "fig.update_layout(\n",
+    "    title='Psuedo Velocity Shock Spectrum (PVSS)',\n",
+    "    xaxis_title=\"Natural Frequency (Hz)\",\n",
+    "    yaxis_title=\"Psuedo Velocity (in/s)\",\n",
+    "    template=\"plotly_dark\",\n",
+    "    xaxis_type=\"log\",\n",
+    "    yaxis_type=\"log\",\n",
+    "    legend=dict(\n",
+    "        orientation=\"h\",\n",
+    "        yanchor=\"top\",\n",
+    "        y=-.2,\n",
+    "        xanchor=\"right\",\n",
+    "        x=1\n",
+    "    )\n",
+    "  )"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Webinar-Introduction-NumPy-and-Pandas.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/webinars/Webinar_Introduction_NumPy_and_Pandas.ipynb
+++ b/docs/webinars/Webinar_Introduction_NumPy_and_Pandas.ipynb
@@ -11,6 +11,7 @@
     "## Introduction\n",
     "\n",
     "This notebook and accompanying webinar was developed and released by the [enDAQ team](https://endaq.com/). This is the second \"chapter\" of our series on *Python for Mechanical Engineers*:\n",
+    "\n",
     "1. [Get Started with Python](https://colab.research.google.com/drive/1_pcGtgJleapV9tz5WfuRuqfWryjqhPHy#scrollTo=ikUJITDDIp19)\n",
     "   * Blog: [Get Started with Python: Why and How Mechanical Engineers Should Make the Switch](https://blog.endaq.com/get-started-with-python-why-how-mechanical-engineers-should-make-the-switch)\n",
     "2. **Introduction to Numpy & Pandas**\n",

--- a/docs/webinars/Webinar_Introduction_enDAQ_Library.ipynb
+++ b/docs/webinars/Webinar_Introduction_enDAQ_Library.ipynb
@@ -1,21 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "Webinar-Introduction-enDAQ-Library.ipynb",
-   "provenance": [],
-   "collapsed_sections": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -31,12 +14,13 @@
     "## Introduction\n",
     "\n",
     "This notebook and accompanying webinar was developed and released by the [enDAQ team](https://endaq.com/). This is the fourth \"chapter\" of our series on *Python for Mechanical Engineers*:\n",
+    "\n",
     "1. [Get Started with Python](https://colab.research.google.com/drive/1_pcGtgJleapV9tz5WfuRuqfWryjqhPHy#scrollTo=ikUJITDDIp19)\n",
-    "  * Blog: [Get Started with Python: Why and How Mechanical Engineers Should Make the Switch](https://blog.endaq.com/get-started-with-python-why-how-mechanical-engineers-should-make-the-switch)\n",
+    "   * Blog: [Get Started with Python: Why and How Mechanical Engineers Should Make the Switch](https://blog.endaq.com/get-started-with-python-why-how-mechanical-engineers-should-make-the-switch)\n",
     "2. [Introduction to Numpy & Pandas for Data Analysis](https://colab.research.google.com/drive/1O-VwAdRoSlcrineAk0Jkd_fcw7mFGHa4#scrollTo=ce97q1ZcBiwj)\n",
     "3. [Introduction to Plotly for Plotting Data](https://colab.research.google.com/drive/1pag2pKQQW5amWgRykAH8uMAPqHA2yUfU)\n",
     "4. **Introduction of the enDAQ Library**\n",
-    "  * [Watch Recording of This](https://info.endaq.com/simplify-shock-and-vibration-analysis-with-endaq-python-library)\n",
+    "   * [Watch Recording of This](https://info.endaq.com/simplify-shock-and-vibration-analysis-with-endaq-python-library)\n",
     "5. [More Custom Examples](https://colab.research.google.com/drive/1cuZa5Yx55qXLhhnBMdzsJ0iiklwVi5Mq)\n",
     "\n",
     "To sign up for future webinars and watch previous ones, [visit our webinars page](https://endaq.com/pages/shock-vibration-webinars). "
@@ -50,7 +34,8 @@
    "source": [
     "## Why Did We Develop This?\n",
     "\n",
-    "When analyzing data you'll need: \n",
+    "When analyzing data you'll need:\n",
+    "\n",
     "- Customize a bit to meet your specific need \n",
     "- Share the results\n",
     "- Share the *methodology* \n",
@@ -86,18 +71,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
-    "id": "Zio_ttH09QpW",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "Zio_ttH09QpW",
     "outputId": "01cb0639-cc27-4dc1-e89b-5851d37686e5"
    },
-   "source": [
-    "!pip install -q endaq\n",
-    "exit() #needed in Colab because they pre-load some libraries"
-   ],
-   "execution_count": 1,
    "outputs": [
     {
      "name": "stderr",
@@ -107,16 +88,22 @@
       "You should consider upgrading via the 'c:\\users\\cflanigan\\documents\\endaq\\endaq-python\\endaq-python\\venv\\scripts\\python.exe -m pip install --upgrade pip' command.\n"
      ]
     }
+   ],
+   "source": [
+    "!pip install -q endaq\n",
+    "exit() #needed in Colab because they pre-load some libraries"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "v68NcIaE9qO3",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "import endaq\n",
     "\n",
@@ -126,9 +113,7 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "import scipy"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -154,17 +139,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "y9l6f4vW9SY7",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "doc = endaq.ide.get_doc('https://info.endaq.com/hubfs/data/Sys034_1.ide')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -177,6 +162,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -187,12 +173,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "print(doc.recorderInfo['PartNumber'])\n",
     "print(doc.recorderInfo['RecorderSerial'])"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -207,6 +192,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -218,12 +204,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "table = endaq.ide.get_channel_table(doc)\n",
     "table"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -236,6 +221,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -247,11 +233,10 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "table.data"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -264,6 +249,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -274,12 +260,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "data = {doc.channels[ch].name: endaq.ide.to_pandas(doc.channels[ch], time_mode='datetime') for ch in doc.channels}\n",
     "data"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -293,6 +278,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -304,6 +290,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.dashboards.rolling_enveloped_dashboard(\n",
     "    data,\n",
@@ -312,9 +299,7 @@
     "    plot_as_bars=True,\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -337,26 +322,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "r3pKvUgvzvg-",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 1000
     },
+    "id": "r3pKvUgvzvg-",
     "outputId": "78c88589-86e8-4261-ff25-cb98db42d83f",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "endaq.plot.utilities.set_theme()\n",
     "\n",
     "fig.update_layout(\n",
     "    template='endaq'\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -369,17 +354,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "fKk0ha-dzyXn",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig.write_html('dashboard.html',include_plotlyjs ='cdn')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -392,6 +377,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -403,6 +389,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "endaq.plot.dashboards.rolling_enveloped_dashboard(\n",
     "    data,\n",
@@ -412,9 +399,7 @@
     "    num_rows=1,\n",
     "    num_cols=None\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -427,12 +412,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "AjawpV_aPuPO",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "csv_data = {\n",
     "    'crash':pd.read_csv('https://info.endaq.com/hubfs/data/Motorcycle-Car-Crash.csv',index_col=0),\n",
@@ -444,12 +431,11 @@
     "    'volleyball':pd.read_csv('https://info.endaq.com/hubfs/data/volleyball-hit-acceleration.csv',index_col=0, header=None, names=['X','Y','Z']),\n",
     "    'football':pd.read_csv('https://info.endaq.com/hubfs/data/football-catch-acceleration.csv',index_col=0, header=None, names=['X','Y','Z']),\n",
     "}"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -461,6 +447,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "endaq.plot.dashboards.rolling_enveloped_dashboard(\n",
     "    csv_data,\n",
@@ -468,9 +455,7 @@
     "    min_points_to_plot=1,\n",
     "    plot_as_bars=True,\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -483,6 +468,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -494,15 +480,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "endaq.plot.dashboards.rolling_metric_dashboard(\n",
     "    csv_data,\n",
     "    desired_num_points=100,\n",
     "    rolling_metrics_to_plot = ('absolute max', 'std')\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -515,6 +500,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -525,14 +511,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "data.keys()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -544,11 +530,10 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "data['100g PE Acceleration']"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -563,6 +548,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -574,12 +560,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "accel = endaq.ide.to_pandas(doc.channels[8])\n",
     "accel"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -596,6 +581,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -607,12 +593,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "filtered = endaq.calc.filters.butterworth(accel, low_cutoff=2)\n",
     "filtered"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -638,24 +623,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "itX-LIrzWqsy",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "accel_time_labels = dict(\n",
     "    xaxis_title_text='',\n",
     "    yaxis_title_text='Acceleration (g)',\n",
     "    legend_title_text=''\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -667,6 +653,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.plots.rolling_min_max_envelope(\n",
     "    filtered,\n",
@@ -678,9 +665,7 @@
     "    accel_time_labels,\n",
     "    title_text='Filtered Time Series with 13M Points',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -695,6 +680,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -706,13 +692,12 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "psd = endaq.calc.psd.welch(filtered, bin_width=1)\n",
     "psd['Resultant'] = psd.sum(axis=1)\n",
     "psd"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -727,12 +712,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "D6nR4_zdyWbf",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "psd_labels = dict(\n",
     "    xaxis_title_text='Frequency (Hz)',\n",
@@ -741,9 +728,7 @@
     "    xaxis_type='log',\n",
     "    yaxis_type='log',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -756,6 +741,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -767,15 +753,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(psd)\n",
     "fig.update_layout(\n",
     "    psd_labels,\n",
     "    title_text='Power Spectral Density',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -797,6 +782,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -808,12 +794,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "oct_psd = endaq.calc.psd.to_octave(psd, fstart=4, octave_bins=3)\n",
     "oct_psd.head()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -826,6 +811,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -837,6 +823,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "for c in oct_psd.columns:\n",
     "  fig.add_trace(go.Scattergl(\n",
@@ -848,9 +835,7 @@
     "  ))\n",
     "\n",
     "fig.show()  "
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -865,6 +850,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -876,12 +862,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "freqs, bins, Pxx, fig = endaq.plot.octave_spectrogram(filtered[['X (100g)']], window=12, bins_per_octave=6)\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -896,6 +881,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -906,14 +892,13 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "endaq.ide.extract_time(doc, \n",
     "                       out='extracted.ide', \n",
     "                       start=pd.to_datetime('2021-10-22 09:17:15'),\n",
     "                       end=pd.to_datetime('2021-10-22 09:17:25'))"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -926,6 +911,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -937,6 +923,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "psd = endaq.calc.psd.welch(filtered['2021-10-22 09:17:15':'2021-10-22 09:17:25'], bin_width=1)\n",
     "psd['Resultant'] = psd.sum(axis=1)\n",
@@ -946,9 +933,7 @@
     "    psd_labels,\n",
     "    title_text='Power Spectral Density from 9:17:15 to 9:17:25',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -961,6 +946,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -972,6 +958,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(data['Light Sensor'][['Lux']][::4])\n",
     "fig.update_layout(\n",
@@ -979,9 +966,7 @@
     "    xaxis_title_text='',\n",
     "    yaxis_title_text=\"Light (Lux)\"\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1005,16 +990,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "S5Q0J1miJ92o",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "S5Q0J1miJ92o",
     "outputId": "34bbcf3c-9823-4e30-8b84-060efd72546e",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "data = {\n",
     "    'Shaker' : endaq.ide.to_pandas(endaq.ide.get_doc('https://info.endaq.com/hubfs/data/Transfer_Shaker.ide').channels[80]),\n",
@@ -1022,9 +1009,7 @@
     "    'Short Beam' : endaq.ide.to_pandas(endaq.ide.get_doc('https://info.endaq.com/hubfs/data/Transfer_Short_Beam.ide').channels[80])\n",
     "}\n",
     "data"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1039,6 +1024,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1050,6 +1036,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.dashboards.rolling_enveloped_dashboard(\n",
     "    data,\n",
@@ -1059,9 +1046,7 @@
     ")\n",
     "fig.update_xaxes(matches='x')\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1076,6 +1061,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1087,6 +1073,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "time_overall = pd.DataFrame()\n",
     "for device in data.keys():\n",
@@ -1100,9 +1087,7 @@
     "  time_overall = pd.concat([time_overall,accel])\n",
     "\n",
     "time_overall"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1115,6 +1100,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1126,6 +1112,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.plots.rolling_min_max_envelope(\n",
     "    time_overall,\n",
@@ -1138,9 +1125,7 @@
     "    title_text='Comparison of Acceleration in Time Domain',\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1155,6 +1140,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1166,6 +1152,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "psd_overall = pd.DataFrame()\n",
     "for device in data.keys():\n",
@@ -1185,12 +1172,11 @@
     "  psd_overall = pd.concat([psd_overall,psd], axis=1)\n",
     "\n",
     "psd_overall"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1202,15 +1188,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(psd_overall[4:500])\n",
     "fig.update_layout(\n",
     "    psd_labels,\n",
     "    title_text='PSD Comparison',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1223,6 +1208,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1234,6 +1220,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "oct_psd = endaq.calc.psd.to_octave(psd_overall, fstart=4, octave_bins = 0.5)\n",
     "\n",
@@ -1243,9 +1230,7 @@
     "    title_text='PSD Comparison',\n",
     "    template='endaq_light'\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1260,6 +1245,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1271,14 +1257,13 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "transfer = psd_overall[5:240].copy().drop('Shaker',axis=1)\n",
     "for col in transfer.columns:\n",
     "    transfer[col] = (psd_overall[col]/psd_overall['Shaker']) ** 0.5\n",
     "transfer"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1291,6 +1276,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1302,6 +1288,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(transfer)\n",
     "fig.update_layout(\n",
@@ -1312,9 +1299,7 @@
     "    xaxis_type='log',\n",
     "    yaxis_type='log',\n",
     ")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1329,6 +1314,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1339,6 +1325,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "displacements = {}\n",
     "for device in data.keys():\n",
@@ -1357,9 +1344,7 @@
     "  displacements[device] = df_disp\n",
     "\n",
     "displacements"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1374,6 +1359,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1385,6 +1371,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "displacement = pd.DataFrame()\n",
     "for device in displacements.keys():\n",
@@ -1398,12 +1385,11 @@
     "  displacement = pd.concat([displacement, disp_resampled.reset_index().melt(id_vars='index').dropna()])\n",
     "\n",
     "displacement"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1415,6 +1401,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(displacement,\n",
     "             x='index',\n",
@@ -1426,9 +1413,7 @@
     "    xaxis_title_text = '',\n",
     "    legend_title_text = '',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1452,24 +1437,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "0Ricg86U7B0-",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 454
     },
+    "id": "0Ricg86U7B0-",
     "outputId": "186861ae-b0aa-49bf-d5c6-df7c1db542b1",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "doc = endaq.ide.get_doc('https://info.endaq.com/hubfs/data/Motorcycle-Car-Crash.ide')\n",
     "accel = endaq.ide.to_pandas(doc.channels[8])\n",
     "accel"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1483,6 +1468,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1494,6 +1480,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.plots.around_peak(\n",
     "    accel, \n",
@@ -1504,9 +1491,7 @@
     "    accel_time_labels,\n",
     "    title_text='Acceleration Around Peak',\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1521,17 +1506,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "vpoy6wUoDvQo",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 454
     },
+    "id": "vpoy6wUoDvQo",
     "outputId": "5e87c489-bae4-448a-ef3d-d7574471699e",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "accel = accel['Y (500g)'].to_frame() #keep as a dataframe\n",
     "accel = (accel - accel.median()) * -1 #apply a high pass and make the shock positive acceleration\n",
@@ -1545,12 +1532,11 @@
     "accel = accel['2019-07-03 17:05:08.4':'2019-07-03 17:05:08.55'] #isolate the time of interest\n",
     "accel = accel - accel.iloc[0] #force start to 0 to remove any filtering artifact\n",
     "accel"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1562,15 +1548,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(accel)\n",
     "fig.update_layout(\n",
     "    accel_time_labels,\n",
     "    title_text='Motorcycle Car Crash, Effect of Filtering'\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1585,21 +1570,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "aKrLOnesDzZJ",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "aKrLOnesDzZJ",
     "outputId": "4e2a2d15-3fb9-4053-fc5f-65a718c76c39",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "freqs = endaq.calc.utils.logfreqs(accel, init_freq=1, bins_per_octave=12)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1612,20 +1597,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "sM6VfZIqC3Na",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "srs = endaq.calc.shock.shock_spectrum(accel, freqs=freqs, damp=0.05, mode='srs')"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1637,6 +1623,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(srs)\n",
     "fig.update_layout(\n",
@@ -1647,9 +1634,7 @@
     "    xaxis_type=\"log\",\n",
     "    yaxis_type=\"log\",\n",
     "  )"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1664,21 +1649,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "EZz_6JGhC12Z",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "pvss = endaq.calc.shock.shock_spectrum(accel, freqs=freqs, damp=0.05, mode='pvss')\n",
     "pvss = pvss*9.81*39.37 #convert to in/s"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1690,6 +1676,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(pvss)\n",
     "fig.update_layout(\n",
@@ -1700,9 +1687,7 @@
     "    xaxis_type=\"log\",\n",
     "    yaxis_type=\"log\",\n",
     "  )"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1717,12 +1702,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "8xkXKS4eYTm0",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "t = np.linspace(0,0.1,num=1000)  # NOTE: if there aren't enough samples, low-frequency artifacts will appear!\n",
     "\n",
@@ -1732,12 +1719,11 @@
     "    df_result = pd.DataFrame({'Time':t,\n",
     "                              'Pulse':result}).set_index('Time')\n",
     "    return df_result"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1749,6 +1735,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "for c in ['No Low-Pass', 'Filtered at: 200 Hz']:\n",
     "\n",
@@ -1765,9 +1752,7 @@
     "  ))\n",
     "\n",
     "fig.show()  "
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1780,12 +1765,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "Pn79by_wDXTj",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "pvss_damping = pd.DataFrame()\n",
     "damps = [0, 0.025, 0.05, 0.10]\n",
@@ -1793,12 +1780,11 @@
     "  pvss = endaq.calc.shock.shock_spectrum(accel['No Low-Pass'].to_frame(), freqs=freqs, damp=damp, mode='pvss')\n",
     "  name = 'Damping Ratio = '+str(damp)\n",
     "  pvss_damping[name] = pvss[pvss.columns[0]]*9.81*39.37 #convert to in/s"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1810,6 +1796,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(pvss_damping)\n",
     "fig.update_layout(\n",
@@ -1820,9 +1807,7 @@
     "    xaxis_type=\"log\",\n",
     "    yaxis_type=\"log\",\n",
     "  )"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1835,23 +1820,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "OHpFpn-ZD1Vb",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "[df_accel, df_vel] = endaq.calc.integrate.integrals(accel, n=1, highpass_cutoff=None, tukey_percent=0)\n",
     "\n",
     "df_vel = df_vel-df_vel.iloc[0] #forced the starting velocity to 0\n",
     "df_vel = df_vel*9.81*39.37 #convert to in/s"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1863,6 +1849,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(df_vel)\n",
     "fig.update_layout(\n",
@@ -1872,9 +1859,7 @@
     "    legend_title_text=''\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1887,24 +1872,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "Wkr_556oqbzc",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 454
     },
+    "id": "Wkr_556oqbzc",
     "outputId": "8b5782e9-3e74-440c-87ab-a9c3a6421bd7",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "df_vibe = pd.read_csv('https://info.endaq.com/hubfs/data/motorcycle-vibration-moving-frequency.csv',index_col=0)\n",
     "df_vibe = df_vibe - df_vibe.median()\n",
     "df_vibe"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1917,6 +1902,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1928,6 +1914,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.plots.rolling_min_max_envelope(\n",
     "    df_vibe,\n",
@@ -1940,9 +1927,7 @@
     "    title_text='Engine Reving of Motorcycle',\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1955,6 +1940,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1966,6 +1952,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "freqs, bins, Pxx, fig = endaq.plot.octave_spectrogram(df_vibe[['Z (40g)']], \n",
     "                                                      window=0.5, \n",
@@ -1973,9 +1960,7 @@
     "                                                      max_freq=1000, \n",
     "                                                      freq_start=40)\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1988,32 +1973,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "hAOOnhsw4wpL",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "df_Pxx = pd.DataFrame(Pxx, index= freqs, columns = bins)\n",
     "df_Pxx = 10 ** (df_Pxx/10)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "U6mcuzN5lPnE",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 542
     },
+    "id": "U6mcuzN5lPnE",
     "outputId": "b87b118b-ebb6-419b-e0cd-81e6ecdb0db1",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(df_Pxx[df_Pxx.index<500].idxmax())\n",
     "fig.update_layout(\n",
@@ -2023,9 +2010,7 @@
     "    showlegend=False\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2040,19 +2025,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "pL1m9yh258BG",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "df_Pxx.index.name='Frequency (Hz)'\n",
     "df_Pxx.columns.name = 'Time (s)'\n",
     "df_Pxx.columns = np.round(df_Pxx.columns,2)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2065,12 +2050,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "cilfOzjg6PyQ",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(\n",
     "    df_Pxx.reset_index().melt(id_vars='Frequency (Hz)'),\n",
@@ -2080,9 +2067,7 @@
     "    log_x=True,\n",
     "    log_y=True,\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2095,12 +2080,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "pWkts0ew_OSr",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "def add_line(df_stat,name,dash,color):\n",
     "  fig.add_trace(go.Scattergl(\n",
@@ -2122,12 +2109,11 @@
     "#Add in mean\n",
     "df_stat = df_Pxx.mean(axis=1)\n",
     "add_line(df_stat,'Mean','dot','#2DB473')  "
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2139,15 +2125,14 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig.update_layout(\n",
     "    legend_y=-0.7,\n",
     "    yaxis_title_text='Acceleration (g^2/Hz)'\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2160,21 +2145,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "C04AKza69MXR",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "psd = endaq.calc.psd.welch(df_vibe[['Z (40g)']], bin_width=0.25)\n",
     "oct_psd = endaq.calc.psd.to_octave(psd,octave_bins=12,fstart=40)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2186,14 +2172,13 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(oct_psd[oct_psd.index<=1000])\n",
     "fig.update_layout(\n",
     "    psd_labels\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2206,6 +2191,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2217,29 +2203,29 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "mic = endaq.ide.to_pandas(endaq.ide.get_doc('https://info.endaq.com/hubfs/data/sound/gangnam-style.ide').channels[8],time_mode='seconds')\n",
     "mic"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "6TwAE0prKztb",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "mic = mic*-5.3075 #convert to Pa, this will be natively done with devices starting in the next month or so"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2251,6 +2237,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = endaq.plot.plots.rolling_min_max_envelope(\n",
     "    mic,\n",
@@ -2265,9 +2252,7 @@
     "    showlegend=False\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2280,12 +2265,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "ShDZi9yh7ZHV",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "import scipy.io.wavfile\n",
     "\n",
@@ -2297,9 +2284,7 @@
     "    int(np.round(1/endaq.calc.utils.sample_spacing(mic))),\n",
     "    mic_normalized.values.astype(np.float32),\n",
     ")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2312,6 +2297,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2323,12 +2309,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "import IPython \n",
     "IPython.display.display(IPython.display.Audio('sound.wav'))"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2341,22 +2326,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "wSzA23_7FuC1",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "n = int(mic.shape[0]/100)\n",
     "rolling_pa = mic.rolling(n).std()[::n]\n",
     "rolling_dB = rolling_pa.apply(endaq.calc.utils.to_dB, reference=endaq.calc.utils.dB_refs[\"SPL\"], raw=True)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2368,6 +2354,7 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(rolling_dB)\n",
     "fig.update_layout(\n",
@@ -2377,9 +2364,7 @@
     "    showlegend=False\n",
     ")\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2392,12 +2377,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "DGI2FVX-HTVa",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "df_pascal_psd = endaq.calc.psd.welch(mic, bin_width=1)\n",
     "df_pascal_octave = endaq.calc.psd.to_octave(df_pascal_psd*df_pascal_psd.index[1],agg=\"sum\",octave_bins=3, fstart=10)\n",
@@ -2406,23 +2393,23 @@
     "                                         reference=endaq.calc.utils.dB_refs[\"SPL\"]**2, \n",
     "                                         squared=True, \n",
     "                                         raw=True)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "p4f-EgYfHnPZ",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 542
     },
+    "id": "p4f-EgYfHnPZ",
     "outputId": "70316514-de7e-4d32-d534-e3e5b89492b6",
     "pycharm": {
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "fig = px.line(df_audio_psd_dB)\n",
     "fig.update_layout(\n",
@@ -2432,9 +2419,7 @@
     "    yaxis_title_text='Sound Level (dB)',\n",
     "    showlegend=False\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2447,6 +2432,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -2458,12 +2444,11 @@
      "is_executing": true
     }
    },
+   "outputs": [],
    "source": [
     "freqs, bins, Pxx, fig = endaq.plot.octave_spectrogram(mic, window=0.5, bins_per_octave=12, freq_start=40, max_freq=5000)\n",
     "fig.show()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2503,5 +2488,32 @@
     "3. Updating enDAQ Cloud to Provide Access to New Python Library"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Webinar-Introduction-enDAQ-Library.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
small formatting fixes for webinar notebooks. This is hard to see from the file diffs, but this includes:

- adding more space above lists so the list text isn't simply treated as a wrapped paragraph
- adding more indentation to nested lists s.t. the nesting is rendered correctly
- changing some LaTeX to render equations more cleanly