### PR TITLE
Feature/test fixes

### DIFF
--- a/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
+++ b/docs/webinars/Webinar_Intro_Python_Acceleration_CSV_Analysis.ipynb
@@ -28,7 +28,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "ou9NjNsdJ72B"
+    "id": "ou9NjNsdJ72B",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Import Data File\n",
@@ -38,7 +41,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "vX2hd0kHKPz4"
+    "id": "vX2hd0kHKPz4",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Example Files\n",
@@ -49,7 +55,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Ut2acKSEKN1C"
+    "id": "Ut2acKSEKN1C",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -71,7 +80,10 @@
      "height": 35
     },
     "id": "MaNRqOKcbNsl",
-    "outputId": "1b96883c-ba3d-49c3-d3e8-745a1700de73"
+    "outputId": "1b96883c-ba3d-49c3-d3e8-745a1700de73",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -95,7 +107,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "yyguF5C1Ju8l"
+    "id": "yyguF5C1Ju8l",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Install & Import Libraries\n",
@@ -106,7 +121,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "XQIa2uQNOR_K"
+    "id": "XQIa2uQNOR_K",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "Note that if running this locally you'll only need to install one time, then subsequent runs can just do the import. But colab and anaconda will contain all the libraries we'll need anyways so the install isn't necessary. Here is how the install would be done though:\n",
@@ -136,7 +154,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "rKONh6lJYtF6",
-    "outputId": "e0c78623-92a5-43e8-d0b7-22fddf826f09"
+    "outputId": "e0c78623-92a5-43e8-d0b7-22fddf826f09",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -156,7 +177,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "N9lHwj3pIozY"
+    "id": "N9lHwj3pIozY",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "Now we'll import our libraries we'll use later."
@@ -166,7 +190,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "4s3mCpAZNAZq"
+    "id": "4s3mCpAZNAZq",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -181,7 +208,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "4HshMSZdObSY"
+    "id": "4HshMSZdObSY",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Load the CSV, Analyze & Plot\n",
@@ -191,7 +221,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "AFbCjAMxPx0G"
+    "id": "AFbCjAMxPx0G",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Load the CSV File and Prepare\n",
@@ -209,7 +242,10 @@
      "height": 447
     },
     "id": "sXOwidDEOrS0",
-    "outputId": "21e88975-7eac-4088-8c7f-24599ba1012a"
+    "outputId": "21e88975-7eac-4088-8c7f-24599ba1012a",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -348,7 +384,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "p_tOgtT5P4Y5"
+    "id": "p_tOgtT5P4Y5",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Basic Analysis\n",
@@ -375,7 +414,10 @@
      "height": 142
     },
     "id": "oxFZ6Oj0O2Pr",
-    "outputId": "98837822-36b4-4ef3-c319-fe32e31956bc"
+    "outputId": "98837822-36b4-4ef3-c319-fe32e31956bc",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -455,7 +497,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "gJTBXREgRm-U"
+    "id": "gJTBXREgRm-U",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Plot Full Time Series\n",
@@ -475,7 +520,10 @@
      "height": 295
     },
     "id": "K1ZUY6PNP7ab",
-    "outputId": "d6aaccfa-76ad-4f05-9346-50ff67638ee3"
+    "outputId": "d6aaccfa-76ad-4f05-9346-50ff67638ee3",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -508,7 +556,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "xme7PeHrWzU8"
+    "id": "xme7PeHrWzU8",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Plot with Plotly\n",
@@ -526,7 +577,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "-qamxSVYbHLz"
+    "id": "-qamxSVYbHLz",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Moving Peak\n",
@@ -542,7 +596,10 @@
      "height": 447
     },
     "id": "03td9T_yeIFn",
-    "outputId": "9d282cb6-2681-4b6a-a12f-91262d836c1f"
+    "outputId": "9d282cb6-2681-4b6a-a12f-91262d836c1f",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -689,7 +746,10 @@
      "height": 542
     },
     "id": "6uubzmj7X8-V",
