### PR TITLE
Release/1.5.1

### DIFF
--- a/endaq/__init__.py
+++ b/endaq/__init__.py
@@ -5,4 +5,4 @@ import endaq.plot
 import endaq.batch
 
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/endaq/calc/integrate.py
+++ b/endaq/calc/integrate.py
@@ -19,7 +19,7 @@ def _integrate(
     dt = utils.sample_spacing(df)
 
     result = df.apply(
-        functools.partial(scipy.integrate.cumulative_trapezoid, dx=dt, initial=0),
+        functools.partial(scipy.integrate.cumtrapz, dx=dt, initial=0),
         axis=0,
         raw=True,
     )


### PR DESCRIPTION
This is a maintenance release for 1.5.1, addressing a small number of specific issues.

Changes:
* Retrieval of file metadata in `endaq.plot.plots.table_plot_from_ide()` made less brittle.
* Reverted to the old name of `scipy.integrate.cumulative_trapezoid()` for broader SciPy version compatibility.