### PR TITLE
allow overlap for fft segments

### DIFF
--- a/endaq/calc/fft.py
+++ b/endaq/calc/fft.py
@@ -32,7 +32,6 @@ def aggregate_fft(df, **kwargs):
     """
     kwargs['scaling'] = 'unit'
     kwargs['window'] = 'boxcar'
-    kwargs['noverlap'] = 0
     return psd.welch(df, **kwargs)
 
 

--- a/endaq/calc/fft.py
+++ b/endaq/calc/fft.py
@@ -30,8 +30,8 @@ def aggregate_fft(df, **kwargs):
         - `SciPy Welch's method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.welch.html>`_
           Documentation for the periodogram function wrapped internally.
     """
-    kwargs['scaling'] = 'unit'
-    kwargs['window'] = 'boxcar'
+    kwargs.setdefault('scaling', 'unit')
+    kwargs.setdefault('window', 'boxcar')
     return psd.welch(df, **kwargs)
 
 


### PR DESCRIPTION
I may have steered @theflanman wrong here when I asked for this function but forcing the overlap to 0 results in more noisy results and doesn't seem necessary. Here's an example using the existing function

![image](https://user-images.githubusercontent.com/35080650/168123287-9f4a389d-9b99-4560-8216-fe0b8015e84a.png)

Here it is when we allow for overlapping which is the default scipy behavior

![image](https://user-images.githubusercontent.com/35080650/168123449-43f7a6a6-fa48-4a20-ab0c-9231243686e6.png)