-    "outputId": "3050a9a0-88ab-4451-9de6-67d82648bbdd"
+    "outputId": "3050a9a0-88ab-4451-9de6-67d82648bbdd",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -746,7 +806,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "QdJZtyIpaImV"
+    "id": "QdJZtyIpaImV",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Moving RMS\n",
@@ -764,7 +827,10 @@
      "height": 542
     },
     "id": "emiCK-7vYJP0",
-    "outputId": "d9aa4fd8-b9ad-4eca-db73-93c962f4ce44"
+    "outputId": "d9aa4fd8-b9ad-4eca-db73-93c962f4ce44",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -824,7 +890,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "naRQofdha_3M"
+    "id": "naRQofdha_3M",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Time History Around Peak\n",
@@ -839,7 +908,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "EiNO0_vDKKsy",
-    "outputId": "21220e37-f7b0-4aa7-e0ec-12183c3390cf"
+    "outputId": "21220e37-f7b0-4aa7-e0ec-12183c3390cf",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -866,7 +938,10 @@
      "height": 542
     },
     "id": "vbsRy0N0aY1E",
-    "outputId": "bfdafee7-7c6e-4ee5-cedf-a1fe096580c7"
+    "outputId": "bfdafee7-7c6e-4ee5-cedf-a1fe096580c7",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -931,7 +1006,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "f7KTFZNijXgI"
+    "id": "f7KTFZNijXgI",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## PSD\n",
@@ -942,11 +1020,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "Ihz-UEolbyNT"
+    "id": "Ihz-UEolbyNT",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
-    "def get_psd(df, bin_width=1.0, window=\"hanning\"):\n",
+    "def get_psd(df, bin_width=1.0, window=\"hann\"):\n",
     "    d_t = (df.index[-1]-df.index[0])/(len(df.index)-1)\n",
     "    fs = 1/d_t\n",
     "    f, psd = signal.welch(\n",
@@ -968,7 +1049,10 @@
      "height": 447
     },
     "id": "9iXUTdMfodir",
-    "outputId": "b5e8f5d9-e5a0-4e18-bd01-5ae033d62d76"
+    "outputId": "b5e8f5d9-e5a0-4e18-bd01-5ae033d62d76",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1113,7 +1197,10 @@
      "height": 542
     },
     "id": "jE2ZLBW-aeZr",
-    "outputId": "2ff24aca-75ef-4434-c45d-37e988e426ce"
+    "outputId": "2ff24aca-75ef-4434-c45d-37e988e426ce",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1172,7 +1259,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "xA_ZSrAM48Sp"
+    "id": "xA_ZSrAM48Sp",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Cumulative RMS from PSD\n",
@@ -1189,7 +1279,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "MIikvleC5BIe"
+    "id": "MIikvleC5BIe",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1210,7 +1303,10 @@
      "height": 542
     },
     "id": "5w283bcf5MVd",
-    "outputId": "f4b6f52c-54fd-445f-d135-7bdf634e9360"
+    "outputId": "f4b6f52c-54fd-445f-d135-7bdf634e9360",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1271,7 +1367,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "tqZQytK3jLju"
+    "id": "tqZQytK3jLju",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## FFT"
@@ -1280,7 +1379,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "PQ6Asg0zjOWn"
+    "id": "PQ6Asg0zjOWn",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Typical FFT (Or Should We Say DFT)\n",
@@ -1291,7 +1393,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "rDTAargQjSNz"
+    "id": "rDTAargQjSNz",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1326,7 +1431,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "3qE8BdHX1pGu"
+    "id": "3qE8BdHX1pGu",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1342,7 +1450,10 @@
      "height": 295
     },
     "id": "sEuX5lKd0cWo",
