### PR TITLE
Removed Python 3.9 support

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
-    - name: Set up Python 3.9
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
     
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [3.10', '3.11', '3.12', '3.13', '3.14']
 
     env:
       OS: ${{ matrix.os }}
@@ -72,9 +72,6 @@ jobs:
           --cov-report=xml 
           --hypothesis-profile=ci
           --numprocesses auto
-          -W error::RuntimeWarning
-          -W error::UserWarning
-          -W error::DeprecationWarning
 
       - name: Generate Codecov Report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     env:
       OS: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setuptools.setup(
         classifiers=['Development Status :: 5 - Production/Stable',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
                      'Programming Language :: Python :: 3.11',
                      'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
* Removed Python 3.9 from the classifiers
* Changed Sphinx workflow to use Python 3.13
* Removed some overly cautious warnings-as-failures from unit tests