### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,19 +7,27 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-24.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+   configuration: docs/conf.py
 
-# Optionally set the version of Python and requirements required to build your docs
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-    - requirements: docs/requirements.txt
+   install:
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .
+     extra_requirements:
+       - docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ebmlite>=3.2.0
 idelib>=3.2.8
 jinja2
 numpy>=1.19.5
-pandas>=1.3
+pandas>=1.3, <3.0
 plotly>=5.3.1
 pynmeagps
 python-dotenv>=0.18.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
     "idelib>=3.2.8",
     "jinja2",
     "numpy>1.19.5",
-    "pandas>=1.3",
+    "pandas>=1.3, <3.0",
     "plotly>=5.3.1",
     "pynmeagps",
     "python-dotenv>=0.18.0",


### PR DESCRIPTION
Updated to remove deprecated Ubuntu version. Some unit tests fail, but all recent branches from development are failing in the same Python versions.