-    "outputId": "0f55d51f-529f-41c3-ff42-67adafb5217a"
+    "outputId": "0f55d51f-529f-41c3-ff42-67adafb5217a",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1375,7 +1486,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "883JemLPjSk9"
+    "id": "883JemLPjSk9",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### FFT from PSD\n",
@@ -1391,7 +1505,10 @@
      "height": 447
     },
     "id": "s1EOA2jaOnMF",
-    "outputId": "0cef351f-f361-43ac-92d3-2d285a43bf73"
+    "outputId": "0cef351f-f361-43ac-92d3-2d285a43bf73",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1529,7 +1646,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "RD-ya2m7jUfb"
+    "id": "RD-ya2m7jUfb",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1558,7 +1678,10 @@
      "height": 542
     },
     "id": "axwfbM7T1Gvs",
-    "outputId": "ea167946-0426-49e5-8e02-228616f8c3ea"
+    "outputId": "ea167946-0426-49e5-8e02-228616f8c3ea",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1619,7 +1742,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "yBbcLxtXlrO6"
+    "id": "yBbcLxtXlrO6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Moving Peak Frequency\n",
@@ -1630,7 +1756,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "kLcuacqMnlQA"
+    "id": "kLcuacqMnlQA",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1660,7 +1789,10 @@
      "height": 542
     },
     "id": "ZDARGyY_pGc3",
-    "outputId": "d516952c-3d85-4061-dc3f-b11e2e901466"
+    "outputId": "d516952c-3d85-4061-dc3f-b11e2e901466",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -1720,7 +1852,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "FkRATc7ImdFo"
+    "id": "FkRATc7ImdFo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": []

