### PR TITLE
fix stack deprecation warning

### DIFF
--- a/endaq/batch/core.py
+++ b/endaq/batch/core.py
@@ -208,6 +208,7 @@ def _make_peak_windows(ch_data_cache: analyzer.CalcCache, margin_len):
     )
 
     # Format results
+
     # Use new implementation of future_stack if Python version >= 3.9
     levels = ["axis", "peak time", "peak offset"]
     if sys.version_info < (3, 9):


### PR DESCRIPTION
Small fix to resolve deprecation warning `pandas.Dataframe.stack`. Pandas has a new implementation of `stack`, which is set using `future_stack=True`. `future_stack` does not exist as a parameter in the pandas version compatible with 3.9, so Python version is checked when `stack()` is being used. 

There's several warnings coming from `numpy` for python>3.9, but those seem to be internal issues with the current version of the library using deprecated pandas methods, so are probably benign.