### PR TITLE
Feature/requirements update

### DIFF
--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -1,7 +1,16 @@
 name: Docs test on push and PR
 
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+  workflow_dispatch:
 
 
 jobs:
@@ -35,15 +44,17 @@ jobs:
 
       - name: Get pip cache location
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        shell: bash
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Get date
         id: date
+        shell: bash
         run: >
           python -c
           "import datetime;
           now = datetime.datetime.now();
-          print(f'::set-output name=text::{now.year}/{now.month}-part{1 + now.day // 8}')"
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}')" >> $GITHUB_OUTPUT
 
       - name: Load pip cache
         uses: actions/cache@v3

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@master
     
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,16 @@
 name: Unit test on push and PR
 
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+  workflow_dispatch:
 
 
 jobs:
@@ -12,10 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        exclude:
-          - os: ubuntu-latest
-            python-version: '3.6'
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     env:
       OS: ${{ matrix.os }}
@@ -26,7 +32,7 @@ jobs:
     steps:
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,7 +44,7 @@ jobs:
 
       - name: Get pip Cache Location
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Get date
         id: date
@@ -46,7 +52,8 @@ jobs:
           python -c
           "import datetime;
           now = datetime.datetime.now();
-          print(f'::set-output name=text::{now.year}/{now.month}-part{1 + now.day // 8}')"
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,19 +44,15 @@ jobs:
 
       - name: Get pip Cache Location
         id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Get date
         id: date
         run: >
           python -c
           "import datetime;
-          import os;
           now = datetime.datetime.now();
-          print(f'::set-output name=text::{now.year}/{now.month}-part{1 + now.day // 8}')"
-#          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
-#          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
-#          fh.close()"
+          print(f'{now.year}/{now.month}-part{1 + now.day // 8}')" >> "$GITHUB_OUTPUT"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,10 +51,9 @@ jobs:
         run: >
           python -c
           "import datetime;
+          import os;
           now = datetime.datetime.now();
-          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
-          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
-          fh.close()"
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,7 +54,7 @@ jobs:
           "import datetime;
           import os;
           now = datetime.datetime.now();
-          fh = open(os.environ['GITHUB_OUTPUT], 'a');
+          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
           print(f'{now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
           fh.close()"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,7 +54,7 @@ jobs:
           python -c
           "import datetime;
           now = datetime.datetime.now();
-          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)" >> $GITHUB_OUTPUT
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}')" >> $GITHUB_OUTPUT
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,14 +49,12 @@ jobs:
 
       - name: Get date
         id: date
+        shell: bash
         run: >
           python -c
           "import datetime;
-          import os;
           now = datetime.datetime.now();
-          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
-          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
-          fh.close()"
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)" >> $GITHUB_OUTPUT
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,8 +52,7 @@ jobs:
           python -c
           "import datetime;
           now = datetime.datetime.now();
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,9 @@ jobs:
           "import datetime;
           import os;
           now = datetime.datetime.now();
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
+          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
+          fh.close()"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,15 +44,19 @@ jobs:
 
       - name: Get pip Cache Location
         id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Get date
         id: date
         run: >
           python -c
           "import datetime;
+          import os;
           now = datetime.datetime.now();
-          print(f'{now.year}/{now.month}-part{1 + now.day // 8}')" >> "$GITHUB_OUTPUT"
+          fh = open(os.environ['GITHUB_OUTPUT], 'a');
+          print(f'{now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
+          fh.close()"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,9 +53,10 @@ jobs:
           "import datetime;
           import os;
           now = datetime.datetime.now();
-          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
-          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
-          fh.close()"
+          print(f'::set-output name=text::{now.year}/{now.month}-part{1 + now.day // 8}')"
+#          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
+#          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
+#          fh.close()"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,7 +52,9 @@ jobs:
           python -c
           "import datetime;
           now = datetime.datetime.now();
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh)"
+          fh = open(os.environ['GITHUB_OUTPUT'], 'a');
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
+          fh.close()"
 
       - name: Load pip Cache
         uses: actions/cache@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
           import os;
           now = datetime.datetime.now();
           fh = open(os.environ['GITHUB_OUTPUT'], 'a');
-          print(f'{now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
+          print(f'text={now.year}/{now.month}-part{1 + now.day // 8}', file=fh);
           fh.close()"
 
       - name: Load pip Cache

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,4 +9,4 @@ sphinxcontrib-serializinghtml==1.1.5
 pydata-sphinx-theme==0.7.1
 sphinx-plotly-directive==0.1.3
 nbsphinx==0.8.8
-ipython==8.1.0
+ipython==8.10

--- a/endaq/batch/analyzer.py
+++ b/endaq/batch/analyzer.py
@@ -6,10 +6,7 @@ from typing import List, Tuple, Optional
 import sys
 import warnings
 
-if sys.version_info[:2] >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
+from functools import cached_property
 
 import numpy as np
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backports.cached-property; python_version<'3.8'
 ebmlite>=3.2.0
-idelib>=3.2.3
+idelib>=3.2.8
 jinja2
 numpy>=1.19.5
 pandas>=1.3

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 INSTALL_REQUIRES = [
     "backports.cached-property; python_version<'3.8'",
     "ebmlite>=3.2.0",
-    "idelib>=3.2.3",
+    "idelib>=3.2.8",
     "jinja2",
     "numpy>=1.19.5",
     "pandas>=1.3",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setuptools.setup(
         classifiers=['Development Status :: 4 - Beta',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Earlier versions of idelib have a bug (https://github.com/MideTechnology/idelib/pull/135) that prevents calibrating data on new devices, so the dependency should be updated.
Also ended up removing the deprecated set-output from the workflow. No other changes