--- a/endaq/batch/core.py
+++ b/endaq/batch/core.py
@@ -540,7 +540,7 @@ class GetDataBuilder:
     def _make_calc_params(self) -> analyzer.CalcParams:
         return analyzer.CalcParams(
             **self._ch_data_cache_kwargs,
-            psd_window=self._psd_window or "hanning",
+            psd_window=self._psd_window or "hann",
             psd_freq_bin_width=self._psd_freq_bin_width or self._psd_freq_bin_width_oct,
             pvss_init_freq=self._pvss_init_freq,
             pvss_bins_per_octave=self._pvss_bins_per_octave,

--- a/endaq/calc/fft.py
+++ b/endaq/calc/fft.py
@@ -148,7 +148,7 @@ def fft(
 
     .. seealso::
 
-        - `SciPy FFT method <https://docs.scipy.org/doc/scipy/reference/reference/generated/scipy.fft.fft.html>`_
+        - `SciPy FFT method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.fft.html>`_
           Documentation for the FFT function wrapped internally.
     """
     if output is None:
@@ -236,7 +236,7 @@ def rfft(
 
     .. seealso::
 
-        - `SciPy RFFT method <https://docs.scipy.org/doc/scipy/reference/reference/generated/scipy.fft.rfft.html>`_
+        - `SciPy RFFT method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.rfft.html>`_
           Documentation for the RFFT function wrapped internally.
     """
 
@@ -319,7 +319,7 @@ def dct(
 
     .. seealso::
 
-        - `SciPy DCT method <https://docs.scipy.org/doc/scipy/reference/reference/generated/scipy.fft.dct.html>`_
+        - `SciPy DCT method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.dct.html>`_
           Documentation for the DCT function wrapped internally.
     """
 
@@ -384,7 +384,7 @@ def dst(
 
     .. seealso::
 
-        - `SciPy DST method <https://docs.scipy.org/doc/scipy/reference/reference/generated/scipy.fft.dst.html>`_
+        - `SciPy DST method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.dst.html>`_
           Documentation for the DST function wrapped internally.
     """
 

--- a/endaq/ide/files.py
+++ b/endaq/ide/files.py
@@ -74,7 +74,9 @@ def normalized_path(
 # ============================================================================
 
 
-def _get_url(url, localfile=None, headers=None, params=None, cookies=None):
+def _get_url(url, localfile=None, headers=None, params=None, cookies=None,
+             timeout=60):
+
     """
     Retrieve an IDE from a (HTTP/HTTPS) URL, including Google Drive shared
     links.
@@ -84,6 +86,7 @@ def _get_url(url, localfile=None, headers=None, params=None, cookies=None):
     :param headers: Additional (optional) request headers.
     :param params: Additional (optional) request parameters.
     :param cookies: Optional browser cookies for the session.
+    :param timeout: Seconds to wait for a response.
     :return: An open file stream containing the IDE data and the number of
         bytes downloaded.
     """
@@ -93,10 +96,11 @@ def _get_url(url, localfile=None, headers=None, params=None, cookies=None):
     netloc = parsed_url.netloc.lower()
     if netloc.endswith('.google.com') or netloc == "google.com":
         response, filename = gdrive_download(url, localfile, params=params,
-                                             cookies=cookies)
+                                             cookies=cookies, timeout=timeout)
     else:
         response = session.get(parsed_url.geturl(), headers=headers,
-                               params=params, cookies=cookies)
+                               params=params, cookies=cookies,
+                               timeout=timeout)
         filename = None
 
     if not response.ok:
@@ -133,7 +137,8 @@ def _get_url(url, localfile=None, headers=None, params=None, cookies=None):
 # ============================================================================
 
 def get_doc(name=None, filename=None, url=None, parsed=True, start=0, end=None,
-            localfile=None, params=None, headers=None, cookies=None, **kwargs):
+            localfile=None, params=None, headers=None, cookies=None,
+            timeout=60, **kwargs):
     """
     Retrieve an IDE file from either a file or URL.
 
@@ -189,6 +194,8 @@ def get_doc(name=None, filename=None, url=None, parsed=True, start=0, end=None,
         opening a URL.
     :param cookies: Additional browser cookies for use in the URL request.
         Only applicable when opening a URL.
+    :param timeout: Seconds to wait for a response to the URL request. Only
+        applicable when opening a URL.
     :return: The fetched IDE data.
 
     Additionally, `get_doc()` will accept the keyword arguments for
@@ -213,7 +220,7 @@ def get_doc(name=None, filename=None, url=None, parsed=True, start=0, end=None,
         parsed_url = path_formatted
         if parsed_url.scheme.startswith('http'):
             stream, _total = _get_url(parsed_url.geturl(), localfile=localfile, headers=headers,
-                                      params=params, cookies=cookies)
+                                      params=params, cookies=cookies, timeout=timeout)
         else:
             # future: more fetching schemes before this `else` (ftp, etc.)?
             raise ValueError(f"Unsupported transfer scheme: {parsed_url.scheme}")

--- a/endaq/ide/gdrive.py
+++ b/endaq/ide/gdrive.py
@@ -33,7 +33,8 @@ def get_file_id(url):
     return None
 
 
-def gdrive_download(url, localfile, params=None, cookies=None, drive_url=DRIVE_URL):
+def gdrive_download(url, localfile, params=None, cookies=None,
+                    drive_url=DRIVE_URL, timeout=60):
     """
     Retrieve an IDE from Google Drive. The file must be set to be shared
     with anyone with the URL.
@@ -54,7 +55,8 @@ def gdrive_download(url, localfile, params=None, cookies=None, drive_url=DRIVE_U
         p.update(params)
 
     session = requests.Session()
-    response = session.get(drive_url, params=p, cookies=cookies, stream=True)
+    response = session.get(drive_url, params=p, cookies=cookies, stream=True,
+                           timeout=timeout)
 
     if not response.ok:
         raise ValueError(f"Could not retrieve data from URL {url} "

--- a/tests/batch/test_analyzer.py
+++ b/tests/batch/test_analyzer.py
@@ -19,7 +19,7 @@ np.random.seed(0)
 
 @pytest.fixture()
 def ide_SSX70065():
-    with idelib.importFile(os.path.join("tests", "batch", "SSX70065.IDE")) as doc:
+    with idelib.importFile(os.path.join(os.path.dirname(__file__), "SSX70065.IDE")) as doc:
         yield doc
 
 
@@ -322,8 +322,8 @@ class TestAnalyzer:
     @pytest.mark.parametrize(
         "filename",
         [
-            os.path.join("tests", "batch", "test1.IDE"),
-            os.path.join("tests", "batch", "test2.IDE"),
+            os.path.join(os.path.dirname(__file__), "test1.IDE"),
+            os.path.join(os.path.dirname(__file__), "test2.IDE"),
         ],
     )
     def testLiveFiles1(self, filename):
@@ -386,7 +386,7 @@ class TestAnalyzer:
     @pytest.mark.parametrize(
         "filename",
         [
-            os.path.join("tests", "batch", "DAQ12006_000005.IDE"),
+            os.path.join(os.path.dirname(__file__), "DAQ12006_000005.IDE"),
         ],
     )
     def testLiveFiles2(self, filename):
@@ -425,7 +425,7 @@ class TestAnalyzer:
     @pytest.mark.parametrize(
         "filename",
         [
-            os.path.join("tests", "batch", "test3.IDE"),
+            os.path.join(os.path.dirname(__file__), "test3.IDE"),
         ],
     )
     def testLiveFile3(self, filename):
@@ -459,8 +459,8 @@ class TestAnalyzer:
     @pytest.mark.parametrize(
         "filename, sample_index",
         [
-            (os.path.join("tests", "batch", "test_GPS_2.IDE"), -2),
-            (os.path.join("tests", "batch", "test_GPS_3.IDE"), -4),
+            (os.path.join(os.path.dirname(__file__), "test_GPS_2.IDE"), -2),
+            (os.path.join(os.path.dirname(__file__), "test_GPS_3.IDE"), -4),
         ],
     )
     def testLiveFileGPS(self, filename, sample_index):

--- a/tests/batch/test_core.py
+++ b/tests/batch/test_core.py
@@ -16,15 +16,15 @@ from endaq.batch.utils import ide_utils
     "filename, expt_result",
     [
         (
-            os.path.join("tests", "batch", "test1.IDE"),
+            os.path.join(os.path.dirname(__file__), "test1.IDE"),
             [10118, np.datetime64("2020-09-16 19:05:49.771728")],
         ),
         (
-            os.path.join("tests", "batch", "test2.IDE"),
+            os.path.join(os.path.dirname(__file__), "test2.IDE"),
             [10118, np.datetime64("2020-09-16 19:04:22.475738")],
         ),
         (
-            os.path.join("tests", "batch", "test4.IDE"),
+            os.path.join(os.path.dirname(__file__), "test4.IDE"),
             [10118, np.datetime64("2020-11-18 17:31:27.000000")],
         ),
     ],
@@ -40,9 +40,9 @@ def test_make_meta(filename, expt_result):
 @pytest.mark.parametrize(
     "filename",
     [
-        os.path.join("tests", "batch", "SSX70065.IDE"),
-        os.path.join("tests", "batch", "test1.IDE"),
-        os.path.join("tests", "batch", "test2.IDE"),
+        os.path.join(os.path.dirname(__file__), "SSX70065.IDE"),
+        os.path.join(os.path.dirname(__file__), "test1.IDE"),
+        os.path.join(os.path.dirname(__file__), "test2.IDE"),
     ],
 )
 def test_make_peak_windows(filename):
@@ -95,11 +95,11 @@ def test_make_peak_windows(filename):
 @pytest.mark.parametrize(
     "filename",
     [
-        os.path.join("tests", "batch", "SSX70065.IDE"),
-        os.path.join("tests", "batch", "test1.IDE"),
-        os.path.join("tests", "batch", "test3.IDE"),
-        os.path.join("tests", "batch", "test5.IDE"),
-        os.path.join("tests", "batch", "GPS-Chick-Fil-A_003.IDE"),
+        os.path.join(os.path.dirname(__file__), "SSX70065.IDE"),
+        os.path.join(os.path.dirname(__file__), "test1.IDE"),
+        os.path.join(os.path.dirname(__file__), "test3.IDE"),
+        os.path.join(os.path.dirname(__file__), "test5.IDE"),
+        os.path.join(os.path.dirname(__file__), "GPS-Chick-Fil-A_003.IDE"),
         "https://info.endaq.com/hubfs/data/High-Drop.ide",
         "https://info.endaq.com/hubfs/data/Punching-Bag.ide",
     ],
@@ -298,9 +298,9 @@ def assert_output_is_valid(output: endaq.batch.core.OutputStruct):
 def test_aggregate_data(getdata_builder):
     """Test `aggregate_data` over several configurations of `GetDataBuilder`."""
     filenames = [
-        os.path.join("tests", "batch", "test1.IDE"),
-        os.path.join("tests", "batch", "test2.IDE"),
-        os.path.join("tests", "batch", "test4.IDE"),
+        os.path.join(os.path.dirname(__file__), "test1.IDE"),
+        os.path.join(os.path.dirname(__file__), "test2.IDE"),
+        os.path.join(os.path.dirname(__file__), "test4.IDE"),
     ]
 
     calc_result = getdata_builder.aggregate_data(filenames)
@@ -674,22 +674,22 @@ def test_output_to_html_plots(output_struct):
     "filenames",
     [
         [
-            os.path.join("tests", "batch", "SSX70065.IDE"),
-            os.path.join("tests", "batch", "test1.IDE"),
-            os.path.join("tests", "batch", "test3.IDE"),
-            os.path.join("tests", "batch", "test5.IDE"),
-            os.path.join("tests", "batch", "GPS-Chick-Fil-A_003.IDE"),
+            os.path.join(os.path.dirname(__file__), "SSX70065.IDE"),
+            os.path.join(os.path.dirname(__file__), "test1.IDE"),
+            os.path.join(os.path.dirname(__file__), "test3.IDE"),
+            os.path.join(os.path.dirname(__file__), "test5.IDE"),
+            os.path.join(os.path.dirname(__file__), "GPS-Chick-Fil-A_003.IDE"),
             "https://info.endaq.com/hubfs/data/High-Drop.ide",
             "https://info.endaq.com/hubfs/data/Punching-Bag.ide",
         ],
         [
-            os.path.join("tests", "batch", "SSX70065.IDE"),
+            os.path.join(os.path.dirname(__file__), "SSX70065.IDE"),
         ],
         [
             "https://info.endaq.com/hubfs/data/High-Drop.ide",
         ],
         [
-            os.path.join("tests", "batch", "SSX70065.IDE"),
+            os.path.join(os.path.dirname(__file__), "SSX70065.IDE"),
             "https://info.endaq.com/hubfs/data/High-Drop.ide",
         ],
         [],


### PR DESCRIPTION
A couple of fixes related to the unit tests.
* Removes references to "hanning" filter, which was removed/renamed in SciPy 1.9.x
* Modifies paths for loading test files to be relative to the test Python file loading it. Previous paths worked in the GitHub Actions, but did not work locally.

Bonus fix: the Scipy URLs in various `endaq.calc.fft` corrected.

Note that as of the time of this PR's opening, the Windows tests run from the GitHub Action are inconsistently hanging and timing out for some reason. This does not seem connected to any changes on our end, or to libraries we use. It may be a temporary issue with GitHub's Windows environments. One timeout occurred while trying to install Python requirements, before the tests themselves even started.

Bonus feature: A `timeout` parameter has been added to `endaq.ide.files.get_doc()`. It was hoped that this would prevent the tests from stalling, but seems to have had no effect. It's a good thing to have in any case, however.
